### PR TITLE
Load ENV on startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   web:
     build:

--- a/tradingagents/agents/utils/agent_states.py
+++ b/tradingagents/agents/utils/agent_states.py
@@ -2,6 +2,8 @@ from typing import Annotated, Sequence
 from datetime import date, timedelta, datetime
 from typing_extensions import TypedDict, Optional
 from langchain_openai import ChatOpenAI
+from langchain_core.messages import AnyMessage
+from langgraph.graph.message import add_messages
 from tradingagents.agents import *
 from langgraph.prebuilt import ToolNode
 from langgraph.graph import END, StateGraph, START, MessagesState

--- a/webui/components/ui.py
+++ b/webui/components/ui.py
@@ -2,7 +2,6 @@
 webui/components/ui.py
 """
 
-import gradio as gr
 from datetime import datetime
 from webui.utils.state import app_state
 from webui.utils.charts import create_chart, create_welcome_chart


### PR DESCRIPTION
Now on startup:
1. If no localStorage keys exist → Automatically loads API keys from .env file and populates the form
2. Also applies them to the runtime config → So they're immediately usable without clicking "Save & Apply"
3. if localStorage has keys → Uses those (and also applies them to runtime)