### PR TITLE
Fix analyst fallback handling and market-hour scheduling

### DIFF
--- a/tests/test_market_hours.py
+++ b/tests/test_market_hours.py
@@ -1,0 +1,40 @@
+import datetime
+import importlib.util
+import pathlib
+import unittest
+
+import pytz
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "webui" / "utils" / "market_hours.py"
+SPEC = importlib.util.spec_from_file_location("market_hours_under_test", MODULE_PATH)
+market_hours = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(market_hours)
+
+get_next_market_datetime = market_hours.get_next_market_datetime
+is_market_open = market_hours.is_market_open
+
+
+class MarketHoursTests(unittest.TestCase):
+    def test_naive_datetime_is_treated_as_eastern_wall_clock(self):
+        is_open, reason = is_market_open(datetime.datetime(2025, 1, 6, 10, 0))
+        self.assertTrue(is_open, reason)
+
+    def test_aware_utc_datetime_is_converted_to_eastern(self):
+        is_open, reason = is_market_open(datetime.datetime(2025, 1, 6, 15, 0, tzinfo=pytz.utc))
+        self.assertTrue(is_open, reason)
+
+    def test_2026_nyse_holiday_is_closed(self):
+        eastern = pytz.timezone("US/Eastern")
+        is_open, reason = is_market_open(eastern.localize(datetime.datetime(2026, 7, 3, 10, 0)))
+        self.assertFalse(is_open)
+        self.assertIn("holiday", reason.lower())
+
+    def test_next_market_datetime_uses_eastern_schedule_from_aware_input(self):
+        start = datetime.datetime(2025, 1, 6, 17, 30, tzinfo=pytz.utc)  # Monday 12:30 PM ET
+        next_dt = get_next_market_datetime(11, start)
+        self.assertEqual(next_dt.strftime("%Y-%m-%d %H:%M %Z"), "2025-01-07 11:00 EST")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/agents/analysts/macro_analyst.py
+++ b/tradingagents/agents/analysts/macro_analyst.py
@@ -20,31 +20,38 @@ def create_macro_analyst(llm, toolkit):
         try:
             current_date = state["trade_date"]
             ticker = state.get("company_of_interest", "MARKET")
+            fred_available = toolkit.has_fred()
+            openai_available = toolkit.has_openai_web_search()
             
             # print(f"[MACRO] Analyzing macro environment on {current_date}")
             
-            # Macro analysis uses the same tools regardless of online/offline mode
-            # since it's focused on economic data rather than company-specific data
-            if toolkit.config["online_tools"]:
-                tools = [
-                    toolkit.get_macro_analysis,
-                    toolkit.get_economic_indicators,
-                    toolkit.get_yield_curve_analysis,
-                    toolkit.get_macro_news_openai,
-                ]
-                # print(f"[MACRO] Using online macro tools: FRED API + OpenAI web search")
-            else:
-                # For offline mode, we still use the same tools but they may use cached data
-                tools = [
-                    toolkit.get_macro_analysis,
-                    toolkit.get_economic_indicators,
-                    toolkit.get_yield_curve_analysis,
-                ]
-                # print(f"[MACRO] Using offline macro tools: Cached Economic Data")
+            tools = []
+            if fred_available:
+                tools.extend(
+                    [
+                        toolkit.get_macro_analysis,
+                        toolkit.get_economic_indicators,
+                        toolkit.get_yield_curve_analysis,
+                    ]
+                )
+            if toolkit.config["online_tools"] and openai_available:
+                tools.append(toolkit.get_macro_news_openai)
+
+            active_sources = []
+            if fred_available:
+                active_sources.append("FRED macro data")
+            macro_news_available = toolkit.config["online_tools"] and openai_available
+            if macro_news_available:
+                active_sources.append("OpenAI macro web search")
 
             source_guidance = (
-                " When online tools are enabled, combine FRED-based macro data tools and OpenAI web-search macro news before concluding."
-                f" Use `get_macro_news_openai(curr_date, ticker_context='{ticker}')` for relevance."
+                " Combine all currently available macro tools before concluding."
+                f" Active sources: {', '.join(active_sources) if active_sources else 'none'}."
+                + (
+                    f" Use `get_macro_news_openai(curr_date, ticker_context='{ticker}')` for relevance."
+                    if macro_news_available
+                    else ""
+                )
             )
 
             system_message = (
@@ -124,7 +131,7 @@ For your reference, the current date is {current_date}. Focus on macroeconomic c
                 # Fallback to system message only
                 capture_agent_prompt("macro_report", system_message, ticker)
 
-            chain = prompt | llm.bind_tools(tools)
+            chain = prompt | (llm.bind_tools(tools) if tools else llm)
             
             # print(f"[MACRO] Invoking LLM chain...")
             # Maintain a copy of the conversation history for iterative tool use
@@ -138,10 +145,13 @@ For your reference, the current date is {current_date}. Focus on macroeconomic c
             successful_tools = []
 
             # Loop to automatically execute any requested tool calls
-            max_iterations = 10  # Prevent infinite loops
+            max_iterations = int(toolkit.config.get("max_tool_iterations_per_agent", 8))
+            max_same_call_repeats = int(toolkit.config.get("max_same_tool_call_repeats", 1))
+            tool_call_counts = {}
+            tool_result_cache = {}
             iteration_count = 0
             
-            while getattr(result, "additional_kwargs", {}).get("tool_calls") and iteration_count < max_iterations:
+            while tools and getattr(result, "additional_kwargs", {}).get("tool_calls") and iteration_count < max_iterations:
                 iteration_count += 1
                 # print(f"[MACRO] Tool execution iteration {iteration_count}")
                 
@@ -167,36 +177,49 @@ For your reference, the current date is {current_date}. Focus on macroeconomic c
                         print(f"[MACRO] ⚠️ {tool_result}")
                         tool_failures.append(tool_name)
                     else:
-                        try:
-                            if hasattr(tool_fn, "invoke"):
-                                tool_result = tool_fn.invoke(tool_args)
-                            else:
-                                tool_result = tool_fn.run(**tool_args)
-                            
-                            successful_tools.append(tool_name)
-                            
-                            # Check if tool returned an actual error message (be more specific)
-                            # Only flag as error if the entire result is an error, not if it contains error sections
-                            if isinstance(tool_result, str) and (
-                                tool_result.lower().startswith("error") or 
-                                (len(tool_result) < 200 and (
-                                    "api key not found" in tool_result.lower() or
-                                    "failed to fetch" in tool_result.lower() or
-                                    "connection error" in tool_result.lower()
-                                ))
-                            ):
-                                print(f"[MACRO] ⚠️ Tool '{tool_name}' returned error: {tool_result[:100]}...")
+                        call_signature = f"{tool_name}:{json.dumps(tool_args, sort_keys=True, default=str)}"
+                        call_count = tool_call_counts.get(call_signature, 0) + 1
+                        tool_call_counts[call_signature] = call_count
+
+                        if call_signature in tool_result_cache:
+                            tool_result = tool_result_cache[call_signature]
+                        elif call_count > max_same_call_repeats:
+                            tool_result = (
+                                f"Skipped repeated tool call '{tool_name}' with identical arguments "
+                                f"after {max_same_call_repeats} execution(s). Reuse previous evidence."
+                            )
+                        else:
+                            try:
+                                if hasattr(tool_fn, "invoke"):
+                                    tool_result = tool_fn.invoke(tool_args)
+                                else:
+                                    tool_result = tool_fn.run(**tool_args)
+                                tool_result_cache[call_signature] = str(tool_result)
+
+                                successful_tools.append(tool_name)
+
+                                # Check if tool returned an actual error message (be more specific)
+                                # Only flag as error if the entire result is an error, not if it contains error sections
+                                if isinstance(tool_result, str) and (
+                                    tool_result.lower().startswith("error") or
+                                    (len(tool_result) < 200 and (
+                                        "api key not found" in tool_result.lower() or
+                                        "failed to fetch" in tool_result.lower() or
+                                        "connection error" in tool_result.lower()
+                                    ))
+                                ):
+                                    print(f"[MACRO] ⚠️ Tool '{tool_name}' returned error: {tool_result[:100]}...")
+                                    tool_failures.append(tool_name)
+                                elif isinstance(tool_result, str) and len(tool_result) > 100:
+                                    # This is likely a valid report, even if it contains some error sections
+                                    # Don't flag as a complete failure
+                                    print(f"[MACRO] 📊 Tool '{tool_name}' returned report with {len(tool_result)} characters")
+                                else:
+                                    print(f"[MACRO] ✅ Tool '{tool_name}' completed successfully")
+
+                            except Exception as tool_err:
+                                tool_result = f"Error running tool '{tool_name}': {str(tool_err)}"
                                 tool_failures.append(tool_name)
-                            elif isinstance(tool_result, str) and len(tool_result) > 100:
-                                # This is likely a valid report, even if it contains some error sections
-                                # Don't flag as a complete failure
-                                print(f"[MACRO] 📊 Tool '{tool_name}' returned report with {len(tool_result)} characters")
-                            else:
-                                print(f"[MACRO] ✅ Tool '{tool_name}' completed successfully")
-                                
-                        except Exception as tool_err:
-                            tool_result = f"Error running tool '{tool_name}': {str(tool_err)}"
-                            tool_failures.append(tool_name)
 
                     tool_call_id = tool_call.get("id") or tool_call.get("tool_call_id")
                     ai_tool_call_msg = AIMessage(content="", additional_kwargs={"tool_calls": [tool_call]})
@@ -209,6 +232,14 @@ For your reference, the current date is {current_date}. Focus on macroeconomic c
                 except Exception as e:
                     print(f"[MACRO] ❌ Error in LLM chain iteration {iteration_count}: {e}")
                     break
+
+            if tools and getattr(result, "additional_kwargs", {}).get("tool_calls"):
+                result = AIMessage(
+                    content=(
+                        (result.content or "").strip()
+                        + f"\n\nTool-loop halted after {max_iterations} iterations to prevent endless retries."
+                    ).strip()
+                )
             
             # If we had tool failures, let the LLM know and ask for a general analysis
             if tool_failures and not successful_tools:
@@ -268,6 +299,28 @@ Based on current market conditions as of {current_date}:
 **Note**: For complete macro analysis, configure FRED_API_KEY environment variable.
 """
                     })()
+
+            analysis_content = (result.content or "").strip()
+            if not analysis_content:
+                analysis_content = (
+                    "Macro analysis was limited by unavailable tools. "
+                    "State the limitation clearly in the final recommendation."
+                )
+
+            if "FINAL TRANSACTION PROPOSAL:" not in analysis_content:
+                final_prompt = f"""Based on the following macro analysis for {current_date}, provide your final swing trading recommendation considering macroeconomic conditions and sector implications.
+
+Analysis:
+{analysis_content}
+
+Provide a brief justification and conclude with: FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL**"""
+                final_result = llm.invoke(final_prompt)
+                final_content = final_result.content if hasattr(final_result, "content") else str(final_result)
+                result = AIMessage(
+                    content=analysis_content + "\n\n---\n\n## Final Recommendation\n\n" + final_content
+                )
+            else:
+                result = AIMessage(content=analysis_content)
             
             elapsed_time = time.time() - start_time
             # print(f"[MACRO] ✅ Analysis completed in {elapsed_time:.2f} seconds")

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -58,29 +58,47 @@ def create_market_analyst(llm, toolkit):
         current_date = state["trade_date"]
         ticker = state["company_of_interest"]
         company_name = state["company_of_interest"]
+        is_crypto = "/" in ticker or "USD" in ticker.upper() or "USDT" in ticker.upper()
+        alpaca_available = is_crypto or toolkit.has_alpaca_credentials()
 
-        if toolkit.config["online_tools"]:
+        if toolkit.config["online_tools"] and alpaca_available:
             tools = [
                 toolkit.get_technical_brief,
                 toolkit.get_alpaca_data_report,
                 toolkit.get_stockstats_indicators_report_online,
             ]
-        else:
+        elif toolkit.config["online_tools"] and not alpaca_available:
+            # Keep running with offline stockstats fallback when Alpaca credentials are unavailable.
             tools = [
-                toolkit.get_alpaca_data_report,
                 toolkit.get_stockstats_indicators_report,
             ]
+        else:
+            tools = [toolkit.get_stockstats_indicators_report]
+            if alpaca_available:
+                tools.insert(0, toolkit.get_alpaca_data_report)
 
-        system_message = (
-            """You are a **multi-timeframe technical analyst**. Your input is a structured Technical Brief (JSON) that has already been computed deterministically across three timeframes: **1 h, 4 h, and 1 d**.
+        technical_brief_available = toolkit.config["online_tools"] and alpaca_available
+        indicator_tool_name = (
+            "get_stockstats_indicators_report_online"
+            if technical_brief_available
+            else "get_stockstats_indicators_report"
+        )
+        evidence_sources = []
+        if technical_brief_available:
+            evidence_sources.append(
+                "   - `get_technical_brief` for compact synthesized confirmation"
+            )
+        if alpaca_available:
+            evidence_sources.append("   - `get_alpaca_data_report` for OHLCV context")
+        evidence_sources.append(f"   - `{indicator_tool_name}` for indicator history")
 
-## Your workflow
-
-1. **Use Alpaca + Stockstats tools** as your base evidence:
-   - `get_alpaca_data_report` for OHLCV context
-   - `get_stockstats_indicators_report_online` (or offline variant) for indicator values
-   - `get_technical_brief` for compact synthesized confirmation
-
+        workflow_intro = (
+            "1. **Use the currently available technical tools as your base evidence:**\n"
+            + "\n".join(evidence_sources)
+            + "\n"
+        )
+        if technical_brief_available:
+            workflow_step_two = """
 2. **Call `get_technical_brief`** with the ticker and current date.
    You will receive a JSON object with the following pre-analyzed sections for each timeframe:
    - `trend` – direction, strength (ADX), EMA slope, HH/HL, SMA 200 & distance
@@ -92,8 +110,46 @@ def create_market_analyst(llm, toolkit):
    Plus cross-timeframe fields:
    - `key_levels` – Support/Resist (incl. 3M/6M highs), Pivots, Fibs
    - `signal_summary` – classified setup type and confidence
+"""
+        else:
+            workflow_step_two = (
+                "\n2. **`get_technical_brief` is unavailable in this run.** "
+                "Build the cross-timeframe view from the available price and indicator tools instead.\n"
+            )
 
-3. **Analyze the brief and raw tool evidence** — look for *SWING TRADING* setups:
+        iteration_guidance = (
+            "\n3. **Actively iterate tool calls before concluding**:\n"
+            "   - Run at least 3 indicator-history calls across different indicators and at least 2 timeframes when the tool supports it.\n"
+            "   - Example flow: momentum (`rsi_14`/`macd`) -> trend (`close_8_ema`, `close_21_ema`, `close_50_sma`) -> volatility/risk (`atr_14`, Bollinger).\n"
+            + (
+                "   - Cross-check indicator history against price levels from Alpaca.\n"
+                if alpaca_available
+                else "   - Do not request unavailable Alpaca data; rely on indicator history and explicitly state that limitation.\n"
+            )
+        )
+
+        system_intro = (
+            "You are a **multi-timeframe technical analyst**. "
+            + (
+                "Your input includes a structured Technical Brief (JSON) that has already been computed deterministically across three timeframes: **1 h, 4 h, and 1 d**.\n"
+                if technical_brief_available
+                else "Build the technical view directly from the raw price and indicator tools available in this run.\n"
+            )
+        )
+        anchor_guidance = (
+            "**Important**: Anchor your thesis in both Alpaca price action and Stockstats indicators."
+            if alpaca_available
+            else "**Important**: Anchor your thesis in the available Stockstats evidence and explicitly note that Alpaca price data is unavailable."
+        )
+
+        system_message = (
+            system_intro
+            + "\n\n## Your workflow\n\n"
+            + workflow_intro
+            + workflow_step_two
+            + iteration_guidance
+            + """
+4. **Analyze the brief and raw tool evidence** — look for *SWING TRADING* setups:
    - **Trend Strength**: Is ADX > 25? Are we above SMA 200 (Long-term trend)?
    - **Gap Ups**: Did price gap up (>1-2%) over a Key Level (e.g., 3-Month High)?
    - **Oversold Bounce**: Is price far below SMA 200 but reclaiming EMA 8? Stoch RSI crossing up?
@@ -101,7 +157,7 @@ def create_market_analyst(llm, toolkit):
    - **Entry Timing**: Look for Stoch RSI crossovers or pullback to EMA 8.
    - **Confluence**: Do 4h and 1d agree?
 
-4. **Produce your analysis** with these sections:
+5. **Produce your analysis** with these sections:
 
 ## Conclusion
 State **BULLISH**, **BEARISH**, or **NEUTRAL** with a 1-sentence rationale.
@@ -136,7 +192,8 @@ Conclude with: **FINAL TRANSACTION PROPOSAL: BUY/HOLD/SELL** and a brief justifi
 - Keep each section on separate lines. Do not output inline "a) ... b) ... c) ..." formatting.
 - Keep table rows on separate lines (valid markdown table syntax).
 
-**Important**: Anchor your thesis in both Alpaca price action and Stockstats indicators."""
+"""
+            + anchor_guidance
         )
 
         prompt = ChatPromptTemplate.from_messages(
@@ -185,16 +242,22 @@ For your reference, the current date is {current_date}. The company we want to l
             # Fallback to system message only
             capture_agent_prompt("market_report", system_message, ticker)
 
-        chain = prompt | llm.bind_tools(tools)
+        chain = prompt | (llm.bind_tools(tools) if tools else llm)
 
         # Copy the incoming conversation history so we can append to it when the model makes tool calls
         messages_history = list(state["messages"])
 
         # First LLM response
         result = chain.invoke(messages_history)
+        max_tool_iterations = int(toolkit.config.get("max_tool_iterations_per_agent", 8))
+        max_same_call_repeats = int(toolkit.config.get("max_same_tool_call_repeats", 1))
+        tool_call_counts = {}
+        tool_result_cache = {}
+        iteration_count = 0
 
         # Handle iterative tool calls until the model stops requesting them
-        while getattr(result, "additional_kwargs", {}).get("tool_calls"):
+        while tools and getattr(result, "additional_kwargs", {}).get("tool_calls") and iteration_count < max_tool_iterations:
+            iteration_count += 1
             for tool_call in result.additional_kwargs["tool_calls"]:
                 # Handle different tool call structures
                 if isinstance(tool_call, dict):
@@ -217,15 +280,27 @@ For your reference, the current date is {current_date}. The company we want to l
                     tool_result = f"Tool '{tool_name}' not found."
                     print(f"[MARKET] ⚠️ {tool_result}")
                 else:
-                    try:
-                        # LangChain Tool objects expose `.run` (string IO) as well as `.invoke` (dict/kwarg IO)
-                        if hasattr(tool_fn, "invoke"):
-                            tool_result = tool_fn.invoke(tool_args)
-                        else:
-                            tool_result = tool_fn.run(**tool_args)
-                        
-                    except Exception as tool_err:
-                        tool_result = f"Error running tool '{tool_name}': {str(tool_err)}"
+                    call_signature = f"{tool_name}:{json.dumps(tool_args, sort_keys=True, default=str)}"
+                    call_count = tool_call_counts.get(call_signature, 0) + 1
+                    tool_call_counts[call_signature] = call_count
+
+                    if call_signature in tool_result_cache:
+                        tool_result = tool_result_cache[call_signature]
+                    elif call_count > max_same_call_repeats:
+                        tool_result = (
+                            f"Skipped repeated tool call '{tool_name}' with identical arguments "
+                            f"after {max_same_call_repeats} execution(s). Reuse previous evidence."
+                        )
+                    else:
+                        try:
+                            # LangChain Tool objects expose `.run` (string IO) as well as `.invoke` (dict/kwarg IO)
+                            if hasattr(tool_fn, "invoke"):
+                                tool_result = tool_fn.invoke(tool_args)
+                            else:
+                                tool_result = tool_fn.run(**tool_args)
+                            tool_result_cache[call_signature] = str(tool_result)
+                        except Exception as tool_err:
+                            tool_result = f"Error running tool '{tool_name}': {str(tool_err)}"
 
                 # Append the assistant tool call and tool result messages so the LLM can continue the conversation
                 tool_call_id = tool_call.get("id") or tool_call.get("tool_call_id")
@@ -243,14 +318,29 @@ For your reference, the current date is {current_date}. The company we want to l
 
             # Ask the LLM to continue with the new context
             result = chain.invoke(messages_history)
+
+        if tools and getattr(result, "additional_kwargs", {}).get("tool_calls"):
+            result = AIMessage(
+                content=(
+                    (result.content or "").strip()
+                    + f"\n\nTool-loop halted after {max_tool_iterations} iterations to prevent endless retries."
+                ).strip()
+            )
         
+        analysis_content = (result.content or "").strip()
+        if not analysis_content:
+            analysis_content = (
+                "The analyst did not return a complete technical narrative. "
+                "State the limitation clearly in the final recommendation."
+            )
+
         # Check if the result already contains FINAL TRANSACTION PROPOSAL
-        if "FINAL TRANSACTION PROPOSAL:" not in result.content:
+        if "FINAL TRANSACTION PROPOSAL:" not in analysis_content:
             # Create a simple prompt that includes the analysis content directly
             final_prompt = f"""Based on the following market and technical analysis for {ticker}, please provide your final trading recommendation.
 
 Analysis:
-{result.content}
+{analysis_content}
 
 You must conclude with: FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** followed by a brief justification."""
             
@@ -259,10 +349,10 @@ You must conclude with: FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** followed b
             final_result = final_chain.invoke(final_prompt)
             
             # Combine the analysis with the final proposal
-            combined_content = result.content + "\n\n" + final_result.content
+            combined_content = analysis_content + "\n\n" + final_result.content
             result = AIMessage(content=_normalize_market_report_markdown(combined_content))
         else:
-            result = AIMessage(content=_normalize_market_report_markdown(result.content))
+            result = AIMessage(content=_normalize_market_report_markdown(analysis_content))
 
         return {
             "messages": [result],

--- a/tradingagents/agents/analysts/social_media_analyst.py
+++ b/tradingagents/agents/analysts/social_media_analyst.py
@@ -18,18 +18,20 @@ def create_social_media_analyst(llm, toolkit):
         ticker = state["company_of_interest"]
         company_name = state["company_of_interest"]
         is_crypto = "/" in ticker or "USD" in ticker.upper() or "USDT" in ticker.upper()
+        openai_available = toolkit.has_openai_web_search()
 
-        if toolkit.config["online_tools"]:
-            reddit_tool = toolkit.get_reddit_news if is_crypto else toolkit.get_reddit_stock_info
-            tools = [
-                toolkit.get_stock_news_openai,
-                reddit_tool,
-            ]
-        else:
-            tools = [toolkit.get_reddit_news] if is_crypto else [toolkit.get_reddit_stock_info]
+        reddit_tool = toolkit.get_reddit_news if is_crypto else toolkit.get_reddit_stock_info
+        tools = [reddit_tool]
+        if toolkit.config["online_tools"] and openai_available:
+            tools.insert(0, toolkit.get_stock_news_openai)
+
+        source_labels = ["Reddit"]
+        if toolkit.config["online_tools"] and openai_available:
+            source_labels.insert(0, "OpenAI web-search sentiment")
 
         source_guidance = (
-            " When online tools are enabled, use both OpenAI web-search sentiment and Reddit-based social signals before concluding."
+            " Use all currently available social tools before concluding."
+            f" Active sources: {', '.join(source_labels)}."
             + (" Use `get_reddit_news(curr_date)` for crypto context." if is_crypto else " Use `get_reddit_stock_info(ticker, curr_date)` for stock context.")
         )
         system_message = (
@@ -110,16 +112,22 @@ For your reference, the current date is {current_date}. The current company we w
             # Fallback to system message only
             capture_agent_prompt("sentiment_report", system_message, ticker)
 
-        chain = prompt | llm.bind_tools(tools)
+        chain = prompt | (llm.bind_tools(tools) if tools else llm)
 
         # Copy the incoming conversation history so we can append to it when the model makes tool calls
         messages_history = list(state["messages"])
 
         # First LLM response
         result = chain.invoke(messages_history)
+        max_tool_iterations = int(toolkit.config.get("max_tool_iterations_per_agent", 8))
+        max_same_call_repeats = int(toolkit.config.get("max_same_tool_call_repeats", 1))
+        tool_call_counts = {}
+        tool_result_cache = {}
+        iteration_count = 0
 
         # Handle iterative tool calls until the model stops requesting them
-        while getattr(result, "additional_kwargs", {}).get("tool_calls"):
+        while tools and getattr(result, "additional_kwargs", {}).get("tool_calls") and iteration_count < max_tool_iterations:
+            iteration_count += 1
             for tool_call in result.additional_kwargs["tool_calls"]:
                 # Handle different tool call structures
                 if isinstance(tool_call, dict):
@@ -142,15 +150,27 @@ For your reference, the current date is {current_date}. The current company we w
                     tool_result = f"Tool '{tool_name}' not found."
                     print(f"[SOCIAL] ⚠️ {tool_result}")
                 else:
-                    try:
-                        # LangChain Tool objects expose `.run` (string IO) as well as `.invoke` (dict/kwarg IO)
-                        if hasattr(tool_fn, "invoke"):
-                            tool_result = tool_fn.invoke(tool_args)
-                        else:
-                            tool_result = tool_fn.run(**tool_args)
-                        
-                    except Exception as tool_err:
-                        tool_result = f"Error running tool '{tool_name}': {str(tool_err)}"
+                    call_signature = f"{tool_name}:{json.dumps(tool_args, sort_keys=True, default=str)}"
+                    call_count = tool_call_counts.get(call_signature, 0) + 1
+                    tool_call_counts[call_signature] = call_count
+
+                    if call_signature in tool_result_cache:
+                        tool_result = tool_result_cache[call_signature]
+                    elif call_count > max_same_call_repeats:
+                        tool_result = (
+                            f"Skipped repeated tool call '{tool_name}' with identical arguments "
+                            f"after {max_same_call_repeats} execution(s). Reuse previous evidence."
+                        )
+                    else:
+                        try:
+                            # LangChain Tool objects expose `.run` (string IO) as well as `.invoke` (dict/kwarg IO)
+                            if hasattr(tool_fn, "invoke"):
+                                tool_result = tool_fn.invoke(tool_args)
+                            else:
+                                tool_result = tool_fn.run(**tool_args)
+                            tool_result_cache[call_signature] = str(tool_result)
+                        except Exception as tool_err:
+                            tool_result = f"Error running tool '{tool_name}': {str(tool_err)}"
 
                 # Append the assistant tool call and tool result messages so the LLM can continue the conversation
                 tool_call_id = tool_call.get("id") or tool_call.get("tool_call_id")
@@ -168,29 +188,23 @@ For your reference, the current date is {current_date}. The current company we w
 
             # Ask the LLM to continue with the new context
             result = chain.invoke(messages_history)
-        
-        # Enhanced validation and final proposal handling
-        analysis_content = result.content if result.content else ""
-        
-        # Check if we have substantial analysis content (not just final proposal)
-        if len(analysis_content.strip()) < 100 or "FINAL TRANSACTION PROPOSAL:" in analysis_content and len(analysis_content.replace("FINAL TRANSACTION PROPOSAL:", "").strip()) < 100:
-            # Generate fallback analysis if content is too short
-            fallback_prompt = f"""As a swing trading social media analyst, provide a comprehensive social sentiment analysis for {ticker} on {current_date}.
 
-Since detailed social media data may not be available, provide a professional analysis covering:
-1. **General Social Sentiment Trends** for {ticker}
-2. **Social Media Momentum Indicators** 
-3. **Community Positioning Analysis**
-4. **Swing Trading Social Signals**
-5. **Risk Factors from Social Sentiment**
-
-Include the required social sentiment table and conclude with swing trading implications.
-Focus on actionable insights for multi-day (2-10 day) swing trading decisions."""
-            
-            fallback_result = llm.invoke(fallback_prompt)
-            analysis_content = fallback_result.content if hasattr(fallback_result, 'content') else str(fallback_result)
+        if tools and getattr(result, "additional_kwargs", {}).get("tool_calls"):
+            result = AIMessage(
+                content=(
+                    (result.content or "").strip()
+                    + f"\n\nTool-loop halted after {max_tool_iterations} iterations to prevent endless retries."
+                ).strip()
+            )
         
-        # Ensure we have a final recommendation
+        analysis_content = (result.content or "").strip()
+        if not analysis_content:
+            analysis_content = (
+                "The analyst did not return a full social narrative. "
+                "Be explicit about that limitation in the final recommendation."
+            )
+
+        # Ensure we have a final recommendation without replacing tool-grounded evidence.
         if "FINAL TRANSACTION PROPOSAL:" not in analysis_content:
             # Create a final recommendation based on the analysis
             final_prompt = f"""Based on the following social media and sentiment analysis for {ticker}, provide your final swing trading recommendation considering social momentum and sentiment indicators.

--- a/webui/callbacks/control_callbacks.py
+++ b/webui/callbacks/control_callbacks.py
@@ -553,11 +553,15 @@ def register_control_callbacks(app):
                 
                 # Market hour scheduling loop
                 import datetime
+                import pytz
                 from webui.utils.market_hours import get_next_market_datetime, is_market_open
+
+                eastern = pytz.timezone('US/Eastern')
+                utc = pytz.utc
                 
                 while not app_state.stop_market_hour:
-                    # Find next execution time
-                    now = datetime.datetime.now()
+                    # Compute the schedule from current UTC time projected into Eastern.
+                    now = datetime.datetime.now(utc).astimezone(eastern)
                     next_execution_times = []
                     
                     for hour in app_state.market_hours:
@@ -571,7 +575,7 @@ def register_control_callbacks(app):
                     print(f"[MARKET_HOUR] Next execution: {next_dt.strftime('%A, %B %d at %I:%M %p %Z')} (Hour {next_hour})")
                     
                     # Wait until next execution time
-                    while datetime.datetime.now() < next_dt.replace(tzinfo=None) and not app_state.stop_market_hour:
+                    while datetime.datetime.now(utc).astimezone(eastern) < next_dt and not app_state.stop_market_hour:
                         time.sleep(60)  # Check every minute
                     
                     if app_state.stop_market_hour:

--- a/webui/utils/market_hours.py
+++ b/webui/utils/market_hours.py
@@ -33,9 +33,53 @@ US_MARKET_HOLIDAYS_2025 = [
     "2025-12-25",  # Christmas Day
 ]
 
+US_MARKET_HOLIDAYS_2026 = [
+    "2026-01-01",  # New Year's Day
+    "2026-01-19",  # Martin Luther King Jr. Day
+    "2026-02-16",  # Presidents' Day
+    "2026-04-03",  # Good Friday
+    "2026-05-25",  # Memorial Day
+    "2026-06-19",  # Juneteenth
+    "2026-07-03",  # Independence Day observed
+    "2026-09-07",  # Labor Day
+    "2026-11-26",  # Thanksgiving Day
+    "2026-12-25",  # Christmas Day
+]
+
+US_MARKET_HOLIDAYS_2027 = [
+    "2027-01-01",  # New Year's Day
+    "2027-01-18",  # Martin Luther King Jr. Day
+    "2027-02-15",  # Presidents' Day
+    "2027-03-26",  # Good Friday
+    "2027-05-31",  # Memorial Day
+    "2027-06-18",  # Juneteenth observed
+    "2027-07-05",  # Independence Day observed
+    "2027-09-06",  # Labor Day
+    "2027-11-25",  # Thanksgiving Day
+    "2027-12-24",  # Christmas Day observed
+]
+
 # Market regular hours (EST/EDT)
 MARKET_OPEN_HOUR = 9   # 9:30 AM (use 9 for conservative approach)
 MARKET_CLOSE_HOUR = 16  # 4:00 PM
+
+
+def _get_eastern_timezone():
+    return pytz.timezone("US/Eastern")
+
+
+def _current_eastern_time() -> datetime.datetime:
+    return datetime.datetime.now(pytz.utc).astimezone(_get_eastern_timezone())
+
+
+def _coerce_to_eastern(target_datetime: datetime.datetime = None) -> datetime.datetime:
+    eastern = _get_eastern_timezone()
+    if target_datetime is None:
+        return _current_eastern_time()
+    if target_datetime.tzinfo is None:
+        # Naive datetimes passed into this module are treated as Eastern wall clock time.
+        return eastern.localize(target_datetime)
+    return target_datetime.astimezone(eastern)
 
 def validate_market_hours(hours_str: str) -> Tuple[bool, List[int], str]:
     """
@@ -80,16 +124,7 @@ def is_market_open(target_datetime: datetime.datetime = None) -> Tuple[bool, str
     Returns:
         Tuple of (is_open, reason_if_closed)
     """
-    if target_datetime is None:
-        target_datetime = datetime.datetime.now()
-    
-    # Convert to Eastern Time
-    eastern = pytz.timezone('US/Eastern')
-    if target_datetime.tzinfo is None:
-        # Assume local time and convert to Eastern
-        target_datetime = pytz.timezone('US/Eastern').localize(target_datetime)
-    else:
-        target_datetime = target_datetime.astimezone(eastern)
+    target_datetime = _coerce_to_eastern(target_datetime)
     
     # Check if it's a weekend
     if target_datetime.weekday() >= 5:  # Saturday = 5, Sunday = 6
@@ -97,7 +132,12 @@ def is_market_open(target_datetime: datetime.datetime = None) -> Tuple[bool, str
     
     # Check if it's a holiday
     date_str = target_datetime.strftime("%Y-%m-%d")
-    all_holidays = US_MARKET_HOLIDAYS_2024 + US_MARKET_HOLIDAYS_2025
+    all_holidays = (
+        US_MARKET_HOLIDAYS_2024
+        + US_MARKET_HOLIDAYS_2025
+        + US_MARKET_HOLIDAYS_2026
+        + US_MARKET_HOLIDAYS_2027
+    )
     if date_str in all_holidays:
         return False, f"Market is closed for holiday on {date_str}"
     
@@ -123,15 +163,7 @@ def get_next_market_datetime(target_hour: int, from_datetime: datetime.datetime 
     Returns:
         Next datetime when market will be open at the target hour
     """
-    if from_datetime is None:
-        from_datetime = datetime.datetime.now()
-        
-    # Convert to Eastern Time
-    eastern = pytz.timezone('US/Eastern')
-    if from_datetime.tzinfo is None:
-        from_datetime = eastern.localize(from_datetime)
-    else:
-        from_datetime = from_datetime.astimezone(eastern)
+    from_datetime = _coerce_to_eastern(from_datetime)
     
     # Start with today at the target hour
     target_dt = from_datetime.replace(hour=target_hour, minute=0, second=0, microsecond=0)


### PR DESCRIPTION
This PR supersedes the safe/mergeable parts of #16 without carrying over the regressions identified in review.

What changed:
- fix market-hour scheduling so runtime always computes from UTC and compares in US/Eastern
- preserve Eastern wall-clock semantics for naive datetimes instead of silently reinterpreting them as UTC
- add NYSE holiday coverage for 2026 and 2027
- remove analyst fallback paths that discarded tool-grounded evidence and regenerated fresh unsupported analysis
- ensure macro/social/market analyst flows still produce a final recommendation without requiring unavailable tools
- make market analyst instructions match the tools actually available in the current run
- add regression tests for market-hours timezone/holiday behavior

Why this replaces #16 instead of merging it directly:
- #16 introduced prompt/tool requirements that can demand unavailable tools in offline or degraded runs
- #16 added content-quality fallbacks that can replace evidence-backed analysis with unsupported prose
- #16 still had a macro fallback path that could overwrite the final recommendation
- #16’s scheduler helper changes reinterpreted naive datetimes as UTC, which breaks existing Eastern-based callers

Validation:
- `python -m py_compile tradingagents/agents/analysts/social_media_analyst.py tradingagents/agents/analysts/macro_analyst.py tradingagents/agents/analysts/market_analyst.py webui/utils/market_hours.py webui/callbacks/control_callbacks.py tests/test_market_hours.py`
- `python -m unittest discover -s tests -p "test_market_hours.py"`

Supersedes: #16