### PR TITLE
Add safe local LLM support for graph runtime

### DIFF
--- a/LOCAL_LLM_GUIDE.md
+++ b/LOCAL_LLM_GUIDE.md
@@ -1,0 +1,68 @@
+"""
+How to Run AlpacaTradingAgent with a Local LLM
+
+This project can route the graph's quick/deep thinker LLM calls to an
+OpenAI-compatible local endpoint such as LM Studio, Ollama, or vLLM.
+
+What local mode covers:
+- the main quick/deep thinker chat models used by the graph
+- reflection-memory embeddings when your endpoint exposes an embeddings API
+
+What local mode does not replace:
+- OpenAI web-search tools in `tradingagents/dataflows/interface.py`
+
+Those tools still rely on OpenAI cloud features. If you want a fully local run,
+set `online_tools=False` so analysts avoid OpenAI web-search calls.
+
+Environment-variable setup
+
+Create a `.env` file with:
+
+```env
+OPENAI_USE_LOCAL=true
+OPENAI_BASE_URL=http://localhost:1234/v1
+OPENAI_API_KEY=local-llm
+
+# Optional when your endpoint exposes embeddings under a custom model name
+OPENAI_EMBEDDING_MODEL=text-embedding-ada-002
+```
+
+Model configuration
+
+You should also set `quick_think_llm` and `deep_think_llm` to model names your
+local server actually exposes. Do not leave cloud-only names in place if your
+server does not provide them.
+
+Example:
+
+```python
+from tradingagents.dataflows.config import set_config
+
+set_config(
+    {
+        "openai_use_local": True,
+        "openai_base_url": "http://localhost:1234/v1",
+        "quick_think_llm": "qwen2.5-7b-instruct",
+        "deep_think_llm": "qwen2.5-14b-instruct",
+        "online_tools": False,
+    }
+)
+```
+
+Supported endpoint patterns
+
+1. LM Studio
+   - `http://localhost:1234/v1`
+
+2. Ollama (OpenAI-compatible mode)
+   - `http://localhost:11434/v1`
+
+3. vLLM OpenAI server
+   - `http://localhost:8000/v1`
+
+Embeddings behavior
+
+Reflection memory uses embeddings. If your local endpoint does not expose a
+compatible embeddings API, the app now degrades gracefully by skipping memory
+lookups/additions for that run instead of crashing the graph.
+"""

--- a/env.sample
+++ b/env.sample
@@ -16,6 +16,17 @@ ALPACA_USE_PAPER=True
 # Get your key from https://platform.openai.com/api-keys
 OPENAI_API_KEY=your_openai_api_key_here
 
+# Local LLM configuration (optional)
+# Enable these to route the graph's quick/deep thinker models to an OpenAI-compatible local endpoint.
+# Examples:
+# LM Studio: http://localhost:1234/v1
+# Ollama OpenAI compatibility: http://localhost:11434/v1
+# vLLM OpenAI server: http://localhost:8000/v1
+OPENAI_USE_LOCAL=false
+OPENAI_BASE_URL=http://localhost:1234/v1
+# Optional override when your endpoint exposes embeddings under a custom model name.
+OPENAI_EMBEDDING_MODEL=text-embedding-ada-002
+
 # Finnhub API Key - Required for financial news and data
 # Get your key from https://finnhub.io/register
 FINNHUB_API_KEY=your_finnhub_api_key_here

--- a/tests/test_local_llm_config.py
+++ b/tests/test_local_llm_config.py
@@ -1,0 +1,92 @@
+import os
+import pathlib
+import importlib.util
+import unittest
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "tradingagents" / "dataflows" / "config.py"
+SPEC = importlib.util.spec_from_file_location("config_under_test", MODULE_PATH)
+config_module = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(config_module)
+
+
+class LocalLLMConfigTests(unittest.TestCase):
+    def setUp(self):
+        self.original_config = config_module.get_config()
+        self.original_runtime_keys = config_module.get_runtime_api_keys()
+        self.original_env = {
+            "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY"),
+            "OPENAI_USE_LOCAL": os.environ.get("OPENAI_USE_LOCAL"),
+            "OPENAI_BASE_URL": os.environ.get("OPENAI_BASE_URL"),
+            "OPENAI_EMBEDDING_MODEL": os.environ.get("OPENAI_EMBEDDING_MODEL"),
+        }
+
+        config_module.clear_runtime_api_keys()
+        config_module.set_config(
+            {
+                "openai_api_key": None,
+                "openai_use_local": False,
+                "openai_base_url": None,
+                "openai_embedding_model": "text-embedding-ada-002",
+            }
+        )
+        for key in self.original_env:
+            os.environ.pop(key, None)
+
+    def tearDown(self):
+        config_module.clear_runtime_api_keys()
+        if self.original_runtime_keys:
+            config_module.set_runtime_api_keys(self.original_runtime_keys)
+        config_module.set_config(self.original_config)
+
+        for key, value in self.original_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_local_client_config_uses_base_url_and_default_api_key(self):
+        config_module.set_config(
+            {
+                "openai_use_local": True,
+                "openai_base_url": "http://localhost:1234/v1",
+                "openai_api_key": None,
+            }
+        )
+
+        client_config = config_module.get_openai_client_config()
+
+        self.assertEqual(client_config["base_url"], "http://localhost:1234/v1")
+        self.assertEqual(client_config["api_key"], "local-llm")
+
+    def test_cloud_client_config_stays_on_openai_key_when_local_disabled(self):
+        config_module.set_config(
+            {
+                "openai_use_local": False,
+                "openai_base_url": "http://localhost:1234/v1",
+                "openai_api_key": "sk-test",
+            }
+        )
+
+        client_config = config_module.get_openai_client_config()
+
+        self.assertEqual(client_config, {"api_key": "sk-test"})
+
+    def test_environment_variables_enable_local_mode(self):
+        os.environ["OPENAI_USE_LOCAL"] = "true"
+        os.environ["OPENAI_BASE_URL"] = "http://localhost:11434/v1"
+
+        self.assertTrue(config_module.is_local_openai_enabled())
+        self.assertEqual(config_module.get_openai_base_url(), "http://localhost:11434/v1")
+        self.assertEqual(
+            config_module.get_openai_client_config(),
+            {"api_key": "local-llm", "base_url": "http://localhost:11434/v1"},
+        )
+
+    def test_embedding_model_can_be_overridden(self):
+        os.environ["OPENAI_EMBEDDING_MODEL"] = "nomic-embed-text"
+        self.assertEqual(config_module.get_openai_embedding_model(), "nomic-embed-text")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/agents/utils/gpt5_llm.py
+++ b/tradingagents/agents/utils/gpt5_llm.py
@@ -143,6 +143,7 @@ class GPT5ChatModel(BaseChatModel):
     
     model: str = "gpt-5-mini"
     api_key: Optional[str] = None
+    base_url: Optional[str] = None
     reasoning_effort: str = "medium"  # Will be mapped to model-specific values
     verbosity: str = "medium"  # low, medium, high
     summary: str = "auto"  # concise, detailed, auto, null
@@ -156,10 +157,12 @@ class GPT5ChatModel(BaseChatModel):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # Initialize the OpenAI client
+        client_kwargs = {}
         if self.api_key:
-            self._client = OpenAI(api_key=self.api_key)
-        else:
-            self._client = OpenAI()  # Uses OPENAI_API_KEY env var
+            client_kwargs["api_key"] = self.api_key
+        if self.base_url:
+            client_kwargs["base_url"] = self.base_url
+        self._client = OpenAI(**client_kwargs) if client_kwargs else OpenAI()
     
     def _get_model_type(self) -> str:
         """Determine the model type for parameter mapping."""
@@ -693,6 +696,7 @@ class GPT5ChatModel(BaseChatModel):
         new_model = GPT5ChatModel(
             model=self.model,
             api_key=self.api_key,
+            base_url=self.base_url,
             reasoning_effort=self.reasoning_effort,
             verbosity=self.verbosity,
             summary=self.summary,
@@ -736,6 +740,8 @@ def get_chat_model(model_name: str, api_key: Optional[str] = None, **kwargs):
     - gpt-5.2: reasoning.effort (none/low/medium/high/xhigh)
     - gpt-5.2-pro: No reasoning effort, just summary
     """
+    base_url = kwargs.pop("base_url", None)
+
     if is_gpt5_model(model_name):
         reasoning_effort = kwargs.pop("reasoning_effort", "medium")
         verbosity = kwargs.pop("verbosity", "medium")
@@ -747,10 +753,16 @@ def get_chat_model(model_name: str, api_key: Optional[str] = None, **kwargs):
         return GPT5ChatModel(
             model=model_name,
             api_key=api_key,
+            base_url=base_url,
             reasoning_effort=reasoning_effort,
             verbosity=verbosity,
             summary=summary,
         )
     else:
         from langchain_openai import ChatOpenAI
-        return ChatOpenAI(model=model_name, openai_api_key=api_key, **kwargs)
+        chat_kwargs = {"model": model_name, **kwargs}
+        if api_key is not None:
+            chat_kwargs["openai_api_key"] = api_key
+        if base_url:
+            chat_kwargs["openai_api_base"] = base_url
+        return ChatOpenAI(**chat_kwargs)

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -2,19 +2,24 @@ import chromadb
 from chromadb.config import Settings
 from openai import OpenAI
 import numpy as np
-from tradingagents.dataflows.config import get_api_key
+from tradingagents.dataflows.config import get_openai_client_config, get_openai_embedding_model
 
 
 class FinancialSituationMemory:
     def __init__(self, name):
-        # Get API key from environment variables or config
-        api_key = get_api_key("openai_api_key", "OPENAI_API_KEY")
-        self.client = OpenAI(api_key=api_key)
+        client_config = get_openai_client_config()
+        self.client = OpenAI(**client_config) if client_config else None
+        self.embedding_model = get_openai_embedding_model()
+        self.embeddings_enabled = self.client is not None
+        self._warned_embedding_failure = False
         self.chroma_client = chromadb.Client(Settings(allow_reset=True))
         self.situation_collection = self.chroma_client.get_or_create_collection(name=name)
 
     def get_embedding(self, text):
         """Get OpenAI embedding for a text"""
+        if not self.embeddings_enabled or self.client is None:
+            return None
+
         # Truncate text if it exceeds the model's token limit
         # text-embedding-ada-002 has a max context length of 8192 tokens
         # Conservative estimate: ~3 characters per token for safety margin
@@ -25,13 +30,25 @@ class FinancialSituationMemory:
             text = text[:half_chars] + "\n...[TRUNCATED]...\n" + text[-half_chars:]
             print(f"[MEMORY] Warning: Text truncated to ~{max_chars} characters for embedding")
         
-        response = self.client.embeddings.create(
-            model="text-embedding-ada-002", input=text
-        )
-        return response.data[0].embedding
+        try:
+            response = self.client.embeddings.create(
+                model=self.embedding_model, input=text
+            )
+            return response.data[0].embedding
+        except Exception as exc:
+            self.embeddings_enabled = False
+            if not self._warned_embedding_failure:
+                print(
+                    "[MEMORY] Embeddings unavailable; reflection memory will be skipped "
+                    f"for this run. ({exc})"
+                )
+                self._warned_embedding_failure = True
+            return None
 
     def add_situations(self, situations_and_advice):
         """Add financial situations and their corresponding advice. Parameter is a list of tuples (situation, rec)"""
+        if not self.embeddings_enabled:
+            return
 
         situations = []
         advice = []
@@ -41,10 +58,16 @@ class FinancialSituationMemory:
         offset = self.situation_collection.count()
 
         for i, (situation, recommendation) in enumerate(situations_and_advice):
+            embedding = self.get_embedding(situation)
+            if embedding is None:
+                continue
             situations.append(situation)
             advice.append(recommendation)
             ids.append(str(offset + i))
-            embeddings.append(self.get_embedding(situation))
+            embeddings.append(embedding)
+
+        if not embeddings:
+            return
 
         self.situation_collection.add(
             documents=situations,
@@ -55,7 +78,12 @@ class FinancialSituationMemory:
 
     def get_memories(self, current_situation, n_matches=1):
         """Find matching recommendations using OpenAI embeddings"""
+        if not self.embeddings_enabled:
+            return []
+
         query_embedding = self.get_embedding(current_situation)
+        if query_embedding is None:
+            return []
 
         results = self.situation_collection.query(
             query_embeddings=[query_embedding],

--- a/tradingagents/dataflows/config.py
+++ b/tradingagents/dataflows/config.py
@@ -80,6 +80,64 @@ def get_api_key(key_name: str, env_var_name: str) -> str:
     return api_key
 
 
+def _coerce_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return bool(value)
+
+
+def is_local_openai_enabled() -> bool:
+    """Return True when LLM calls should use an OpenAI-compatible local endpoint."""
+    env_value = os.getenv("OPENAI_USE_LOCAL")
+    if env_value is not None:
+        return _coerce_bool(env_value)
+    config = get_config()
+    return _coerce_bool(config.get("openai_use_local", False))
+
+
+def get_openai_base_url() -> Optional[str]:
+    """Get the configured OpenAI-compatible base URL, if any."""
+    config = get_config()
+    base_url = os.getenv("OPENAI_BASE_URL") or config.get("openai_base_url")
+    return str(base_url).strip() if base_url else None
+
+
+def get_openai_embedding_model() -> str:
+    """Return the embedding model name used by reflection memory."""
+    config = get_config()
+    return (
+        os.getenv("OPENAI_EMBEDDING_MODEL")
+        or config.get("openai_embedding_model")
+        or "text-embedding-ada-002"
+    )
+
+
+def get_openai_client_config() -> Dict[str, str]:
+    """
+    Build OpenAI SDK client kwargs.
+
+    Local mode only applies to generic chat/embedding clients. OpenAI web-search
+    tools should keep their existing cloud-only behavior unless explicitly
+    reworked, because most local OpenAI-compatible servers do not support
+    `responses.create(..., tools=[{"type": "web_search"}])`.
+    """
+    api_key = get_openai_api_key()
+    use_local = is_local_openai_enabled()
+    base_url = get_openai_base_url()
+
+    client_config: Dict[str, str] = {}
+    if use_local and base_url:
+        client_config["base_url"] = base_url
+        client_config["api_key"] = api_key or "local-llm"
+        return client_config
+
+    if api_key:
+        client_config["api_key"] = api_key
+    return client_config
+
+
 def get_openai_api_key() -> str:
     """Get OpenAI API key from runtime, environment variables, or config."""
     return get_api_key("openai_api_key", "OPENAI_API_KEY")

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -54,6 +54,9 @@ DEFAULT_CONFIG = {
     "openai_store_responses": False,  # Disable response storing by default to reduce latency/payload
     # API keys (these will be overridden by environment variables if present)
     "openai_api_key": None,
+    "openai_use_local": False,  # Route core LLM calls to a local OpenAI-compatible endpoint
+    "openai_base_url": None,  # Example: http://localhost:1234/v1
+    "openai_embedding_model": "text-embedding-ada-002",
     "finnhub_api_key": None,
     "alpaca_api_key": None,
     "alpaca_secret_key": None,

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -20,7 +20,7 @@ from tradingagents.agents.utils.agent_states import (
 from tradingagents.agents.utils.gpt5_llm import get_chat_model, is_gpt5_model, get_model_params_for_depth, describe_model_params
 from tradingagents.run_logger import get_run_audit_logger
 from tradingagents.dataflows.interface import set_config
-from tradingagents.dataflows.config import get_api_key
+from tradingagents.dataflows.config import get_openai_client_config
 
 from .conditional_logic import ConditionalLogic
 from .setup import GraphSetup
@@ -57,8 +57,9 @@ class TradingAgentsGraph:
             exist_ok=True,
         )
 
-        # Get API key from environment variables or config
-        api_key = get_api_key("openai_api_key", "OPENAI_API_KEY")
+        llm_client_config = get_openai_client_config()
+        api_key = llm_client_config.get("api_key")
+        base_url = llm_client_config.get("base_url")
 
         # Initialize LLMs with appropriate parameters based on model type and research depth
         deep_think_model = self.config["deep_think_llm"]
@@ -85,16 +86,20 @@ class TradingAgentsGraph:
         print(f"[LLM CONFIG] Research Depth: {research_depth}")
         print(f"[LLM CONFIG] Quick Thinker ({quick_think_model}): {quick_params_desc}")
         print(f"[LLM CONFIG] Deep Thinker ({deep_think_model}): {deep_params_desc}")
+        if base_url:
+            print(f"[LLM CONFIG] Using local OpenAI-compatible endpoint: {base_url}")
         
         self.deep_thinking_llm = get_chat_model(
             deep_think_model, 
             api_key=api_key,
+            base_url=base_url,
             **deep_think_kwargs
         )
         
         self.quick_thinking_llm = get_chat_model(
             quick_think_model, 
             api_key=api_key,
+            base_url=base_url,
             **quick_think_kwargs
         )
         


### PR DESCRIPTION
This PR supersedes the mergeable intent of #10 and wires local OpenAI-compatible endpoints into the actual graph runtime safely.

What changed:
- add config/env helpers for `OPENAI_USE_LOCAL`, `OPENAI_BASE_URL`, and `OPENAI_EMBEDDING_MODEL`
- route the graph's quick/deep thinker models through the configured local endpoint
- propagate `base_url` through both the GPT-5 wrapper and ChatOpenAI factory paths
- let reflection memory use the same endpoint when embeddings are available
- degrade gracefully when embeddings are not exposed instead of crashing the run
- add `LOCAL_LLM_GUIDE.md` and update `env.sample`
- add regression tests for local-LLM config resolution

Why this replaces #10 instead of merging it directly:
- #10 did not wire local endpoint settings into `TradingAgentsGraph`, so the main quick/deep thinker models would still run against the default OpenAI path
- #10 repointed OpenAI web-search tools toward the local endpoint, but LM Studio / Ollama / vLLM usually do not support OpenAI web-search tools; that breaks online mode
- #10 switched memory to a local client without handling the common case where the endpoint lacks embeddings support, which can crash the graph during memory lookup/addition

Behavioral notes:
- local mode applies to the graph LLMs and memory embeddings only
- OpenAI web-search tools remain cloud-only; for a fully local run, set `online_tools=False`

Validation:
- `python -m py_compile tradingagents/dataflows/config.py tradingagents/default_config.py tradingagents/graph/trading_graph.py tradingagents/agents/utils/gpt5_llm.py tradingagents/agents/utils/memory.py tests/test_local_llm_config.py`
- `python -m unittest discover -s tests -p "test_local_llm_config.py"`

Supersedes: #10