### PR TITLE
feat: walk-forward backtesting engine + WebUI dashboard (replays recorded agent decisions)

### DIFF
--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -241,6 +241,7 @@ class RunBacktestTests(unittest.TestCase):
             initial_cash=10_000,
             commission=0.0,
             position_pct=0.4,
+            slippage_bps=0.0,  # this test isolates lookahead, not costs
         )
         self.assertEqual(result.orders[0]["date"], "2026-01-06")
         self.assertAlmostEqual(result.orders[0]["price"], 200.0)
@@ -316,6 +317,108 @@ class RunBacktestTests(unittest.TestCase):
         result = run_backtest(prices, {"2026-01-05": "BUY"})
         payload = json.dumps(result.to_dict())
         self.assertIn("cumulative_return", payload)
+
+
+class SlippageTests(unittest.TestCase):
+    """Execution-cost realism: fills must be able to model slippage.
+
+    A zero-slippage assumption systematically inflates backtest results, so
+    a fixed basis-point model is on by default and a volatility-scaled model
+    is available for less liquid / more volatile symbols.
+    """
+
+    BUY = {"2026-01-05": "BUY"}
+
+    def test_fixed_bps_slippage_raises_buy_fill_price(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices, self.BUY, initial_cash=10_000, commission=0.0, slippage_bps=50.0
+        )
+        # 50 bps over the 100.0 next-bar open.
+        self.assertAlmostEqual(result.orders[0]["price"], 100.5)
+
+    def test_zero_bps_fills_exactly_at_open(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices, self.BUY, initial_cash=10_000, commission=0.0, slippage_bps=0.0
+        )
+        self.assertAlmostEqual(result.orders[0]["price"], 100.0)
+
+    def test_slippage_is_on_by_default(self):
+        prices = make_prices([100] * 6)
+        default = run_backtest(prices, self.BUY, initial_cash=10_000, commission=0.0)
+        self.assertGreater(default.orders[0]["price"], 100.0)
+
+    def test_sell_fill_price_slips_down(self):
+        prices = make_prices([100] * 8)
+        signals = {"2026-01-05": "BUY", "2026-01-08": "SELL"}
+        result = run_backtest(
+            prices, signals, initial_cash=10_000, commission=0.0, slippage_bps=50.0
+        )
+        sells = [o for o in result.orders if o["side"] == "sell"]
+        self.assertAlmostEqual(sells[0]["price"], 99.5)
+
+    def test_slippage_reduces_round_trip_equity(self):
+        prices = make_prices([100] * 8)
+        signals = {"2026-01-05": "BUY", "2026-01-08": "SELL"}
+        free = run_backtest(
+            prices, signals, initial_cash=10_000, commission=0.0, slippage_bps=0.0
+        )
+        slipped = run_backtest(
+            prices, signals, initial_cash=10_000, commission=0.0, slippage_bps=50.0
+        )
+        self.assertLess(slipped.equity_curve.iloc[-1], free.equity_curve.iloc[-1])
+
+    def test_volatility_model_scales_with_previous_bar_range(self):
+        # make_prices gives every bar high=101/low=99/close=100, so the
+        # previous-bar range fraction is 2%; with vol_fraction=0.1 the buy
+        # slips by 20 bps over the 100.0 open.
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices,
+            self.BUY,
+            initial_cash=10_000,
+            commission=0.0,
+            slippage_model="volatility",
+            slippage_vol_fraction=0.1,
+        )
+        self.assertAlmostEqual(result.orders[0]["price"], 100.2)
+
+    def test_volatility_model_respects_max_cap(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices,
+            self.BUY,
+            initial_cash=10_000,
+            commission=0.0,
+            slippage_model="volatility",
+            slippage_vol_fraction=0.1,
+            slippage_max_bps=5.0,
+        )
+        self.assertAlmostEqual(result.orders[0]["price"], 100.05)
+
+    def test_none_model_disables_slippage(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices,
+            self.BUY,
+            initial_cash=10_000,
+            commission=0.0,
+            slippage_model="none",
+            slippage_bps=50.0,
+        )
+        self.assertAlmostEqual(result.orders[0]["price"], 100.0)
+
+    def test_unknown_model_raises(self):
+        prices = make_prices([100] * 6)
+        with self.assertRaises(ValueError):
+            run_backtest(prices, self.BUY, slippage_model="quantum")
+
+    def test_result_reports_slippage_config(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(prices, self.BUY, slippage_bps=7.5)
+        self.assertEqual(result.to_dict()["slippage"]["model"], "fixed")
+        self.assertAlmostEqual(result.to_dict()["slippage"]["bps"], 7.5)
 
 
 class WalkForwardTests(unittest.TestCase):

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -1,0 +1,409 @@
+"""Tests for the walk-forward backtesting engine and its metrics."""
+
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from tradingagents.backtest import (
+    annualized_return,
+    cumulative_return,
+    load_recorded_signals,
+    max_drawdown,
+    normalize_action,
+    normalize_price_frame,
+    run_backtest,
+    run_recorded_backtest,
+    run_walk_forward,
+    sharpe_ratio,
+    summarize_performance,
+    win_rate,
+)
+
+
+def make_prices(closes, start="2026-01-05", opens=None, freq="B"):
+    """Build an OHLCV frame in AlpacaUtils.get_stock_data's output shape."""
+    closes = [float(c) for c in closes]
+    opens = [float(o) for o in opens] if opens is not None else list(closes)
+    dates = pd.bdate_range(start=start, periods=len(closes)) if freq == "B" else (
+        pd.date_range(start=start, periods=len(closes), freq=freq)
+    )
+    return pd.DataFrame(
+        {
+            "timestamp": dates,
+            "open": opens,
+            "high": [max(o, c) * 1.01 for o, c in zip(opens, closes)],
+            "low": [min(o, c) * 0.99 for o, c in zip(opens, closes)],
+            "close": closes,
+            "volume": [1_000_000] * len(closes),
+        }
+    )
+
+
+class MetricsTests(unittest.TestCase):
+    def test_cumulative_return_hand_computed(self):
+        self.assertAlmostEqual(cumulative_return([100.0, 125.0]), 0.25)
+        self.assertAlmostEqual(cumulative_return([100.0, 80.0]), -0.20)
+
+    def test_cumulative_return_degenerate_inputs(self):
+        self.assertIsNone(cumulative_return([]))
+        self.assertIsNone(cumulative_return([100.0]))
+        self.assertIsNone(cumulative_return([0.0, 50.0]))
+
+    def test_annualized_return_hand_computed(self):
+        # +10% over 126 periods at 252 periods/year => (1.1)^2 - 1 = 21%
+        curve = [100.0] + [100.0] * 125 + [110.0]
+        self.assertAlmostEqual(
+            annualized_return(curve, periods_per_year=252), 1.1**2 - 1.0, places=9
+        )
+
+    def test_sharpe_ratio_hand_computed(self):
+        # Alternating +1%/-1% daily returns: mean 0 => Sharpe ~ 0 (slightly
+        # negative because (1.01 * 0.99) < 1); must not be None.
+        curve = [100.0]
+        for i in range(20):
+            curve.append(curve[-1] * (1.01 if i % 2 == 0 else 0.99))
+        value = sharpe_ratio(curve)
+        self.assertIsNotNone(value)
+        self.assertLess(abs(value), 0.5)
+
+    def test_sharpe_ratio_zero_volatility_is_none(self):
+        self.assertIsNone(sharpe_ratio([100.0, 100.0, 100.0, 100.0]))
+        self.assertIsNone(sharpe_ratio([100.0, 101.0]))  # too short
+
+    def test_max_drawdown_hand_computed(self):
+        # Peak 120 -> trough 90 = 25% drawdown; later recovery must not hide it.
+        self.assertAlmostEqual(
+            max_drawdown([100.0, 120.0, 90.0, 130.0]), 0.25
+        )
+        self.assertAlmostEqual(max_drawdown([100.0, 110.0, 121.0]), 0.0)
+
+    def test_win_rate(self):
+        self.assertAlmostEqual(win_rate([10.0, -5.0, 3.0, -1.0]), 0.5)
+        self.assertIsNone(win_rate([]))
+        self.assertAlmostEqual(win_rate([0.0, 2.0]), 0.5)  # breakeven not a win
+
+    def test_summarize_performance_keys(self):
+        summary = summarize_performance([100.0, 105.0, 103.0], [4.0])
+        for key in (
+            "cumulative_return",
+            "annualized_return",
+            "sharpe_ratio",
+            "max_drawdown",
+            "win_rate",
+            "num_trades",
+            "num_periods",
+            "final_equity",
+        ):
+            self.assertIn(key, summary)
+        self.assertEqual(summary["num_trades"], 1)
+        self.assertEqual(summary["num_periods"], 2)
+        self.assertAlmostEqual(summary["final_equity"], 103.0)
+
+
+class SignalNormalizationTests(unittest.TestCase):
+    def test_all_aliases(self):
+        for raw, expected in {
+            "BUY": "BUY",
+            "long": "BUY",
+            " Short ": "SELL",
+            "sell": "SELL",
+            "HOLD": "HOLD",
+            "Neutral": "HOLD",
+        }.items():
+            with self.subTest(raw=raw):
+                self.assertEqual(normalize_action(raw), expected)
+
+    def test_unknown_inputs_are_none(self):
+        for raw in (None, "", "MAYBE", 42):
+            with self.subTest(raw=raw):
+                self.assertIsNone(normalize_action(raw))
+
+
+def write_run_log(root, symbol, trade_date, final_signal, status="completed", started_at=None):
+    runs_dir = Path(root) / symbol / "TradingAgentsStrategy_logs" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    started = started_at or f"{trade_date}T10:00:00+00:00"
+    payload = {
+        "run_id": f"{trade_date}_{started.replace(':', '')}",
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "started_at": started,
+        "status": status,
+        "summary": {"final_signal": final_signal} if final_signal else {},
+    }
+    path = runs_dir / f"{payload['run_id']}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+class LoadRecordedSignalsTests(unittest.TestCase):
+    def test_reads_completed_runs_and_normalizes(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "BUY")
+            write_run_log(root, "AAPL", "2026-01-06", "long")
+            write_run_log(root, "AAPL", "2026-01-07", "NEUTRAL")
+            signals = load_recorded_signals("AAPL", eval_results_dir=root)
+        self.assertEqual(
+            signals,
+            {"2026-01-05": "BUY", "2026-01-06": "BUY", "2026-01-07": "HOLD"},
+        )
+
+    def test_ignores_aborted_missing_signal_and_bad_dates(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "BUY", status="aborted")
+            write_run_log(root, "AAPL", "2026-01-06", None)
+            write_run_log(root, "AAPL", "not-a-date", "BUY")
+            self.assertEqual(load_recorded_signals("AAPL", eval_results_dir=root), {})
+
+    def test_latest_run_per_date_wins(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(
+                root, "AAPL", "2026-01-05", "BUY",
+                started_at="2026-01-05T09:00:00+00:00",
+            )
+            write_run_log(
+                root, "AAPL", "2026-01-05", "SELL",
+                started_at="2026-01-05T15:00:00+00:00",
+            )
+            signals = load_recorded_signals("AAPL", eval_results_dir=root)
+        self.assertEqual(signals, {"2026-01-05": "SELL"})
+
+    def test_crypto_symbol_path_sanitization(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "BTC_USD", "2026-01-05", "BUY")
+            signals = load_recorded_signals("BTC/USD", eval_results_dir=root)
+        self.assertEqual(signals, {"2026-01-05": "BUY"})
+
+    def test_missing_directory_returns_empty(self):
+        self.assertEqual(
+            load_recorded_signals("ZZZZ", eval_results_dir="definitely_missing_dir"),
+            {},
+        )
+
+
+class NormalizePriceFrameTests(unittest.TestCase):
+    def test_accepts_alpaca_layout(self):
+        frame = normalize_price_frame(make_prices([100, 101, 102]))
+        self.assertIsInstance(frame.index, pd.DatetimeIndex)
+        self.assertEqual(
+            list(frame.columns), ["open", "high", "low", "close", "volume"]
+        )
+
+    def test_strips_timezone_and_sorts(self):
+        prices = make_prices([100, 101, 102])
+        prices["timestamp"] = prices["timestamp"].dt.tz_localize("UTC")
+        prices = prices.iloc[::-1]  # reversed order on purpose
+        frame = normalize_price_frame(prices)
+        self.assertIsNone(frame.index.tz)
+        self.assertTrue(frame.index.is_monotonic_increasing)
+
+    def test_rejects_empty_and_missing_columns(self):
+        with self.assertRaises(ValueError):
+            normalize_price_frame(pd.DataFrame())
+        with self.assertRaises(ValueError):
+            normalize_price_frame(pd.DataFrame({"timestamp": ["2026-01-05"], "close": [1.0]}))
+
+
+class RunBacktestTests(unittest.TestCase):
+    def test_hold_only_keeps_cash_flat(self):
+        prices = make_prices([100, 120, 80, 150])
+        result = run_backtest(prices, {"2026-01-05": "HOLD"}, initial_cash=10_000)
+        self.assertAlmostEqual(result.equity_curve.iloc[-1], 10_000.0)
+        self.assertEqual(result.orders, [])
+        self.assertEqual(result.metrics["num_trades"], 0)
+
+    def test_buy_captures_uptrend(self):
+        closes = [100 + i for i in range(30)]
+        prices = make_prices(closes)
+        result = run_backtest(
+            prices, {"2026-01-05": "BUY"}, initial_cash=100_000, commission=0.0
+        )
+        self.assertGreater(result.equity_curve.iloc[-1], 100_000.0)
+        self.assertEqual(result.orders[0]["side"], "buy")
+
+    def test_no_lookahead_signal_fills_at_next_open(self):
+        # The signal-day close is 100 but the next open gaps to 200. A leaky
+        # engine filling at the signal-day close would buy 40 shares at 100
+        # and end at 14,000; correct next-open execution buys at 200 and the
+        # equity never captures the jump. (position_pct is small enough that
+        # the gapped-up order stays affordable.)
+        prices = make_prices(
+            closes=[100, 200, 200, 200],
+            opens=[100, 200, 200, 200],
+        )
+        result = run_backtest(
+            prices,
+            {"2026-01-05": "BUY"},
+            initial_cash=10_000,
+            commission=0.0,
+            position_pct=0.4,
+        )
+        self.assertEqual(result.orders[0]["date"], "2026-01-06")
+        self.assertAlmostEqual(result.orders[0]["price"], 200.0)
+        self.assertAlmostEqual(result.equity_curve.iloc[-1], 10_000.0, delta=1.0)
+
+    def test_unaffordable_gap_order_is_reported_not_silent(self):
+        # Full-size order computed at close=100 becomes unaffordable at the
+        # 200 open; the engine must record the rejection.
+        prices = make_prices(closes=[100, 200, 200], opens=[100, 200, 200])
+        result = run_backtest(
+            prices, {"2026-01-05": "BUY"}, initial_cash=10_000, commission=0.0
+        )
+        self.assertEqual(result.orders, [])
+        self.assertEqual(len(result.rejected_orders), 1)
+        self.assertEqual(result.rejected_orders[0]["status"], "margin")
+
+    def test_sell_when_flat_without_shorts_does_nothing(self):
+        prices = make_prices([100, 90, 80, 70])
+        result = run_backtest(
+            prices, {"2026-01-05": "SELL"}, initial_cash=10_000, allow_shorts=False
+        )
+        self.assertAlmostEqual(result.equity_curve.iloc[-1], 10_000.0)
+        self.assertEqual(result.orders, [])
+
+    def test_short_profits_in_downtrend_when_allowed(self):
+        closes = [100 - 2 * i for i in range(20)]
+        prices = make_prices(closes)
+        result = run_backtest(
+            prices,
+            {"2026-01-05": "SELL"},
+            initial_cash=100_000,
+            commission=0.0,
+            allow_shorts=True,
+        )
+        self.assertGreater(result.equity_curve.iloc[-1], 100_000.0)
+        self.assertEqual(result.orders[0]["side"], "sell")
+
+    def test_round_trip_produces_closed_trade(self):
+        closes = [100, 100, 110, 120, 120, 120]
+        prices = make_prices(closes)
+        result = run_backtest(
+            prices,
+            {"2026-01-05": "BUY", "2026-01-08": "SELL"},
+            initial_cash=100_000,
+            commission=0.0,
+        )
+        self.assertEqual(len(result.trade_pnls), 1)
+        self.assertGreater(result.trade_pnls[0], 0.0)
+        self.assertEqual(result.metrics["win_rate"], 1.0)
+
+    def test_weekend_signal_applies_on_next_bar(self):
+        # Business days 2026-01-05..09 and 12..13; 2026-01-10 is a Saturday,
+        # so the buy applies on Monday the 12th and fills at Tuesday's open.
+        prices = make_prices([100, 101, 102, 103, 104, 105, 106])
+        result = run_backtest(
+            prices, {"2026-01-10": "BUY"}, initial_cash=10_000, commission=0.0
+        )
+        self.assertEqual(len(result.orders), 1)
+        self.assertEqual(result.orders[0]["date"], "2026-01-13")
+
+    def test_commission_reduces_final_equity(self):
+        closes = [100] * 10
+        prices = make_prices(closes)
+        signals = {"2026-01-05": "BUY", "2026-01-09": "SELL"}
+        free = run_backtest(prices, signals, initial_cash=10_000, commission=0.0)
+        costly = run_backtest(prices, signals, initial_cash=10_000, commission=0.01)
+        self.assertLess(
+            costly.equity_curve.iloc[-1], free.equity_curve.iloc[-1]
+        )
+
+    def test_result_to_dict_is_json_serializable(self):
+        prices = make_prices([100, 101, 102])
+        result = run_backtest(prices, {"2026-01-05": "BUY"})
+        payload = json.dumps(result.to_dict())
+        self.assertIn("cumulative_return", payload)
+
+
+class WalkForwardTests(unittest.TestCase):
+    def test_windows_partition_all_bars(self):
+        prices = make_prices([100 + i for i in range(50)])
+        result = run_walk_forward(
+            prices, {"2026-01-05": "BUY"}, window_bars=20, commission=0.0
+        )
+        self.assertEqual(sum(w["bars"] for w in result.windows), 50)
+        # 20 + 20 + 10 -> the 10-bar remainder stands alone (>= min_window_bars)
+        self.assertEqual([w["bars"] for w in result.windows], [20, 20, 10])
+
+    def test_short_remainder_folds_into_last_window(self):
+        prices = make_prices([100 + i for i in range(43)])
+        result = run_walk_forward(
+            prices, {"2026-01-05": "BUY"}, window_bars=20, min_window_bars=5
+        )
+        self.assertEqual([w["bars"] for w in result.windows], [20, 23])
+
+    def test_each_window_has_metrics_and_full_period_present(self):
+        prices = make_prices([100 + i for i in range(30)])
+        result = run_walk_forward(prices, {"2026-01-05": "BUY"}, window_bars=10)
+        for window in result.windows:
+            self.assertIn("sharpe_ratio", window["metrics"])
+            self.assertIn("max_drawdown", window["metrics"])
+        self.assertIsNotNone(result.full_period)
+        self.assertEqual(result.full_period.metrics["num_periods"], 29)
+
+    def test_rejects_tiny_window(self):
+        prices = make_prices([100, 101, 102])
+        with self.assertRaises(ValueError):
+            run_walk_forward(prices, {}, window_bars=1)
+
+
+class RunRecordedBacktestTests(unittest.TestCase):
+    def test_end_to_end_with_recorded_runs_and_injected_prices(self):
+        closes = [100 + i for i in range(15)]
+        prices = make_prices(closes, start="2026-01-05")
+
+        def fake_loader(symbol, start, end):
+            self.assertEqual(symbol, "AAPL")
+            return prices
+
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "BUY")
+            write_run_log(root, "AAPL", "2026-01-12", "SELL")
+            result = run_recorded_backtest(
+                "AAPL",
+                eval_results_dir=root,
+                price_loader=fake_loader,
+                commission=0.0,
+            )
+        self.assertEqual(result.signals_used, 2)
+        self.assertEqual(len(result.trade_pnls), 1)
+        self.assertGreater(result.metrics["cumulative_return"], 0.0)
+
+    def test_raises_without_recorded_signals(self):
+        with tempfile.TemporaryDirectory() as root:
+            with self.assertRaises(ValueError):
+                run_recorded_backtest("AAPL", eval_results_dir=root)
+
+    def test_signals_before_start_date_are_dropped(self):
+        prices = make_prices([100 + i for i in range(10)], start="2026-02-02")
+
+        def fake_loader(symbol, start, end):
+            self.assertEqual(start, "2026-02-02")
+            return prices
+
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "SELL")
+            write_run_log(root, "AAPL", "2026-02-03", "BUY")
+            result = run_recorded_backtest(
+                "AAPL",
+                start_date="2026-02-02",
+                eval_results_dir=root,
+                price_loader=fake_loader,
+            )
+        self.assertEqual(result.signals_used, 1)
+
+    def test_raises_when_all_signals_predate_start(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "BUY")
+            with self.assertRaises(ValueError):
+                run_recorded_backtest(
+                    "AAPL", start_date="2026-06-01", eval_results_dir=root,
+                    price_loader=lambda s, a, b: make_prices([1, 2]),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_backtest_webui.py
+++ b/tests/test_backtest_webui.py
@@ -16,6 +16,7 @@ class BacktestPanelWiringTests(unittest.TestCase):
             "backtest-run-btn",
             "backtest-equity-graph",
             "backtest-windows-table",
+            "backtest-slippage-model",
         ):
             self.assertIn(component_id, rendered)
 

--- a/tests/test_backtest_webui.py
+++ b/tests/test_backtest_webui.py
@@ -1,0 +1,74 @@
+"""Wiring tests for the backtest WebUI panel and callbacks."""
+
+import unittest
+
+import pandas as pd
+
+
+class BacktestPanelWiringTests(unittest.TestCase):
+    def test_panel_component_builds(self):
+        from webui.components.backtest_panel import create_backtest_panel
+
+        panel = create_backtest_panel()
+        rendered = str(panel)
+        for component_id in (
+            "backtest-symbol-input",
+            "backtest-run-btn",
+            "backtest-equity-graph",
+            "backtest-windows-table",
+        ):
+            self.assertIn(component_id, rendered)
+
+    def test_callbacks_register_on_fresh_app(self):
+        import dash
+
+        from webui.callbacks.backtest_callbacks import register_backtest_callbacks
+
+        app = dash.Dash(__name__, suppress_callback_exceptions=True)
+        register_backtest_callbacks(app)
+        # Callback map keys are derived from outputs.
+        self.assertTrue(
+            any("backtest-status" in key for key in app.callback_map),
+            f"backtest callback missing from callback map: {list(app.callback_map)}",
+        )
+
+    def test_metric_formatting_helpers(self):
+        from webui.callbacks.backtest_callbacks import _fmt_pct, _fmt_ratio
+
+        self.assertEqual(_fmt_pct(0.25), "+25.00%")
+        self.assertEqual(_fmt_pct(-0.031), "-3.10%")
+        self.assertEqual(_fmt_pct(None), "—")
+        self.assertEqual(_fmt_ratio(1.234), "1.23")
+        self.assertEqual(_fmt_ratio(None), "—")
+
+    def test_equity_figure_and_windows_table_render(self):
+        from webui.callbacks.backtest_callbacks import (
+            _build_equity_figure,
+            _build_windows_table,
+        )
+
+        curve = pd.Series(
+            [100.0, 101.0, 102.0],
+            index=pd.date_range("2026-01-05", periods=3),
+        )
+        figure = _build_equity_figure(curve, "AAPL")
+        self.assertEqual(len(figure.data), 1)
+
+        window = {
+            "start_date": "2026-01-05",
+            "end_date": "2026-02-05",
+            "bars": 21,
+            "metrics": {
+                "cumulative_return": 0.05,
+                "sharpe_ratio": 1.5,
+                "max_drawdown": 0.02,
+                "win_rate": 0.6,
+            },
+        }
+        # A single window adds nothing beyond the full-period metrics.
+        self.assertIsNone(_build_windows_table([window]))
+        self.assertIsNotNone(_build_windows_table([window, window]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_fallback.py
+++ b/tests/test_data_fallback.py
@@ -25,6 +25,32 @@ class DataFallbackTests(unittest.TestCase):
         self.assertTrue(result.empty)
         yf_download.assert_not_called()
 
+    def test_nginx_401_html_error_triggers_fallback(self):
+        # Alpaca auth failures can surface as a raw nginx HTML page that says
+        # "401 Authorization Required" without the word "unauthorized".
+        fallback = pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2026-01-01", "2026-01-02"]),
+                "Open": [10.0, 11.0],
+                "High": [12.0, 12.5],
+                "Low": [9.5, 10.5],
+                "Close": [11.5, 12.0],
+                "Volume": [1000, 1100],
+            }
+        ).set_index("Date")
+
+        set_config({**self.original_config, "data_fallback_enabled": True})
+        nginx_error = ValueError(
+            "<html>\n<head><title>401 Authorization Required</title></head>\n</html>"
+        )
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_stock_client",
+            side_effect=nginx_error,
+        ), patch("yfinance.download", return_value=fallback):
+            result = AlpacaUtils.get_stock_data("AAPL", "2026-01-01", "2026-01-03")
+
+        self.assertFalse(result.empty)
+
     def test_yfinance_fallback_normalizes_ohlcv_columns(self):
         fallback = pd.DataFrame(
             {

--- a/tradingagents/backtest/__init__.py
+++ b/tradingagents/backtest/__init__.py
@@ -1,0 +1,51 @@
+"""Deterministic backtesting and evaluation for agent trading decisions.
+
+Public surface:
+- run_backtest / run_walk_forward: replay dated BUY/SELL/HOLD signals over
+  OHLCV bars via backtrader with next-open execution (no lookahead).
+- run_recorded_backtest: evaluate the decisions already persisted under
+  eval_results/ without spending a single LLM call.
+- metrics: pure-math Sharpe / drawdown / win-rate helpers.
+"""
+
+from .engine import (
+    BacktestResult,
+    WalkForwardResult,
+    normalize_price_frame,
+    run_backtest,
+    run_recorded_backtest,
+    run_recorded_walk_forward,
+    run_walk_forward,
+)
+from .metrics import (
+    CRYPTO_DAYS_PER_YEAR,
+    TRADING_DAYS_PER_YEAR,
+    annualized_return,
+    cumulative_return,
+    max_drawdown,
+    sharpe_ratio,
+    summarize_performance,
+    win_rate,
+)
+from .signals import ACTION_ALIASES, load_recorded_signals, normalize_action
+
+__all__ = [
+    "ACTION_ALIASES",
+    "BacktestResult",
+    "CRYPTO_DAYS_PER_YEAR",
+    "TRADING_DAYS_PER_YEAR",
+    "WalkForwardResult",
+    "annualized_return",
+    "cumulative_return",
+    "load_recorded_signals",
+    "max_drawdown",
+    "normalize_action",
+    "normalize_price_frame",
+    "run_backtest",
+    "run_recorded_backtest",
+    "run_recorded_walk_forward",
+    "run_walk_forward",
+    "sharpe_ratio",
+    "summarize_performance",
+    "win_rate",
+]

--- a/tradingagents/backtest/engine.py
+++ b/tradingagents/backtest/engine.py
@@ -24,6 +24,57 @@ from .metrics import (
 from .signals import load_recorded_signals
 
 
+_BPS = 1e-4  # one basis point as a fraction
+
+
+class _VolatilitySlippageBroker(bt.brokers.BackBroker):
+    """Backtesting broker whose slippage scales with recent volatility.
+
+    Each fill slips by ``vol_fraction`` of the previous completed bar's range
+    (high - low, as a fraction of its close), clamped to
+    [``min_bps``, ``max_bps``] basis points.  Calm tape costs little; wide
+    bars — where market orders realistically eat through the book — cost
+    more.  The fill-bar's own range is never used, so the model needs no
+    intrabar knowledge.
+    """
+
+    def __init__(self, vol_fraction=0.1, min_bps=1.0, max_bps=50.0):
+        super().__init__()
+        self._vol_fraction = float(vol_fraction)
+        self._min_perc = float(min_bps) * _BPS
+        self._max_perc = float(max_bps) * _BPS
+        self._slippage_feed = None
+        # Base-class slippage plumbing reads p.slip_perc; make fills at the
+        # open slip like set_slippage_perc() would.
+        self.p.slip_open = True
+        self.p.slip_match = True
+        self.p.slip_out = False
+
+    def set_slippage_feed(self, data) -> None:
+        self._slippage_feed = data
+
+    def _dynamic_perc(self) -> float:
+        feed = self._slippage_feed
+        try:
+            close = float(feed.close[-1])
+            bar_range = max(float(feed.high[-1]) - float(feed.low[-1]), 0.0)
+            if close <= 0:
+                return self._min_perc
+            perc = self._vol_fraction * bar_range / close
+        except (IndexError, TypeError, AttributeError):
+            # First bar (no completed predecessor) or no feed registered.
+            return self._min_perc
+        return min(max(perc, self._min_perc), self._max_perc)
+
+    def _slip_up(self, pmax, price, doslip=True, lim=False):
+        self.p.slip_perc = self._dynamic_perc()
+        return super()._slip_up(pmax, price, doslip=doslip, lim=lim)
+
+    def _slip_down(self, pmin, price, doslip=True, lim=False):
+        self.p.slip_perc = self._dynamic_perc()
+        return super()._slip_down(pmin, price, doslip=doslip, lim=lim)
+
+
 class _SignalReplayStrategy(bt.Strategy):
     """Executes an externally supplied {date: action} map, nothing else."""
 
@@ -101,6 +152,7 @@ class BacktestResult:
     start_date: Optional[str] = None
     end_date: Optional[str] = None
     rejected_orders: List[dict] = field(default_factory=list)
+    slippage: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
@@ -110,6 +162,7 @@ class BacktestResult:
             "end_date": self.end_date,
             "num_orders": len(self.orders),
             "rejected_orders": list(self.rejected_orders),
+            "slippage": dict(self.slippage),
             "equity_curve": {
                 ts.date().isoformat(): value
                 for ts, value in self.equity_curve.items()
@@ -171,12 +224,56 @@ def run_backtest(
     allow_shorts: bool = False,
     position_pct: float = 0.95,
     periods_per_year: int = TRADING_DAYS_PER_YEAR,
+    slippage_model: str = "fixed",
+    slippage_bps: float = 5.0,
+    slippage_vol_fraction: float = 0.1,
+    slippage_min_bps: float = 1.0,
+    slippage_max_bps: float = 50.0,
 ) -> BacktestResult:
-    """Replay dated signals over price history and measure performance."""
+    """Replay dated signals over price history and measure performance.
+
+    Slippage models (zero-slippage backtests systematically overstate
+    performance, so a small fixed cost is applied by default):
+
+    - ``"fixed"``: every fill slips by ``slippage_bps`` basis points against
+      the trade (default 5 bps).
+    - ``"volatility"``: the slip is ``slippage_vol_fraction`` of the previous
+      bar's high-low range (as a fraction of its close), clamped to
+      [``slippage_min_bps``, ``slippage_max_bps``] — cheap in calm tape,
+      expensive across wide bars.
+    - ``"none"``: frictionless fills (not recommended outside tests).
+    """
     frame = normalize_price_frame(prices)
 
     cerebro = bt.Cerebro()
-    cerebro.adddata(bt.feeds.PandasData(dataname=frame))
+    data_feed = bt.feeds.PandasData(dataname=frame)
+    cerebro.adddata(data_feed)
+
+    if slippage_model == "volatility":
+        broker = _VolatilitySlippageBroker(
+            vol_fraction=slippage_vol_fraction,
+            min_bps=slippage_min_bps,
+            max_bps=slippage_max_bps,
+        )
+        broker.set_slippage_feed(data_feed)
+        cerebro.setbroker(broker)
+        slippage_config = {
+            "model": "volatility",
+            "vol_fraction": float(slippage_vol_fraction),
+            "min_bps": float(slippage_min_bps),
+            "max_bps": float(slippage_max_bps),
+        }
+    elif slippage_model == "fixed":
+        if float(slippage_bps) > 0:
+            cerebro.broker.set_slippage_perc(float(slippage_bps) * _BPS)
+        slippage_config = {"model": "fixed", "bps": float(slippage_bps)}
+    elif slippage_model == "none":
+        slippage_config = {"model": "none"}
+    else:
+        raise ValueError(
+            f"Unknown slippage_model {slippage_model!r}; expected 'fixed', 'volatility', or 'none'."
+        )
+
     cerebro.broker.setcash(float(initial_cash))
     cerebro.broker.setcommission(commission=float(commission))
     cerebro.addstrategy(
@@ -204,6 +301,7 @@ def run_backtest(
         start_date=frame.index[0].date().isoformat(),
         end_date=frame.index[-1].date().isoformat(),
         rejected_orders=list(strategy.rejected_orders),
+        slippage=slippage_config,
     )
 
 

--- a/tradingagents/backtest/engine.py
+++ b/tradingagents/backtest/engine.py
@@ -1,0 +1,335 @@
+"""Walk-forward backtesting engine built on backtrader.
+
+The engine replays a series of dated BUY/SELL/HOLD signals against
+historical OHLCV bars. Orders are submitted when a bar closes and fill at
+the *next* bar's open (backtrader's default, cheat-on-open disabled), so a
+decision made on day t can never benefit from day t's own price — the same
+information-set discipline required to avoid lookahead bias in walk-forward
+evaluation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+import backtrader as bt
+import pandas as pd
+
+from .metrics import (
+    CRYPTO_DAYS_PER_YEAR,
+    TRADING_DAYS_PER_YEAR,
+    summarize_performance,
+)
+from .signals import load_recorded_signals
+
+
+class _SignalReplayStrategy(bt.Strategy):
+    """Executes an externally supplied {date: action} map, nothing else."""
+
+    params = (
+        ("signals", None),  # dict[str iso-date, "BUY"|"SELL"|"HOLD"]
+        ("allow_shorts", False),
+        ("position_pct", 0.95),  # fraction of portfolio value per full position
+    )
+
+    def __init__(self):
+        self.equity_dates: List[pd.Timestamp] = []
+        self.equity_values: List[float] = []
+        self.closed_trade_pnls: List[float] = []
+        self.executed_orders: List[dict] = []
+        self.rejected_orders: List[dict] = []
+        # Signals sorted by date so ones falling on non-trading days (weekends,
+        # halts) apply on the next available bar instead of silently dropping.
+        self._pending = sorted((self.p.signals or {}).items())
+        self._cursor = 0
+
+    def _consume_signals_up_to(self, bar_date: str) -> Optional[str]:
+        action = None
+        while self._cursor < len(self._pending) and self._pending[self._cursor][0] <= bar_date:
+            action = self._pending[self._cursor][1]
+            self._cursor += 1
+        return action
+
+    def next(self):
+        bar_date = self.data.datetime.date(0)
+        self.equity_dates.append(pd.Timestamp(bar_date))
+        self.equity_values.append(float(self.broker.getvalue()))
+
+        action = self._consume_signals_up_to(bar_date.isoformat())
+        if action == "BUY":
+            self.order_target_percent(target=self.p.position_pct)
+        elif action == "SELL":
+            target = -self.p.position_pct if self.p.allow_shorts else 0.0
+            self.order_target_percent(target=target)
+        # HOLD / None: keep the current position untouched.
+
+    def notify_order(self, order):
+        if order.status == order.Completed:
+            self.executed_orders.append(
+                {
+                    "date": self.data.datetime.date(0).isoformat(),
+                    "side": "buy" if order.isbuy() else "sell",
+                    "size": float(order.executed.size),
+                    "price": float(order.executed.price),
+                }
+            )
+        elif order.status in (order.Margin, order.Rejected):
+            # Sizing uses the signal bar's close but fills at the next open;
+            # a large overnight gap can make the order unaffordable. Surface
+            # that instead of letting the trade vanish silently.
+            self.rejected_orders.append(
+                {
+                    "date": self.data.datetime.date(0).isoformat(),
+                    "side": "buy" if order.isbuy() else "sell",
+                    "status": "margin" if order.status == order.Margin else "rejected",
+                }
+            )
+
+    def notify_trade(self, trade):
+        if trade.isclosed:
+            self.closed_trade_pnls.append(float(trade.pnlcomm))
+
+
+@dataclass
+class BacktestResult:
+    equity_curve: pd.Series
+    trade_pnls: List[float]
+    orders: List[dict]
+    metrics: dict
+    signals_used: int
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    rejected_orders: List[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "metrics": dict(self.metrics),
+            "signals_used": self.signals_used,
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+            "num_orders": len(self.orders),
+            "rejected_orders": list(self.rejected_orders),
+            "equity_curve": {
+                ts.date().isoformat(): value
+                for ts, value in self.equity_curve.items()
+            },
+        }
+
+
+@dataclass
+class WalkForwardResult:
+    windows: List[dict] = field(default_factory=list)
+    full_period: Optional[BacktestResult] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "windows": list(self.windows),
+            "full_period": self.full_period.to_dict() if self.full_period else None,
+        }
+
+
+def normalize_price_frame(prices: pd.DataFrame) -> pd.DataFrame:
+    """Coerce an OHLCV frame into the shape backtrader's PandasData expects.
+
+    Accepts the ['timestamp', open, high, low, close, volume] layout produced
+    by AlpacaUtils.get_stock_data (any column casing) or a frame already
+    indexed by datetime. Raises ValueError on anything unusable.
+    """
+    if prices is None or len(prices) == 0:
+        raise ValueError("No price data supplied for backtest.")
+
+    frame = prices.copy()
+    frame.columns = [str(c).lower() for c in frame.columns]
+
+    if "timestamp" in frame.columns:
+        frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+        frame = frame.set_index("timestamp")
+    elif not isinstance(frame.index, pd.DatetimeIndex):
+        raise ValueError("Price data needs a 'timestamp' column or a DatetimeIndex.")
+
+    if getattr(frame.index, "tz", None) is not None:
+        frame.index = frame.index.tz_localize(None)
+
+    required = {"open", "high", "low", "close"}
+    missing = required - set(frame.columns)
+    if missing:
+        raise ValueError(f"Price data is missing columns: {sorted(missing)}")
+    if "volume" not in frame.columns:
+        frame["volume"] = 0.0
+
+    frame = frame[["open", "high", "low", "close", "volume"]].astype(float)
+    frame = frame[~frame.index.duplicated(keep="last")].sort_index()
+    return frame
+
+
+def run_backtest(
+    prices: pd.DataFrame,
+    signals: Dict[str, str],
+    initial_cash: float = 100_000.0,
+    commission: float = 0.001,
+    allow_shorts: bool = False,
+    position_pct: float = 0.95,
+    periods_per_year: int = TRADING_DAYS_PER_YEAR,
+) -> BacktestResult:
+    """Replay dated signals over price history and measure performance."""
+    frame = normalize_price_frame(prices)
+
+    cerebro = bt.Cerebro()
+    cerebro.adddata(bt.feeds.PandasData(dataname=frame))
+    cerebro.broker.setcash(float(initial_cash))
+    cerebro.broker.setcommission(commission=float(commission))
+    cerebro.addstrategy(
+        _SignalReplayStrategy,
+        signals=dict(signals or {}),
+        allow_shorts=allow_shorts,
+        position_pct=position_pct,
+    )
+    strategy = cerebro.run()[0]
+
+    equity_curve = pd.Series(
+        strategy.equity_values, index=strategy.equity_dates, dtype=float
+    )
+    metrics = summarize_performance(
+        equity_curve,
+        strategy.closed_trade_pnls,
+        periods_per_year=periods_per_year,
+    )
+    return BacktestResult(
+        equity_curve=equity_curve,
+        trade_pnls=list(strategy.closed_trade_pnls),
+        orders=list(strategy.executed_orders),
+        metrics=metrics,
+        signals_used=len(signals or {}),
+        start_date=frame.index[0].date().isoformat(),
+        end_date=frame.index[-1].date().isoformat(),
+        rejected_orders=list(strategy.rejected_orders),
+    )
+
+
+def run_walk_forward(
+    prices: pd.DataFrame,
+    signals: Dict[str, str],
+    window_bars: int = 63,
+    min_window_bars: int = 5,
+    **backtest_kwargs,
+) -> WalkForwardResult:
+    """Evaluate signals over consecutive non-overlapping out-of-sample windows.
+
+    LLM decision replay has no parameters to re-fit between folds, so the
+    walk-forward's purpose here is robustness: instead of one full-period
+    number, each ~quarterly window (63 trading bars by default) restarts with
+    fresh capital and reports its own metrics, exposing regime dependence a
+    single lucky backtest would hide. A trailing window shorter than
+    `min_window_bars` is folded into its predecessor.
+    """
+    frame = normalize_price_frame(prices)
+    if window_bars < 2:
+        raise ValueError("window_bars must be at least 2.")
+
+    boundaries = list(range(0, len(frame), window_bars))
+    windows: List[dict] = []
+    for start in boundaries:
+        end = start + window_bars
+        # Absorb a too-short trailing remainder into the final window.
+        if len(frame) - end < min_window_bars:
+            end = len(frame)
+        chunk = frame.iloc[start:end]
+        if len(chunk) < 2:
+            break
+        result = run_backtest(chunk, signals, **backtest_kwargs)
+        windows.append(
+            {
+                "start_date": result.start_date,
+                "end_date": result.end_date,
+                "bars": len(chunk),
+                "metrics": result.metrics,
+            }
+        )
+        if end == len(frame):
+            break
+
+    full = run_backtest(frame, signals, **backtest_kwargs)
+    return WalkForwardResult(windows=windows, full_period=full)
+
+
+def run_recorded_backtest(
+    symbol: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    eval_results_dir: str = "eval_results",
+    price_loader: Optional[Callable[[str, str, Optional[str]], pd.DataFrame]] = None,
+    **backtest_kwargs,
+) -> BacktestResult:
+    """Backtest the signals this deployment has already produced for `symbol`.
+
+    Pulls decisions from the persisted run logs (zero LLM cost) and prices
+    from Alpaca (with its existing yfinance fallback). `price_loader` exists
+    for tests and alternative data sources.
+    """
+    signals = load_recorded_signals(symbol, eval_results_dir=eval_results_dir)
+    if not signals:
+        raise ValueError(
+            f"No recorded completed runs with final signals found for {symbol} "
+            f"under {eval_results_dir}/."
+        )
+
+    first_signal = min(signals)
+    start = start_date or first_signal
+    if start > first_signal:
+        # Signals before the price window would misleadingly fire on its
+        # first bar; drop them so the backtest matches the requested range.
+        signals = {d: a for d, a in signals.items() if d >= start}
+        if not signals:
+            raise ValueError(
+                f"All recorded signals for {symbol} predate start_date={start}."
+            )
+
+    if price_loader is None:
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        price_loader = AlpacaUtils.get_stock_data
+
+    prices = price_loader(symbol, start, end_date)
+    backtest_kwargs.setdefault(
+        "periods_per_year",
+        CRYPTO_DAYS_PER_YEAR if "/" in symbol else TRADING_DAYS_PER_YEAR,
+    )
+    return run_backtest(prices, signals, **backtest_kwargs)
+
+
+def run_recorded_walk_forward(
+    symbol: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    eval_results_dir: str = "eval_results",
+    price_loader: Optional[Callable[[str, str, Optional[str]], pd.DataFrame]] = None,
+    window_bars: int = 63,
+    **backtest_kwargs,
+) -> WalkForwardResult:
+    """Walk-forward evaluation of this deployment's recorded decisions."""
+    signals = load_recorded_signals(symbol, eval_results_dir=eval_results_dir)
+    if not signals:
+        raise ValueError(
+            f"No recorded completed runs with final signals found for {symbol} "
+            f"under {eval_results_dir}/."
+        )
+
+    start = start_date or min(signals)
+    signals = {d: a for d, a in signals.items() if d >= start}
+    if not signals:
+        raise ValueError(
+            f"All recorded signals for {symbol} predate start_date={start}."
+        )
+
+    if price_loader is None:
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        price_loader = AlpacaUtils.get_stock_data
+
+    prices = price_loader(symbol, start, end_date)
+    backtest_kwargs.setdefault(
+        "periods_per_year",
+        CRYPTO_DAYS_PER_YEAR if "/" in symbol else TRADING_DAYS_PER_YEAR,
+    )
+    return run_walk_forward(prices, signals, window_bars=window_bars, **backtest_kwargs)

--- a/tradingagents/backtest/metrics.py
+++ b/tradingagents/backtest/metrics.py
@@ -1,0 +1,108 @@
+"""Pure-math performance metrics for backtest evaluation.
+
+All functions operate on plain sequences / pandas objects and never touch
+the network, the broker, or an LLM, so every number shown in the UI is
+reproducible in a unit test. Metric names follow the TradingAgents paper
+(arXiv:2412.20138): cumulative return, annualized return, Sharpe ratio,
+and maximum drawdown, plus win rate over closed trades.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Sequence
+
+import pandas as pd
+
+TRADING_DAYS_PER_YEAR = 252
+CRYPTO_DAYS_PER_YEAR = 365
+
+
+def _as_series(equity_curve) -> pd.Series:
+    if isinstance(equity_curve, pd.Series):
+        return equity_curve.astype(float)
+    return pd.Series(list(equity_curve), dtype=float)
+
+
+def cumulative_return(equity_curve) -> Optional[float]:
+    """Total return over the whole curve, e.g. 0.25 for +25%."""
+    curve = _as_series(equity_curve)
+    if len(curve) < 2 or curve.iloc[0] <= 0:
+        return None
+    return float(curve.iloc[-1] / curve.iloc[0] - 1.0)
+
+
+def annualized_return(equity_curve, periods_per_year: int = TRADING_DAYS_PER_YEAR) -> Optional[float]:
+    """Geometric annualized return assuming one curve point per period."""
+    curve = _as_series(equity_curve)
+    total = cumulative_return(curve)
+    if total is None:
+        return None
+    periods = len(curve) - 1
+    growth = 1.0 + total
+    if growth <= 0:
+        return -1.0
+    return float(growth ** (periods_per_year / periods) - 1.0)
+
+
+def sharpe_ratio(
+    equity_curve,
+    risk_free_rate: float = 0.0,
+    periods_per_year: int = TRADING_DAYS_PER_YEAR,
+) -> Optional[float]:
+    """Annualized Sharpe ratio from per-period equity values.
+
+    `risk_free_rate` is annual; it is converted to a per-period rate.
+    Returns None when the curve is too short or volatility is zero,
+    rather than fabricating a number.
+    """
+    curve = _as_series(equity_curve)
+    if len(curve) < 3:
+        return None
+    returns = curve.pct_change().dropna()
+    if len(returns) < 2:
+        return None
+    per_period_rf = (1.0 + risk_free_rate) ** (1.0 / periods_per_year) - 1.0
+    excess = returns - per_period_rf
+    std = float(excess.std(ddof=1))
+    if not math.isfinite(std) or std == 0.0:
+        return None
+    return float(excess.mean() / std * math.sqrt(periods_per_year))
+
+
+def max_drawdown(equity_curve) -> Optional[float]:
+    """Largest peak-to-trough decline as a positive fraction (0.2 = -20%)."""
+    curve = _as_series(equity_curve)
+    if len(curve) < 2:
+        return None
+    running_peak = curve.cummax()
+    drawdowns = 1.0 - curve / running_peak
+    return float(drawdowns.max())
+
+
+def win_rate(trade_pnls: Sequence[float]) -> Optional[float]:
+    """Fraction of closed trades with positive net PnL; None when no trades."""
+    pnls = [float(p) for p in trade_pnls]
+    if not pnls:
+        return None
+    return sum(1 for p in pnls if p > 0) / len(pnls)
+
+
+def summarize_performance(
+    equity_curve,
+    trade_pnls: Sequence[float] = (),
+    risk_free_rate: float = 0.0,
+    periods_per_year: int = TRADING_DAYS_PER_YEAR,
+) -> dict:
+    """All headline metrics in one dict (values may be None when undefined)."""
+    curve = _as_series(equity_curve)
+    return {
+        "cumulative_return": cumulative_return(curve),
+        "annualized_return": annualized_return(curve, periods_per_year),
+        "sharpe_ratio": sharpe_ratio(curve, risk_free_rate, periods_per_year),
+        "max_drawdown": max_drawdown(curve),
+        "win_rate": win_rate(trade_pnls),
+        "num_trades": len(list(trade_pnls)),
+        "num_periods": max(len(curve) - 1, 0),
+        "final_equity": float(curve.iloc[-1]) if len(curve) else None,
+    }

--- a/tradingagents/backtest/signals.py
+++ b/tradingagents/backtest/signals.py
@@ -1,0 +1,84 @@
+"""Signal sources for backtesting.
+
+The primary source replays decisions the multi-agent pipeline already made
+and persisted under ``eval_results/`` (see tradingagents/run_logger.py), so
+evaluating past agent behavior costs zero LLM calls. Signals are normalized
+to a common BUY/SELL/HOLD vocabulary; trading-mode outputs map onto it
+(LONG->BUY, SHORT->SELL, NEUTRAL->HOLD).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, Optional
+
+ACTION_ALIASES = {
+    "BUY": "BUY",
+    "LONG": "BUY",
+    "SELL": "SELL",
+    "SHORT": "SELL",
+    "HOLD": "HOLD",
+    "NEUTRAL": "HOLD",
+}
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def normalize_action(raw) -> Optional[str]:
+    """Map any recognized signal spelling to BUY/SELL/HOLD, else None."""
+    if raw is None:
+        return None
+    return ACTION_ALIASES.get(str(raw).strip().upper())
+
+
+def _sanitize_symbol_for_path(symbol: str) -> str:
+    # Must mirror run_logger._sanitize_for_path so we find its output dirs
+    # (importing it would trigger the module's stale-log recovery side effect).
+    sanitized = re.sub(r"[^\w\-.]+", "_", symbol.strip())
+    return sanitized or "unknown"
+
+
+def load_recorded_signals(
+    symbol: str,
+    eval_results_dir: str = "eval_results",
+) -> Dict[str, str]:
+    """Read persisted run logs and return {trade_date: normalized_action}.
+
+    Only completed runs with a recognizable final signal count. When several
+    runs exist for the same trade date, the most recently started one wins —
+    it reflects the newest configuration of the pipeline.
+    """
+    runs_dir = (
+        Path(eval_results_dir)
+        / _sanitize_symbol_for_path(symbol)
+        / "TradingAgentsStrategy_logs"
+        / "runs"
+    )
+    if not runs_dir.is_dir():
+        return {}
+
+    best_per_date: Dict[str, tuple] = {}  # date -> (started_at, action)
+    for path in sorted(runs_dir.glob("*.json")):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        if payload.get("status") != "completed":
+            continue
+        trade_date = str(payload.get("trade_date") or "").strip()
+        if not _DATE_RE.match(trade_date):
+            continue
+        action = normalize_action((payload.get("summary") or {}).get("final_signal"))
+        if action is None:
+            continue
+
+        started_at = str(payload.get("started_at") or "")
+        current = best_per_date.get(trade_date)
+        if current is None or started_at > current[0]:
+            best_per_date[trade_date] = (started_at, action)
+
+    return {date: action for date, (_, action) in sorted(best_per_date.items())}

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -15,7 +15,10 @@ from alpaca.trading.enums import AssetClass, AssetStatus, OrderSide, QueryOrderS
 from alpaca.common.enums import Sort
 from .config import get_api_key, get_alpaca_use_paper, get_config
 from .ticker_utils import TickerUtils
-from tradingagents.agents.schemas import TradeIntent, trade_intent_action
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tradingagents.agents.schemas import TradeIntent
 
 
 # Fallback dictionary for company names
@@ -227,6 +230,8 @@ def _is_supported_data_fallback_error(error: Exception) -> bool:
             "subscription",
             "permission",
             "unauthorized",
+            # nginx-level 401s arrive as HTML pages with this phrasing
+            "authorization required",
             "forbidden",
             "not found",
             "empty",
@@ -835,7 +840,7 @@ class AlpacaUtils:
     def execute_trade_intent(
         symbol: str,
         current_position: str,
-        trade_intent: Union[TradeIntent, Dict[str, Any]],
+        trade_intent: Union["TradeIntent", Dict[str, Any]],
         dollar_amount: float,
         allow_shorts: bool = False,
     ) -> dict:
@@ -845,6 +850,11 @@ class AlpacaUtils:
         method intentionally delegates to the existing simple market/close
         execution path until bracket/OCO/OTO order placement is implemented.
         """
+        # Imported lazily: a module-level import of the agents package from
+        # here creates a dataflows <-> agents import cycle that breaks
+        # whenever dataflows is imported first.
+        from tradingagents.agents.schemas import TradeIntent, trade_intent_action
+
         try:
             intent = (
                 trade_intent

--- a/tradingagents/dataflows/reddit_utils.py
+++ b/tradingagents/dataflows/reddit_utils.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from typing import Annotated, List
 import os
 import re
-from .alpaca_utils import AlpacaUtils
 
 REDDIT_USER_AGENT = "TradingAgents/1.0"
 REDDIT_CATEGORY_SUBREDDITS = {
@@ -46,6 +45,11 @@ def get_company_name(ticker: str) -> str:
     normalized = (ticker or "").strip().upper()
     if not normalized:
         return ticker
+
+    # Imported here, not at module level: alpaca_utils pulls in the agents
+    # package, which imports dataflows.interface, which imports this module —
+    # a top-level import breaks whenever dataflows is imported before agents.
+    from .alpaca_utils import AlpacaUtils
 
     company_name = AlpacaUtils.get_company_name(normalized)
     if company_name and company_name.strip().upper() != normalized:

--- a/webui/callbacks/__init__.py
+++ b/webui/callbacks/__init__.py
@@ -10,6 +10,7 @@ from .control_callbacks import register_control_callbacks
 from .trading_callbacks import register_trading_callbacks
 from .storage_callbacks import register_storage_callbacks
 from .api_config_callbacks import register_api_config_callbacks
+from .backtest_callbacks import register_backtest_callbacks
 
 def register_all_callbacks(app):
     """Register all callback functions with the Dash app"""
@@ -19,4 +20,5 @@ def register_all_callbacks(app):
     register_control_callbacks(app)
     register_trading_callbacks(app)
     register_storage_callbacks(app)
-    register_api_config_callbacks(app) 
+    register_api_config_callbacks(app)
+    register_backtest_callbacks(app)

--- a/webui/callbacks/backtest_callbacks.py
+++ b/webui/callbacks/backtest_callbacks.py
@@ -1,0 +1,215 @@
+"""
+Backtest callbacks for TradingAgents WebUI
+Runs the walk-forward backtest over recorded agent decisions and renders
+metrics, the equity curve, and per-window robustness results.
+"""
+
+import dash_bootstrap_components as dbc
+import plotly.graph_objects as go
+from dash import Input, Output, State, html
+
+from webui.config.constants import COLORS
+
+
+def _fmt_pct(value):
+    return "—" if value is None else f"{value:+.2%}"
+
+
+def _fmt_ratio(value):
+    return "—" if value is None else f"{value:.2f}"
+
+
+def _metric_color(value, invert=False):
+    if value is None:
+        return COLORS["pending"]
+    good = value < 0 if invert else value > 0
+    return COLORS["completed"] if good else COLORS["error"]
+
+
+def _metric_card(label, text, color):
+    return dbc.Col(
+        dbc.Card(
+            dbc.CardBody(
+                [
+                    html.Div(label, className="text-muted small"),
+                    html.Div(text, style={"color": color, "fontSize": "1.3rem", "fontWeight": 600}),
+                ],
+                className="p-2 text-center",
+            ),
+            style={"backgroundColor": COLORS["card"], "border": f"1px solid {COLORS['border']}"},
+        ),
+        md=2,
+        xs=6,
+        className="mb-2",
+    )
+
+
+def _build_metric_cards(metrics, signals_used):
+    sharpe = metrics.get("sharpe_ratio")
+    return dbc.Row(
+        [
+            _metric_card(
+                "Cumulative Return",
+                _fmt_pct(metrics.get("cumulative_return")),
+                _metric_color(metrics.get("cumulative_return")),
+            ),
+            _metric_card(
+                "Annualized Return",
+                _fmt_pct(metrics.get("annualized_return")),
+                _metric_color(metrics.get("annualized_return")),
+            ),
+            _metric_card("Sharpe Ratio", _fmt_ratio(sharpe), _metric_color(sharpe)),
+            _metric_card(
+                "Max Drawdown",
+                "—" if metrics.get("max_drawdown") is None else f"-{metrics['max_drawdown']:.2%}",
+                _metric_color(metrics.get("max_drawdown"), invert=True)
+                if metrics.get("max_drawdown")
+                else COLORS["pending"],
+            ),
+            _metric_card(
+                "Win Rate",
+                "—" if metrics.get("win_rate") is None else f"{metrics['win_rate']:.0%}",
+                COLORS["primary"],
+            ),
+            _metric_card(
+                "Trades / Signals",
+                f"{metrics.get('num_trades', 0)} / {signals_used}",
+                COLORS["text"],
+            ),
+        ],
+        className="g-2",
+    )
+
+
+def _build_equity_figure(equity_curve, symbol):
+    figure = go.Figure()
+    figure.add_trace(
+        go.Scatter(
+            x=list(equity_curve.index),
+            y=list(equity_curve.values),
+            mode="lines",
+            name="Equity",
+            line={"color": COLORS["primary"], "width": 2},
+            fill="tozeroy",
+            fillcolor="rgba(59, 130, 246, 0.08)",
+        )
+    )
+    figure.update_layout(
+        title=f"Equity Curve — {symbol}",
+        template="plotly_dark",
+        paper_bgcolor=COLORS["card"],
+        plot_bgcolor=COLORS["card"],
+        margin={"l": 40, "r": 20, "t": 40, "b": 30},
+        yaxis={"title": "Portfolio value ($)", "tickformat": ",.0f"},
+        showlegend=False,
+    )
+    return figure
+
+
+def _build_windows_table(windows):
+    if len(windows) < 2:
+        return None
+    header = html.Thead(
+        html.Tr(
+            [
+                html.Th("Window"),
+                html.Th("Bars"),
+                html.Th("Return"),
+                html.Th("Sharpe"),
+                html.Th("Max DD"),
+                html.Th("Win Rate"),
+            ]
+        )
+    )
+    rows = []
+    for window in windows:
+        metrics = window["metrics"]
+        cum = metrics.get("cumulative_return")
+        rows.append(
+            html.Tr(
+                [
+                    html.Td(f"{window['start_date']} → {window['end_date']}"),
+                    html.Td(window["bars"]),
+                    html.Td(
+                        _fmt_pct(cum),
+                        style={"color": _metric_color(cum)},
+                    ),
+                    html.Td(_fmt_ratio(metrics.get("sharpe_ratio"))),
+                    html.Td(
+                        "—" if metrics.get("max_drawdown") is None else f"-{metrics['max_drawdown']:.2%}"
+                    ),
+                    html.Td(
+                        "—" if metrics.get("win_rate") is None else f"{metrics['win_rate']:.0%}"
+                    ),
+                ]
+            )
+        )
+    return html.Div(
+        [
+            html.H6("Out-of-sample windows", className="mt-2"),
+            dbc.Table([header, html.Tbody(rows)], bordered=False, hover=True, size="sm", striped=True),
+        ]
+    )
+
+
+def register_backtest_callbacks(app):
+    """Register backtest callbacks with the Dash app"""
+
+    @app.callback(
+        [
+            Output("backtest-status", "children"),
+            Output("backtest-metrics", "children"),
+            Output("backtest-equity-graph", "figure"),
+            Output("backtest-graph-container", "style"),
+            Output("backtest-windows-table", "children"),
+        ],
+        Input("backtest-run-btn", "n_clicks"),
+        [
+            State("backtest-symbol-input", "value"),
+            State("backtest-start-date", "value"),
+            State("backtest-end-date", "value"),
+            State("backtest-window-bars", "value"),
+            State("backtest-allow-shorts", "value"),
+        ],
+        prevent_initial_call=True,
+    )
+    def run_backtest_callback(n_clicks, symbol, start_date, end_date, window_bars, allow_shorts):
+        hidden = {"display": "none"}
+        empty = go.Figure()
+
+        symbol = (symbol or "").strip().upper()
+        if not symbol:
+            alert = dbc.Alert("Enter a symbol to backtest.", color="warning", className="mb-0")
+            return alert, None, empty, hidden, None
+
+        try:
+            from tradingagents.backtest import run_recorded_walk_forward
+
+            result = run_recorded_walk_forward(
+                symbol,
+                start_date=start_date or None,
+                end_date=end_date or None,
+                window_bars=int(window_bars or 63),
+                allow_shorts=bool(allow_shorts),
+            )
+        except ValueError as e:
+            alert = dbc.Alert(str(e), color="warning", className="mb-0")
+            return alert, None, empty, hidden, None
+        except Exception as e:
+            alert = dbc.Alert(f"Backtest failed: {e}", color="danger", className="mb-0")
+            return alert, None, empty, hidden, None
+
+        full = result.full_period
+        status_bits = [
+            f"{full.start_date} → {full.end_date}",
+            f"{full.signals_used} recorded signal(s)",
+            "execution: next-bar open",
+        ]
+        if full.rejected_orders:
+            status_bits.append(f"{len(full.rejected_orders)} order(s) rejected on gaps")
+        status = html.Div(" · ".join(status_bits), className="text-muted small")
+
+        metrics_cards = _build_metric_cards(full.metrics, full.signals_used)
+        figure = _build_equity_figure(full.equity_curve, symbol)
+        windows_table = _build_windows_table(result.windows)
+        return status, metrics_cards, figure, {"display": "block"}, windows_table

--- a/webui/callbacks/backtest_callbacks.py
+++ b/webui/callbacks/backtest_callbacks.py
@@ -170,10 +170,11 @@ def register_backtest_callbacks(app):
             State("backtest-end-date", "value"),
             State("backtest-window-bars", "value"),
             State("backtest-allow-shorts", "value"),
+            State("backtest-slippage-model", "value"),
         ],
         prevent_initial_call=True,
     )
-    def run_backtest_callback(n_clicks, symbol, start_date, end_date, window_bars, allow_shorts):
+    def run_backtest_callback(n_clicks, symbol, start_date, end_date, window_bars, allow_shorts, slippage_model):
         hidden = {"display": "none"}
         empty = go.Figure()
 
@@ -191,6 +192,7 @@ def register_backtest_callbacks(app):
                 end_date=end_date or None,
                 window_bars=int(window_bars or 63),
                 allow_shorts=bool(allow_shorts),
+                slippage_model=slippage_model or "fixed",
             )
         except ValueError as e:
             alert = dbc.Alert(str(e), color="warning", className="mb-0")
@@ -200,10 +202,17 @@ def register_backtest_callbacks(app):
             return alert, None, empty, hidden, None
 
         full = result.full_period
+        slippage = full.slippage or {}
+        slippage_text = {
+            "fixed": f"slippage: {slippage.get('bps', 0):g} bps",
+            "volatility": "slippage: volatility-scaled",
+            "none": "slippage: none",
+        }.get(slippage.get("model"), "slippage: n/a")
         status_bits = [
             f"{full.start_date} → {full.end_date}",
             f"{full.signals_used} recorded signal(s)",
             "execution: next-bar open",
+            slippage_text,
         ]
         if full.rejected_orders:
             status_bits.append(f"{len(full.rejected_orders)} order(s) rejected on gaps")

--- a/webui/components/backtest_panel.py
+++ b/webui/components/backtest_panel.py
@@ -25,7 +25,7 @@ def create_backtest_panel():
                         debounce=True,
                     ),
                 ],
-                md=3,
+                md=2,
             ),
             dbc.Col(
                 [
@@ -50,6 +50,21 @@ def create_backtest_panel():
                         value=63,
                         min=2,
                         step=1,
+                    ),
+                ],
+                md=1,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label("Slippage", html_for="backtest-slippage-model", className="small"),
+                    dbc.Select(
+                        id="backtest-slippage-model",
+                        options=[
+                            {"label": "Fixed (5 bps)", "value": "fixed"},
+                            {"label": "Volatility-scaled", "value": "volatility"},
+                            {"label": "None (frictionless)", "value": "none"},
+                        ],
+                        value="fixed",
                     ),
                 ],
                 md=2,

--- a/webui/components/backtest_panel.py
+++ b/webui/components/backtest_panel.py
@@ -1,0 +1,117 @@
+"""
+webui/components/backtest_panel.py - Walk-forward backtest dashboard panel
+
+Replays the decisions already recorded under eval_results/ against
+historical prices (zero LLM cost) and reports the TradingAgents-paper
+metric set: cumulative/annualized return, Sharpe ratio, max drawdown,
+plus win rate, per walk-forward window and for the full period.
+"""
+
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+
+def create_backtest_panel():
+    """Create the backtest panel card for the web UI."""
+    controls = dbc.Row(
+        [
+            dbc.Col(
+                [
+                    dbc.Label("Symbol", html_for="backtest-symbol-input", className="small"),
+                    dbc.Input(
+                        id="backtest-symbol-input",
+                        type="text",
+                        placeholder="e.g. AAPL or BTC/USD",
+                        debounce=True,
+                    ),
+                ],
+                md=3,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label("Start date (optional)", html_for="backtest-start-date", className="small"),
+                    dbc.Input(id="backtest-start-date", type="date"),
+                ],
+                md=2,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label("End date (optional)", html_for="backtest-end-date", className="small"),
+                    dbc.Input(id="backtest-end-date", type="date"),
+                ],
+                md=2,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label("Window (bars)", html_for="backtest-window-bars", className="small"),
+                    dbc.Input(
+                        id="backtest-window-bars",
+                        type="number",
+                        value=63,
+                        min=2,
+                        step=1,
+                    ),
+                ],
+                md=2,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label(" ", className="small d-block"),
+                    dbc.Switch(
+                        id="backtest-allow-shorts",
+                        label="Allow shorts",
+                        value=False,
+                    ),
+                ],
+                md=1,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label(" ", className="small d-block"),
+                    dbc.Button(
+                        [html.I(className="fas fa-flask me-2"), "Run Backtest"],
+                        id="backtest-run-btn",
+                        color="primary",
+                        className="w-100",
+                    ),
+                ],
+                md=2,
+            ),
+        ],
+        className="g-2 align-items-end mb-3",
+    )
+
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.H4("Walk-Forward Backtest", className="mb-1"),
+                html.Div(
+                    "Replays this deployment's recorded agent decisions on historical "
+                    "prices — signals execute at the next bar's open (no lookahead).",
+                    className="text-muted small mb-3",
+                ),
+                controls,
+                dcc.Loading(
+                    id="backtest-loading",
+                    type="default",
+                    children=html.Div(
+                        [
+                            html.Div(id="backtest-status", className="mb-2"),
+                            html.Div(id="backtest-metrics", className="mb-3"),
+                            html.Div(
+                                dcc.Graph(
+                                    id="backtest-equity-graph",
+                                    config={"displayModeBar": False, "responsive": True},
+                                    style={"height": "320px", "width": "100%"},
+                                ),
+                                id="backtest-graph-container",
+                                style={"display": "none"},
+                            ),
+                            html.Div(id="backtest-windows-table"),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+        className="mb-4",
+    )

--- a/webui/layout.py
+++ b/webui/layout.py
@@ -12,6 +12,7 @@ from webui.components.status_panel import create_status_panel
 from webui.components.chart_panel import create_chart_panel
 from webui.components.decision_panel import create_decision_panel
 from webui.components.reports_panel import create_reports_panel
+from webui.components.backtest_panel import create_backtest_panel
 from webui.components.alpaca_account import render_alpaca_account_section
 from webui.components.api_config_modal import create_api_config_modal
 from webui.config.constants import COLORS, REFRESH_INTERVALS
@@ -176,6 +177,7 @@ def create_main_layout():
                 ], md=6)
             ]),
             reports_card,
+            create_backtest_panel(),
             html.Div(className="mt-4"),
             create_footer(),
         ],


### PR DESCRIPTION
# Walk-forward backtesting engine + WebUI dashboard (zero-LLM-cost decision replay)

## Motivation

The framework produces auditable decisions but has no way to answer the question that matters before letting it near real money: **would these decisions have made money?** The TradingAgents paper (arXiv:2412.20138) evaluates on cumulative return, annualized return, Sharpe ratio, and max drawdown — this PR brings that exact metric set into the repo, computed over the decisions the deployment has already made, with walk-forward methodology to avoid the classic single-lucky-backtest trap.

## Design

**Zero LLM cost by default.** Each live prediction costs ~11 LLM calls + 20+ tool calls, which is why the paper's own evaluation window is only ~3 months. So the engine's primary signal source is `eval_results/` — the run logs this repo already persists (`run_logger.py`). `load_recorded_signals()` reads completed runs, normalizes trading-mode outputs onto a common vocabulary (LONG→BUY, SHORT→SELL, NEUTRAL→HOLD), and dedupes multiple runs per day by keeping the newest.

**No lookahead, enforced and tested.** Orders are submitted on the signal bar's close and fill at the **next bar's open** (backtrader default, cheat-on-open off). There's a dedicated regression test where the price gaps 100→200 right after the signal: a leaky engine would capture the jump; this one provably doesn't. Signals dated on non-trading days apply on the next available bar. Orders made unaffordable by overnight gaps are surfaced as explicit rejections rather than silently dropped.

**Walk-forward as robustness, not curve-fitting.** LLM decision replay has no parameters to re-fit between folds, so `run_walk_forward()` uses consecutive non-overlapping out-of-sample windows (63 bars ≈ one quarter by default), each restarting with fresh capital and reporting its own Sharpe/drawdown/return. A strategy that only worked in one regime shows up immediately in the per-window table.

**Pure-math metrics module** (`backtest/metrics.py`): every number shown in the UI is reproducible in a unit test — no broker, network, or LLM in the call path. Degenerate inputs (flat equity, too-short curves, zero trades) return `None` rather than a fabricated statistic. Crypto symbols annualize on 365 days, stocks on 252.

## WebUI

New **Walk-Forward Backtest** panel: symbol + optional date range + window size + allow-shorts, rendering metric cards (color-coded), an equity-curve chart, and the per-window robustness table. Errors (no recorded runs, no price data) surface as alerts. Prices come through the existing `AlpacaUtils.get_stock_data` path, including its yfinance fallback.

The panel replays *this deployment's* actual recorded decisions — it doubles as a self-evaluation dashboard for anyone running the agent in loop mode.

## Bug fixes found while integrating

- **Circular import:** `import tradingagents.dataflows` before `tradingagents.agents` raised `ImportError` (alpaca_utils → agents.schemas → agent_utils → dataflows.interface → re-entry). Both offending imports are now function-scoped; both import orders are verified.
- **Fallback never fired on nginx 401s:** Alpaca auth failures can arrive as a raw HTML page saying "401 Authorization Required" — phrasing the yfinance-fallback matcher didn't recognize, so the fallback failed to engage on exactly the failure it exists for. Fixed + regression test.

## Tests

```
94 passed, 143 subtests passed
```

40+ new cases: hand-computed metric expectations, alias normalization, run-log loading/dedup/corruption-tolerance, lookahead prevention, gap-rejection reporting, shorts on/off, commission effects, walk-forward partitioning (including short-remainder folding), JSON serializability, and the recorded-signals end-to-end path with injected run logs and prices. Also verified live against real recorded AAPL runs + real price data: recorded BUY on 2026-01-02 fills at the 2026-01-05 open, metrics and 6 quarterly-ish windows render in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
