### PR TITLE
feat: self-learning memory - persistent agent memories fed by realized trade outcomes

### DIFF
--- a/tests/test_self_learning_memory.py
+++ b/tests/test_self_learning_memory.py
@@ -1,0 +1,249 @@
+"""Tests for the self-learning memory loop: persistence, snapshot recovery,
+and outcome-driven reflection into the per-agent ChromaDB memories."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from tradingagents.agents.utils.memory import FinancialSituationMemory
+from tradingagents.graph.reflection import Reflector
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.run_logger import load_final_state_snapshot
+
+
+def _fake_embedding(text):
+    # Deterministic 8-dim embedding so similar texts produce similar vectors.
+    seed = float(sum(ord(c) for c in text) % 97)
+    return [seed / 97.0 + i * 0.01 for i in range(8)]
+
+
+def _enable_fake_embeddings(memory):
+    memory.embeddings_enabled = True
+    memory.get_embedding = _fake_embedding
+
+
+class MemoryPersistenceTests(unittest.TestCase):
+    def test_default_memory_stays_in_process(self):
+        memory = FinancialSituationMemory("ephemeral_test_memory")
+        self.assertEqual(type(memory.chroma_client).__name__, "Client")
+
+    def test_persistent_memory_survives_reopen(self):
+        # ignore_cleanup_errors: chromadb keeps its store files open on
+        # Windows, so temp-dir removal can race the process handle.
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            config = {"agent_memory_dir": tmp}
+
+            first = FinancialSituationMemory("persist_test_memory", config)
+            _enable_fake_embeddings(first)
+            first.add_situations(
+                [("High inflation with rising rates", "Prefer defensive sectors")]
+            )
+            self.assertEqual(first.situation_collection.count(), 1)
+
+            second = FinancialSituationMemory("persist_test_memory", config)
+            _enable_fake_embeddings(second)
+            self.assertEqual(second.situation_collection.count(), 1)
+
+            matches = second.get_memories("High inflation with rising rates", n_matches=1)
+            self.assertEqual(len(matches), 1)
+            self.assertEqual(matches[0]["recommendation"], "Prefer defensive sectors")
+
+    def test_ids_do_not_collide_across_instances(self):
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            config = {"agent_memory_dir": tmp}
+            for i in range(3):
+                memory = FinancialSituationMemory("collision_test_memory", config)
+                _enable_fake_embeddings(memory)
+                memory.add_situations([(f"situation {i}", f"advice {i}")])
+            final = FinancialSituationMemory("collision_test_memory", config)
+            self.assertEqual(final.situation_collection.count(), 3)
+
+    def test_empty_agent_memory_dir_means_ephemeral(self):
+        memory = FinancialSituationMemory("cfg_test_memory", {"agent_memory_dir": ""})
+        self.assertEqual(type(memory.chroma_client).__name__, "Client")
+
+
+def _write_run(root, symbol, trade_date, status="completed", final_state=None, started_at=None):
+    runs_dir = Path(root) / symbol / "TradingAgentsStrategy_logs" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    started = started_at or f"{trade_date}T10:00:00+00:00"
+    payload = {
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "started_at": started,
+        "status": status,
+        "snapshots": {"final_state": final_state} if final_state is not None else {},
+    }
+    name = f"{trade_date}_{started.replace(':', '').replace('+', '')}.json"
+    (runs_dir / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+class LoadFinalStateSnapshotTests(unittest.TestCase):
+    def test_returns_latest_completed_snapshot_for_date(self):
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(
+                root, "AAPL", "2026-01-05",
+                final_state={"market_report": "old"},
+                started_at="2026-01-05T09:00:00+00:00",
+            )
+            _write_run(
+                root, "AAPL", "2026-01-05",
+                final_state={"market_report": "new"},
+                started_at="2026-01-05T15:00:00+00:00",
+            )
+            snapshot = load_final_state_snapshot("AAPL", "2026-01-05", eval_results_dir=root)
+        self.assertEqual(snapshot, {"market_report": "new"})
+
+    def test_ignores_failed_runs_other_dates_and_missing_snapshots(self):
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(root, "AAPL", "2026-01-05", status="failed",
+                       final_state={"market_report": "failed"})
+            _write_run(root, "AAPL", "2026-01-06", final_state={"market_report": "other day"})
+            _write_run(root, "AAPL", "2026-01-05", final_state=None)
+            self.assertIsNone(
+                load_final_state_snapshot("AAPL", "2026-01-05", eval_results_dir=root)
+            )
+
+    def test_missing_directory_returns_none(self):
+        self.assertIsNone(
+            load_final_state_snapshot("ZZZZ", "2026-01-05", eval_results_dir="no_such_dir")
+        )
+
+    def test_crypto_symbol_is_sanitized(self):
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(root, "BTC_USD", "2026-01-05", final_state={"market_report": "btc"})
+            snapshot = load_final_state_snapshot("BTC/USD", "2026-01-05", eval_results_dir=root)
+        self.assertEqual(snapshot, {"market_report": "btc"})
+
+
+def _full_state():
+    return {
+        "market_report": "market",
+        "sentiment_report": "sentiment",
+        "news_report": "news",
+        "fundamentals_report": "fundamentals",
+        "investment_debate_state": {
+            "bull_history": "bull said",
+            "bear_history": "bear said",
+            "judge_decision": "judge decided",
+        },
+        "trader_investment_plan": "trader plan",
+        "risk_debate_state": {"judge_decision": "risk decision"},
+    }
+
+
+class ReflectOnOutcomeTests(unittest.TestCase):
+    def _reflector(self):
+        llm = Mock()
+        llm.invoke.return_value = Mock(content="lesson learned")
+        return Reflector(llm)
+
+    def test_all_components_reflect_and_store(self):
+        reflector = self._reflector()
+        memories = {
+            name: Mock()
+            for name in ("bull", "bear", "trader", "invest_judge", "risk_manager")
+        }
+        results = reflector.reflect_on_outcome(_full_state(), "+5.0% realized", memories)
+
+        self.assertEqual(set(results), set(memories))
+        self.assertTrue(all(results.values()))
+        for memory in memories.values():
+            memory.add_situations.assert_called_once()
+            (pairs,), _ = memory.add_situations.call_args
+            situation, lesson = pairs[0]
+            self.assertIn("market", situation)
+            self.assertEqual(lesson, "lesson learned")
+
+    def test_one_failure_does_not_block_other_components(self):
+        reflector = self._reflector()
+        memories = {
+            "bull": Mock(add_situations=Mock(side_effect=RuntimeError("chroma down"))),
+            "trader": Mock(),
+        }
+        results = reflector.reflect_on_outcome(_full_state(), "-2.0% realized", memories)
+        self.assertFalse(results["bull"])
+        self.assertTrue(results["trader"])
+        memories["trader"].add_situations.assert_called_once()
+
+    def test_missing_memories_are_skipped(self):
+        reflector = self._reflector()
+        results = reflector.reflect_on_outcome(_full_state(), "+1.0%", {"bull": Mock()})
+        self.assertEqual(set(results), {"bull"})
+
+
+class OutcomeReflectionWiringTests(unittest.TestCase):
+    """Exercise TradingAgentsGraph._reflect_agents_on_outcome via a stub self."""
+
+    def _fake_graph(self, enabled=True):
+        fake = Mock(spec=TradingAgentsGraph)
+        fake.config = {"reflection_on_outcome_enabled": enabled}
+        fake.reflector = Mock()
+        for name in (
+            "bull_memory",
+            "bear_memory",
+            "trader_memory",
+            "invest_judge_memory",
+            "risk_manager_memory",
+        ):
+            setattr(fake, name, Mock())
+        return fake
+
+    def test_resolved_outcome_triggers_reflection_with_recovered_state(self):
+        fake = self._fake_graph()
+        state = _full_state()
+        with patch(
+            "tradingagents.run_logger.load_final_state_snapshot", return_value=state
+        ):
+            TradingAgentsGraph._reflect_agents_on_outcome(
+                fake, "AAPL", "2026-01-05", 0.05, 0.02, 5
+            )
+        fake.reflector.reflect_on_outcome.assert_called_once()
+        args, _ = fake.reflector.reflect_on_outcome.call_args
+        passed_state, returns_losses, memories = args
+        self.assertIs(passed_state, state)
+        self.assertIn("+5.0%", returns_losses)
+        self.assertIn("+2.0%", returns_losses)
+        self.assertEqual(
+            set(memories),
+            {"bull", "bear", "trader", "invest_judge", "risk_manager"},
+        )
+
+    def test_disabled_flag_skips_reflection(self):
+        fake = self._fake_graph(enabled=False)
+        with patch(
+            "tradingagents.run_logger.load_final_state_snapshot"
+        ) as loader:
+            TradingAgentsGraph._reflect_agents_on_outcome(
+                fake, "AAPL", "2026-01-05", 0.05, None, 5
+            )
+        loader.assert_not_called()
+        fake.reflector.reflect_on_outcome.assert_not_called()
+
+    def test_missing_snapshot_skips_reflection(self):
+        fake = self._fake_graph()
+        with patch(
+            "tradingagents.run_logger.load_final_state_snapshot", return_value=None
+        ):
+            TradingAgentsGraph._reflect_agents_on_outcome(
+                fake, "AAPL", "2026-01-05", 0.05, None, 5
+            )
+        fake.reflector.reflect_on_outcome.assert_not_called()
+
+    def test_reflection_errors_never_propagate(self):
+        fake = self._fake_graph()
+        fake.reflector.reflect_on_outcome.side_effect = RuntimeError("llm down")
+        with patch(
+            "tradingagents.run_logger.load_final_state_snapshot",
+            return_value=_full_state(),
+        ):
+            # Must not raise: outcome reflection is strictly best-effort.
+            TradingAgentsGraph._reflect_agents_on_outcome(
+                fake, "AAPL", "2026-01-05", 0.05, None, 5
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trading_graph_mocked.py
+++ b/tests/test_trading_graph_mocked.py
@@ -67,7 +67,9 @@ def _final_state(ticker, trade_date):
 
 class MockedTradingGraphTests(unittest.TestCase):
     def test_propagate_preserves_macro_and_safe_paths_with_checkpoint(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        # ignore_cleanup_errors: chromadb holds its store files open on
+        # Windows, so temp-dir removal can race the process handle.
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             tmp_path = Path(tmp)
             for ticker, safe_ticker in (("AAPL", "AAPL"), ("BTC/USD", "BTC_USD")):
                 with self.subTest(ticker=ticker):
@@ -81,6 +83,7 @@ class MockedTradingGraphTests(unittest.TestCase):
                             "data_cache_dir": str(tmp_path / f"cache-{safe_ticker}"),
                             "results_dir": str(tmp_path / "results"),
                             "memory_log_path": str(tmp_path / f"memory-{safe_ticker}.md"),
+                            "agent_memory_dir": str(tmp_path / f"agent-memory-{safe_ticker}"),
                             "checkpoint_enabled": True,
                         }
                     )
@@ -113,7 +116,9 @@ class MockedTradingGraphTests(unittest.TestCase):
         ]
 
         for provider, provider_config, expected_key, expected_value in cases:
-            with self.subTest(provider=provider), tempfile.TemporaryDirectory() as tmp:
+            with self.subTest(provider=provider), tempfile.TemporaryDirectory(
+                ignore_cleanup_errors=True
+            ) as tmp:
                 calls = []
 
                 def fake_create_llm_client(**kwargs):
@@ -129,6 +134,7 @@ class MockedTradingGraphTests(unittest.TestCase):
                         "data_cache_dir": str(Path(tmp) / "cache"),
                         "results_dir": str(Path(tmp) / "results"),
                         "memory_log_path": str(Path(tmp) / "memory.md"),
+                        "agent_memory_dir": str(Path(tmp) / "agent-memory"),
                         **provider_config,
                     }
                 )

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -4,18 +4,29 @@ from openai import OpenAI
 import numpy as np
 from pathlib import Path
 import re
+import uuid
 from tradingagents.dataflows.config import get_openai_client_config, get_openai_embedding_model
 from tradingagents.agents.utils.agent_trading_modes import extract_recommendation
 
 
 class FinancialSituationMemory:
-    def __init__(self, name):
+    def __init__(self, name, config: dict = None):
         client_config = get_openai_client_config()
         self.client = OpenAI(**client_config) if client_config else None
         self.embedding_model = get_openai_embedding_model()
         self.embeddings_enabled = self.client is not None
         self._warned_embedding_failure = False
-        self.chroma_client = chromadb.Client(Settings(allow_reset=True))
+        persist_dir = (config or {}).get("agent_memory_dir") or ""
+        if persist_dir:
+            # Persistent store: lessons written after outcome resolution
+            # survive process restarts, which is what makes the reflection
+            # loop cumulative instead of session-scoped.
+            Path(persist_dir).mkdir(parents=True, exist_ok=True)
+            self.chroma_client = chromadb.PersistentClient(
+                path=str(persist_dir), settings=Settings(allow_reset=True)
+            )
+        else:
+            self.chroma_client = chromadb.Client(Settings(allow_reset=True))
         self.situation_collection = self.chroma_client.get_or_create_collection(name=name)
 
     def get_embedding(self, text):
@@ -58,15 +69,15 @@ class FinancialSituationMemory:
         ids = []
         embeddings = []
 
-        offset = self.situation_collection.count()
-
-        for i, (situation, recommendation) in enumerate(situations_and_advice):
+        for situation, recommendation in situations_and_advice:
             embedding = self.get_embedding(situation)
             if embedding is None:
                 continue
             situations.append(situation)
             advice.append(recommendation)
-            ids.append(str(offset + i))
+            # Random ids: count-based ids collide across processes once the
+            # collection is persistent (two sessions can see the same count).
+            ids.append(uuid.uuid4().hex)
             embeddings.append(embedding)
 
         if not embeddings:

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -10,6 +10,15 @@ DEFAULT_CONFIG = {
         os.path.join(_TRADINGAGENTS_HOME, "memory", "trading_memory.md"),
     ),
     "memory_log_max_entries": None,
+    # Self-learning memory: when set, the per-agent ChromaDB reflection
+    # memories persist across restarts instead of resetting each session.
+    "agent_memory_dir": os.getenv(
+        "TRADINGAGENTS_AGENT_MEMORY_DIR",
+        os.path.join(_TRADINGAGENTS_HOME, "memory", "agent_memory"),
+    ),
+    # Feed realized outcomes back into the per-agent memories (5 quick-LLM
+    # reflection calls per resolved decision). Requires OpenAI embeddings.
+    "reflection_on_outcome_enabled": True,
     "checkpoint_enabled": False,
     # "data_dir": "/Users/yluo/Documents/Code/ScAI/FR1-data",
     "data_dir": "data/ScAI/FR1-data",

--- a/tradingagents/graph/reflection.py
+++ b/tradingagents/graph/reflection.py
@@ -96,6 +96,39 @@ class Reflector:
         )
         risk_manager_memory.add_situations([(situation, result)])
 
+    def reflect_on_outcome(
+        self,
+        state: Dict[str, Any],
+        returns_losses: str,
+        memories: Dict[str, Any],
+    ) -> Dict[str, bool]:
+        """Run every per-agent reflection against a realized outcome.
+
+        `state` is a final_state dict (live or recovered from a run log) and
+        `memories` maps component name -> FinancialSituationMemory. Each
+        component is isolated: one failure (missing key, LLM error) must not
+        block the remaining lessons from being written.
+        """
+        reflectors = {
+            "bull": self.reflect_bull_researcher,
+            "bear": self.reflect_bear_researcher,
+            "trader": self.reflect_trader,
+            "invest_judge": self.reflect_invest_judge,
+            "risk_manager": self.reflect_risk_manager,
+        }
+        results: Dict[str, bool] = {}
+        for name, reflect in reflectors.items():
+            memory = memories.get(name)
+            if memory is None:
+                continue
+            try:
+                reflect(state, returns_losses, memory)
+                results[name] = True
+            except Exception as exc:
+                print(f"[REFLECTION] Skipped {name} reflection: {exc}")
+                results[name] = False
+        return results
+
     def reflect_on_final_decision(
         self,
         final_decision: str,

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -135,12 +135,12 @@ class TradingAgentsGraph:
         
         self.toolkit = Toolkit(config=self.config)
 
-        # Initialize memories
-        self.bull_memory = FinancialSituationMemory("bull_memory")
-        self.bear_memory = FinancialSituationMemory("bear_memory")
-        self.trader_memory = FinancialSituationMemory("trader_memory")
-        self.invest_judge_memory = FinancialSituationMemory("invest_judge_memory")
-        self.risk_manager_memory = FinancialSituationMemory("risk_manager_memory")
+        # Initialize memories (persistent when agent_memory_dir is configured)
+        self.bull_memory = FinancialSituationMemory("bull_memory", self.config)
+        self.bear_memory = FinancialSituationMemory("bear_memory", self.config)
+        self.trader_memory = FinancialSituationMemory("trader_memory", self.config)
+        self.invest_judge_memory = FinancialSituationMemory("invest_judge_memory", self.config)
+        self.risk_manager_memory = FinancialSituationMemory("risk_manager_memory", self.config)
         self.memory_log = TradingMemoryLog(self.config)
 
         # Create tool nodes
@@ -301,6 +301,55 @@ class TradingAgentsGraph:
                 holding_days=holding_days,
                 reflection=reflection,
             )
+            self._reflect_agents_on_outcome(
+                ticker, entry_date_text, raw_return, alpha_return, holding_days
+            )
+
+    def _reflect_agents_on_outcome(
+        self,
+        ticker: str,
+        trade_date: str,
+        raw_return: float,
+        alpha_return: Optional[float],
+        holding_days: int,
+    ) -> None:
+        """Feed a realized outcome back into the per-agent ChromaDB memories.
+
+        Recovers the original run's final_state from the persisted run log,
+        so each agent reflects on the exact situation it saw when the
+        decision was made — not on today's state. Best-effort by design:
+        reflection failures must never affect the current analysis run.
+        """
+        if not self.config.get("reflection_on_outcome_enabled", True):
+            return
+        try:
+            from tradingagents.run_logger import load_final_state_snapshot
+
+            state = load_final_state_snapshot(ticker, trade_date)
+            if not state:
+                return
+            alpha_text = (
+                f"{alpha_return:+.1%} vs benchmark"
+                if alpha_return is not None
+                else "n/a"
+            )
+            returns_losses = (
+                f"Realized return over {holding_days} trading days: "
+                f"{raw_return:+.1%} (alpha: {alpha_text})."
+            )
+            self.reflector.reflect_on_outcome(
+                state,
+                returns_losses,
+                {
+                    "bull": self.bull_memory,
+                    "bear": self.bear_memory,
+                    "trader": self.trader_memory,
+                    "invest_judge": self.invest_judge_memory,
+                    "risk_manager": self.risk_manager_memory,
+                },
+            )
+        except Exception as exc:
+            print(f"[REFLECTION] Outcome reflection skipped for {ticker} {trade_date}: {exc}")
 
     def _create_tool_nodes(self) -> Dict[str, ToolNode]:
         """Create tool nodes for different data sources."""

--- a/tradingagents/run_logger.py
+++ b/tradingagents/run_logger.py
@@ -389,6 +389,49 @@ class RunAuditLogger:
             json.dump(run_data, f, indent=2, ensure_ascii=False)
 
 
+def load_final_state_snapshot(
+    symbol: str,
+    trade_date: str,
+    eval_results_dir: str = "eval_results",
+) -> Optional[Dict[str, Any]]:
+    """Return the final_state snapshot of the newest completed run for a date.
+
+    Lets outcome-time consumers (reflection, evaluation) recover the exact
+    market situation a past decision was made in, without keeping every run
+    in process memory. Returns None when no matching completed run exists.
+    """
+    runs_dir = (
+        Path(eval_results_dir)
+        / _sanitize_for_path(symbol or "unknown")
+        / "TradingAgentsStrategy_logs"
+        / "runs"
+    )
+    if not runs_dir.is_dir():
+        return None
+
+    best_payload = None
+    best_started_at = ""
+    for path in runs_dir.glob("*.json"):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except Exception:
+            continue
+        if payload.get("status") != "completed":
+            continue
+        if str(payload.get("trade_date")) != str(trade_date):
+            continue
+        final_state = (payload.get("snapshots") or {}).get("final_state")
+        if not isinstance(final_state, dict):
+            continue
+        started_at = str(payload.get("started_at") or "")
+        if started_at >= best_started_at:
+            best_started_at = started_at
+            best_payload = final_state
+
+    return best_payload
+
+
 _RUN_AUDIT_LOGGER = RunAuditLogger()
 
 


### PR DESCRIPTION
# Self-learning memory: persistent agent memories fed by realized trade outcomes

## The gap

The framework carries five per-agent ChromaDB reflection memories (bull, bear, trader, invest judge, risk manager) and a full `Reflector` with per-component reflection prompts — but **the learning loop was never closed**:

1. `reflect_and_remember()` is not called from anywhere in the codebase, so the memories never received a single lesson.
2. The collections were ephemeral in-process ChromaDB clients, so even a manually written lesson vanished on restart.
3. Net effect: every analysis run queried memories that were always empty, and `past_memory_str` never contained anything.

Meanwhile the markdown `TradingMemoryLog` already resolves pending decisions against realized returns (raw + alpha vs SPY/BTC benchmark) a few days after each decision — the outcome data existed; it just never reached the agents' vector memories.

## What this PR does

Closes the loop FinMem-style (arXiv:2311.13743 — layered memory + reflection is the paper's core mechanism for improving LLM trading decisions over time):

**Persistence.** `FinancialSituationMemory` now accepts the config dict; with `agent_memory_dir` set (default `~/.tradingagents/memory/agent_memory`, same convention as the existing `memory_log_path`) it uses `chromadb.PersistentClient`, so lessons accumulate across sessions. Setting it empty restores the old ephemeral behavior. Entry ids switched from `count()`-offset to `uuid4` — count-based ids collide across processes once the collection persists.

**Situation recovery.** New `run_logger.load_final_state_snapshot(symbol, trade_date)` pulls the original run's `final_state` from the audit logs this repo already writes. Reflection therefore sees **the exact market reports and debate history the agents saw when they decided** — not today's state, which would poison the lesson.

**Outcome-time reflection.** When `_resolve_memory_log_outcomes()` resolves a pending decision with a realized return, the new `Reflector.reflect_on_outcome()` runs all five per-agent reflections against that outcome and writes each lesson into the corresponding persistent memory. Each component is isolated (one failure can't block the others), and the whole step is best-effort — reflection can never break or delay the current analysis run.

**Config.** `reflection_on_outcome_enabled` (default True; costs 5 quick-thinker calls per resolved decision, and degrades silently to a no-op when embeddings are unavailable — same graceful path the memory class already had) and `agent_memory_dir`.

## Why it matters

Retrieval was already wired: bull/bear/trader/judge prompts all query `get_memories()` with the current situation. This PR makes those queries return actual lessons tied to realized P&L, so the debate is grounded in what previously worked or failed in similar situations — the exact mechanism FinMem showed improves trading performance, and it compounds the longer the agent runs.

## Tests

```
68 passed, 133 subtests passed
```

New `tests/test_self_learning_memory.py`: persistence across reopen, id-collision safety across instances, snapshot recovery (latest completed run wins; failed runs, other dates, and missing snapshots ignored; crypto symbol path sanitization), per-component failure isolation, and the resolution-time wiring (enabled/disabled flag, missing snapshot, reflection errors never propagate). Existing mocked-graph tests updated to keep their ChromaDB stores inside the test temp dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
