### PR TITLE
fix: stop hitting the Alpaca API at import time (lazy webui app construction)

### DIFF
--- a/tests/test_import_no_network.py
+++ b/tests/test_import_no_network.py
@@ -1,0 +1,105 @@
+"""Importing tradingagents packages must never open a network connection.
+
+Module-level code that calls out to Alpaca (or any other remote API) makes the
+package unusable offline, slows every import, and leaks "unauthorized" errors
+into unrelated tooling (tests, CLI help, docs builds).  These tests run each
+import in a fresh subprocess with ``socket.socket.connect`` instrumented, and
+fail if any connection is attempted.
+"""
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+_PROBE_TEMPLATE = textwrap.dedent(
+    """
+    import json
+    import socket
+    import sys
+    import traceback
+
+    attempts = []
+
+    def _spy_connect(self, addr):
+        attempts.append(
+            {{"addr": str(addr), "stack": traceback.format_stack(limit=15)}}
+        )
+        raise OSError("network blocked by test_import_no_network")
+
+    socket.socket.connect = _spy_connect
+
+    error = None
+    try:
+        {imports}
+    except Exception as exc:  # noqa: BLE001 - report any import failure
+        error = f"{{type(exc).__name__}}: {{exc}}"
+
+    print(json.dumps({{"attempts": attempts, "error": error}}))
+    """
+)
+
+
+def _probe_imports(import_lines):
+    """Run the given import statements in a clean subprocess; return report."""
+    code = _PROBE_TEMPLATE.format(
+        imports="\n    ".join(import_lines)
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        timeout=300,
+    )
+    stdout_lines = [line for line in result.stdout.strip().splitlines() if line]
+    assert stdout_lines, (
+        f"probe subprocess produced no report; stderr:\n{result.stderr[-2000:]}"
+    )
+    return json.loads(stdout_lines[-1])
+
+
+def _assert_no_network(report):
+    attempts = report["attempts"]
+    if attempts:
+        first = attempts[0]
+        stack = "".join(first["stack"][-8:])
+        raise AssertionError(
+            f"import attempted {len(attempts)} network connection(s); "
+            f"first to {first['addr']} via:\n{stack}"
+        )
+
+
+def test_importing_agents_package_opens_no_network_connection():
+    report = _probe_imports(["import tradingagents.agents"])
+    assert report["error"] is None, f"import failed: {report['error']}"
+    _assert_no_network(report)
+
+
+def test_importing_dataflows_package_opens_no_network_connection():
+    # NOTE: on some branches importing dataflows first trips a known circular
+    # import; importing agents first is the historically safe order and is
+    # what the analyst modules do in production.
+    report = _probe_imports(
+        ["import tradingagents.agents", "import tradingagents.dataflows"]
+    )
+    assert report["error"] is None, f"import failed: {report['error']}"
+    _assert_no_network(report)
+
+
+def test_importing_prompt_capture_does_not_build_dash_app():
+    """webui.utils.prompt_capture is imported by every analyst module; pulling
+    it in must not construct the Dash app (which renders account tables and
+    calls Alpaca)."""
+    report = _probe_imports(
+        [
+            "import webui.utils.prompt_capture",
+            "import sys",
+            "assert 'webui.app_dash' not in sys.modules, 'webui import eagerly builds the Dash app'",
+        ]
+    )
+    assert report["error"] is None, f"import failed: {report['error']}"
+    _assert_no_network(report)

--- a/webui/__init__.py
+++ b/webui/__init__.py
@@ -1,4 +1,15 @@
 """
 Trading Agents Framework - Web UI Package
 """
-from webui.app_dash import run_app
+
+# Import lazily (PEP 562): eagerly importing webui.app_dash builds the whole
+# Dash layout, which hits the Alpaca API.  Core tradingagents modules import
+# webui.utils.* helpers and must not pay that cost (or need network access).
+
+
+def __getattr__(name):
+    if name == "run_app":
+        from webui.app_dash import run_app
+
+        return run_app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/webui/app_dash.py
+++ b/webui/app_dash.py
@@ -132,8 +132,14 @@ def run_app(port=7860, share=False, server_name="127.0.0.1", debug=False, max_th
     return 0
 
 
-# Create the app instance for use by other modules
-app = create_app()
+def __getattr__(name):
+    # Lazy `app` attribute (PEP 562) so WSGI servers can still point at
+    # ``webui.app_dash:app`` while plain imports stay side-effect free:
+    # create_app() renders the account layout, which calls the Alpaca API.
+    if name == "app":
+        return create_app()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 if __name__ == "__main__":
-    run_app(debug=True) 
+    run_app(debug=True)


### PR DESCRIPTION
## Problem

Merely importing core packages fires **three live Alpaca API requests**. Any `tradingagents.agents` module imports `webui.utils.prompt_capture`, which executes `webui/__init__.py` → `from webui.app_dash import run_app` → module-level `app = create_app()` → `create_main_layout()` renders the account section, calling `get_positions_data()`, `get_recent_orders_page()`, and `get_account_info()` at import time.

Consequences:

- Offline machines / CI / expired keys see spurious `{"message": "unauthorized."}` errors on plain imports and test runs.
- Every import of the core package pays the latency of 3 HTTPS round-trips.
- The normal entrypoint built the Dash app **twice** (once at module level, once inside `run_app()`).

## Fix

- **`webui/__init__.py`** — expose `run_app` lazily via PEP 562 module `__getattr__`, so importing `webui.utils.*` no longer drags in the whole Dash app.
- **`webui/app_dash.py`** — replace the module-level `app = create_app()` with a lazy `__getattr__`. WSGI-style deployment (`webui.app_dash:app`) keeps working, but plain imports are now side-effect free (and the double app construction at startup is gone).

## Regression guard

`tests/test_import_no_network.py` runs each import in a fresh subprocess with `socket.socket.connect` instrumented and fails if **any** network connection is attempted while importing `tradingagents.agents`, `tradingagents.dataflows`, or `webui.utils.prompt_capture`. It also asserts `webui.app_dash` never enters `sys.modules` as an import side effect.

## Testing

- New guard tests: red before the fix (3 connection attempts to `paper-api.alpaca.markets`), green after.
- Full suite: **56 passed**.
- Manual smoke: `from webui import run_app` and `webui.app_dash.app` (WSGI path) both still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
