### PR TITLE
fix: no network calls or circular imports at package import time

### DIFF
--- a/tests/test_import_no_network.py
+++ b/tests/test_import_no_network.py
@@ -1,0 +1,57 @@
+"""Importing tradingagents packages must never trigger network calls.
+
+Each case runs in a fresh interpreter so previously imported modules in the
+pytest process cannot mask import-time side effects. Inside the subprocess,
+socket primitives are replaced with guards that record any connection
+attempt before the package is imported.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+GUARD_SCRIPT = """
+import socket
+
+attempts = []
+
+def _blocked(*args, **kwargs):
+    attempts.append(args)
+    raise RuntimeError("network access attempted during import")
+
+socket.socket.connect = _blocked
+socket.create_connection = _blocked
+socket.getaddrinfo = _blocked
+
+import {module}
+
+print("ATTEMPTED_CONNECTIONS:", len(attempts))
+print("IMPORT_OK")
+"""
+
+
+@pytest.mark.parametrize(
+    "module",
+    ["tradingagents.dataflows", "tradingagents.agents", "tradingagents"],
+)
+def test_import_does_not_touch_network(module):
+    result = subprocess.run(
+        [sys.executable, "-c", GUARD_SCRIPT.format(module=module)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, f"import {module} failed:\n{output}"
+    assert "IMPORT_OK" in result.stdout, f"import {module} did not complete:\n{output}"
+    assert "ATTEMPTED_CONNECTIONS: 0" in result.stdout, (
+        f"import {module} attempted network connections:\n{output}"
+    )
+    assert "Error fetching" not in output, (
+        f"import {module} triggered Alpaca API calls:\n{output}"
+    )

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -4,7 +4,7 @@ import os
 import pandas as pd
 import time
 from datetime import datetime, timedelta
-from typing import Annotated, Union, Optional, List, Dict, Any
+from typing import Annotated, Union, Optional, List, Dict, Any, TYPE_CHECKING
 from alpaca.data.historical import StockHistoricalDataClient, CryptoHistoricalDataClient
 from alpaca.data.requests import StockBarsRequest, CryptoBarsRequest, StockLatestQuoteRequest, CryptoLatestQuoteRequest
 from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
@@ -15,7 +15,10 @@ from alpaca.trading.enums import AssetClass, AssetStatus, OrderSide, QueryOrderS
 from alpaca.common.enums import Sort
 from .config import get_api_key, get_alpaca_use_paper, get_config
 from .ticker_utils import TickerUtils
-from tradingagents.agents.schemas import TradeIntent, trade_intent_action
+# Imported lazily inside execute_trade_intent: a module-level import would
+# create a circular import (dataflows -> agents -> dataflows.interface).
+if TYPE_CHECKING:
+    from tradingagents.agents.schemas import TradeIntent
 
 
 # Fallback dictionary for company names
@@ -835,7 +838,7 @@ class AlpacaUtils:
     def execute_trade_intent(
         symbol: str,
         current_position: str,
-        trade_intent: Union[TradeIntent, Dict[str, Any]],
+        trade_intent: Union["TradeIntent", Dict[str, Any]],
         dollar_amount: float,
         allow_shorts: bool = False,
     ) -> dict:
@@ -845,6 +848,8 @@ class AlpacaUtils:
         method intentionally delegates to the existing simple market/close
         execution path until bracket/OCO/OTO order placement is implemented.
         """
+        from tradingagents.agents.schemas import TradeIntent, trade_intent_action
+
         try:
             intent = (
                 trade_intent

--- a/webui/__init__.py
+++ b/webui/__init__.py
@@ -1,4 +1,14 @@
 """
 Trading Agents Framework - Web UI Package
 """
-from webui.app_dash import run_app
+
+
+def __getattr__(name):
+    # Lazy so that importing webui submodules (e.g. webui.utils.prompt_capture
+    # from tradingagents.agents) does not build the Dash app, which fetches
+    # Alpaca account data.
+    if name == "run_app":
+        from webui.app_dash import run_app
+
+        return run_app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/webui/app_dash.py
+++ b/webui/app_dash.py
@@ -132,8 +132,20 @@ def run_app(port=7860, share=False, server_name="127.0.0.1", debug=False, max_th
     return 0
 
 
-# Create the app instance for use by other modules
-app = create_app()
+# The app instance is created lazily: building it eagerly at import time
+# fetches Alpaca account data, so any import of this module (directly or via
+# the webui package) would trigger network calls.
+_app = None
+
+
+def __getattr__(name):
+    global _app
+    if name == "app":
+        if _app is None:
+            _app = create_app()
+        return _app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 if __name__ == "__main__":
     run_app(debug=True) 


### PR DESCRIPTION
## Problem

`import tradingagents.agents` printed:

```
Error fetching positions: {message: unauthorized.}
Error fetching orders: {message: unauthorized.}
Error fetching account info: {message: unauthorized.}
```

Root cause chain: `tradingagents.agents` -> analysts import `webui.utils.prompt_capture` -> `webui/__init__.py` eagerly imports `app_dash` -> module-level `app = create_app()` builds the full Dash layout, which calls `AlpacaUtils.get_positions_data() / get_recent_orders_page() / get_account_info()` — three live Alpaca API calls at import time.

Separately, `import tradingagents.dataflows` on its own failed with `ImportError` (circular import): `alpaca_utils` imports `tradingagents.agents.schemas` at module level, which executes `agents/__init__` -> `agent_utils` -> `dataflows.interface` -> back into the partially initialized `reddit_utils`.

## Fix

- **webui/app_dash.py**: replace module-level `app = create_app()` with a cached module `__getattr__` — `from webui.app_dash import app` (and WSGI-style `webui.app_dash:app`) still works, but the app is only built on first access. `run_app()` already creates its own instance.
- **webui/__init__.py**: expose `run_app` lazily via module `__getattr__`, so importing `webui.*` submodules no longer builds the Dash app.
- **tradingagents/dataflows/alpaca_utils.py**: import `TradeIntent` / `trade_intent_action` inside `execute_trade_intent` (with a `TYPE_CHECKING` import for annotations), breaking the dataflows -> agents cycle.

## Test

`tests/test_import_no_network.py` imports `tradingagents`, `tradingagents.dataflows`, and `tradingagents.agents` each in a fresh interpreter with socket primitives replaced by recording guards, asserting the import succeeds with **zero** connection attempts.

Full suite: `56 passed, 133 subtests passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)