### PR TITLE
feat: submit real bracket/OTO protective orders (stops & targets actually reach the market)

### DIFF
--- a/tests/test_bracket_protective_orders.py
+++ b/tests/test_bracket_protective_orders.py
@@ -1,0 +1,205 @@
+"""Protective stop-loss / take-profit orders must actually reach the broker.
+
+Before this feature, ``execute_trade_intent`` recorded stops and targets as
+advisory metadata only (``protective_order_status: "advisory_only"``) — no
+protective order was ever submitted to Alpaca.  These tests drive the real
+bracket/OTO submission path with a mocked trading client.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tradingagents.agents.schemas import (
+    ExecutableAction,
+    RiskDecision,
+    build_trade_intent_from_risk_decision,
+    extract_protective_price,
+)
+from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+
+def _intent(symbol="AAPL", stop_loss=None, take_profit=None, action=ExecutableAction.BUY,
+            trading_mode="investment", current_position="NEUTRAL", allow_shorts=False):
+    return build_trade_intent_from_risk_decision(
+        symbol=symbol,
+        trading_mode=trading_mode,
+        current_position=current_position,
+        allow_shorts=allow_shorts,
+        trade_date="2026-01-02",
+        decision=RiskDecision(
+            action=action,
+            confidence="medium",
+            risk_rationale="test",
+            required_controls="test controls",
+            stop_loss=stop_loss,
+            take_profit=take_profit,
+        ),
+    )
+
+
+class ExtractProtectivePriceTests(unittest.TestCase):
+    def test_parses_plain_number(self):
+        self.assertEqual(extract_protective_price("182.50"), 182.50)
+
+    def test_parses_dollar_prefixed_number(self):
+        self.assertEqual(extract_protective_price("Stop at $1,234.56 (ATR-based)"), 1234.56)
+
+    def test_takes_first_price_when_multiple(self):
+        self.assertEqual(extract_protective_price("195 then 202"), 195.0)
+
+    def test_returns_none_for_no_number(self):
+        self.assertIsNone(extract_protective_price("trail below support"))
+        self.assertIsNone(extract_protective_price(None))
+
+    def test_ignores_percentages(self):
+        # "8% below entry" is relative guidance, not an absolute price level.
+        self.assertIsNone(extract_protective_price("8% below entry"))
+
+
+class TradeIntentNumericControlsTests(unittest.TestCase):
+    def test_builder_populates_numeric_protective_prices(self):
+        intent = _intent(stop_loss="182.50", take_profit="$195")
+        self.assertEqual(intent.risk_controls.stop_loss_price, 182.50)
+        self.assertEqual(intent.risk_controls.take_profit_price, 195.0)
+
+    def test_builder_leaves_prices_none_for_qualitative_guidance(self):
+        intent = _intent(stop_loss="below support", take_profit=None)
+        self.assertIsNone(intent.risk_controls.stop_loss_price)
+        self.assertIsNone(intent.risk_controls.take_profit_price)
+
+
+class BracketExecutionTests(unittest.TestCase):
+    def setUp(self):
+        self.client = MagicMock()
+        order = MagicMock()
+        order.id = "order-1"
+        order.symbol = "AAPL"
+        order.side = "buy"
+        order.qty = 5
+        order.notional = None
+        order.status = "accepted"
+        order.order_class = "bracket"
+        self.client.submit_order.return_value = order
+
+        self.patches = [
+            patch(
+                "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
+                return_value=self.client,
+            ),
+            patch.object(
+                AlpacaUtils,
+                "get_latest_quote",
+                return_value={"bid_price": 190.0, "ask_price": 190.1},
+            ),
+        ]
+        for p in self.patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in self.patches])
+
+    def _execute(self, intent, symbol="AAPL", current_position="NEUTRAL", allow_shorts=False):
+        return AlpacaUtils.execute_trade_intent(
+            symbol=symbol,
+            current_position=current_position,
+            trade_intent=intent.model_dump(mode="json"),
+            dollar_amount=1000,
+            allow_shorts=allow_shorts,
+        )
+
+    def test_buy_with_stop_and_target_submits_bracket_order(self):
+        result = self._execute(_intent(stop_loss="182.50", take_profit="195"))
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["protective_order_status"], "submitted_bracket")
+        request = self.client.submit_order.call_args[0][0]
+        self.assertEqual(str(request.order_class.value).lower(), "bracket")
+        self.assertEqual(float(request.stop_loss.stop_price), 182.50)
+        self.assertEqual(float(request.take_profit.limit_price), 195.0)
+        self.assertEqual(str(request.time_in_force.value).lower(), "gtc")
+        self.assertIsNotNone(request.qty)
+
+    def test_buy_with_stop_only_submits_oto_order(self):
+        result = self._execute(_intent(stop_loss="182.50"))
+
+        self.assertEqual(result["protective_order_status"], "submitted_oto")
+        request = self.client.submit_order.call_args[0][0]
+        self.assertEqual(str(request.order_class.value).lower(), "oto")
+        self.assertEqual(float(request.stop_loss.stop_price), 182.50)
+        self.assertIsNone(request.take_profit)
+
+    def test_crypto_buy_stays_advisory(self):
+        result = self._execute(
+            _intent(symbol="BTC/USD", stop_loss="60000", take_profit="70000"),
+            symbol="BTC/USD",
+        )
+
+        self.assertEqual(result["protective_order_status"], "advisory_only")
+        request = self.client.submit_order.call_args[0][0]
+        self.assertIsNone(getattr(request, "stop_loss", None))
+        self.assertTrue(any("crypto" in w.lower() for w in result["intent_warnings"]))
+
+    def test_inverted_long_prices_fall_back_to_advisory(self):
+        # For a long entry the stop must sit below the target.
+        result = self._execute(_intent(stop_loss="200", take_profit="180"))
+
+        self.assertEqual(result["protective_order_status"], "advisory_only")
+        request = self.client.submit_order.call_args[0][0]
+        self.assertIsNone(getattr(request, "stop_loss", None))
+
+    def test_no_numeric_prices_stays_advisory(self):
+        result = self._execute(_intent(stop_loss="below support"))
+
+        self.assertEqual(result["protective_order_status"], "advisory_only")
+
+    def test_config_flag_disables_bracket_submission(self):
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_config",
+            return_value={"protective_bracket_orders_enabled": False},
+        ):
+            result = self._execute(_intent(stop_loss="182.50", take_profit="195"))
+
+        self.assertEqual(result["protective_order_status"], "advisory_only")
+        request = self.client.submit_order.call_args[0][0]
+        self.assertIsNone(getattr(request, "stop_loss", None))
+
+    def test_bracket_rejection_falls_back_to_plain_market_order(self):
+        plain_order = MagicMock()
+        plain_order.id = "order-2"
+        plain_order.symbol = "AAPL"
+        plain_order.side = "buy"
+        plain_order.qty = 5
+        plain_order.notional = None
+        plain_order.status = "accepted"
+        self.client.submit_order.side_effect = [
+            Exception("bracket orders not allowed"),
+            plain_order,
+        ]
+
+        result = self._execute(_intent(stop_loss="182.50", take_profit="195"))
+
+        self.assertTrue(result["success"])
+        self.assertEqual(
+            result["protective_order_status"], "bracket_rejected_fallback_plain"
+        )
+        self.assertEqual(self.client.submit_order.call_count, 2)
+
+    def test_short_entry_bracket_prices_validated_inverted(self):
+        # For a short entry the target sits below the stop.
+        result = self._execute(
+            _intent(
+                stop_loss="210",
+                take_profit="180",
+                action=ExecutableAction.SHORT,
+                trading_mode="trading",
+                allow_shorts=True,
+            ),
+            allow_shorts=True,
+        )
+
+        self.assertEqual(result["protective_order_status"], "submitted_bracket")
+        request = self.client.submit_order.call_args[0][0]
+        self.assertEqual(float(request.stop_loss.stop_price), 210.0)
+        self.assertEqual(float(request.take_profit.limit_price), 180.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_structured_decisions.py
+++ b/tests/test_structured_decisions.py
@@ -90,7 +90,11 @@ class StructuredDecisionTests(unittest.TestCase):
         self.assertEqual(intent.position_transition, PositionTransition.OPEN_LONG)
         self.assertEqual(intent.order_intent.side, "buy")
         self.assertEqual(intent.risk_controls.mode, "advisory_only")
-        self.assertIn("protective-order", " ".join(intent.execution_constraints.warnings))
+        # Numeric protective levels are extracted so execution can submit
+        # real bracket orders instead of leaving controls advisory.
+        self.assertEqual(intent.risk_controls.stop_loss_price, 182.50)
+        self.assertEqual(intent.risk_controls.take_profit_price, 195.0)
+        self.assertTrue(intent.execution_constraints.broker_protective_orders_enabled)
         self.assertEqual(trade_intent_action(intent.model_dump(mode="json")), "BUY")
 
     def test_alpaca_execution_prefers_validated_trade_intent(self):

--- a/tradingagents/agents/schemas.py
+++ b/tradingagents/agents/schemas.py
@@ -6,11 +6,39 @@ The upstream 5-tier rating is advisory metadata only.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, Field
+
+_PRICE_PATTERN = re.compile(r"\$?\s*(\d{1,3}(?:,\d{3})+|\d+)(?:\.(\d+))?")
+
+
+def extract_protective_price(guidance: Optional[str]) -> Optional[float]:
+    """Extract the first absolute price level from free-text risk guidance.
+
+    Returns None for qualitative guidance ("below support"), relative values
+    ("8% below entry"), or empty input — a protective order must never be
+    submitted from a level we are not sure about.
+    """
+    if not guidance:
+        return None
+    match = _PRICE_PATTERN.search(guidance)
+    if not match:
+        return None
+    # Percentages are relative to an unknown entry price, not price levels.
+    tail = guidance[match.end():].lstrip()
+    if tail.startswith("%") or tail.lower().startswith("percent"):
+        return None
+    whole = match.group(1).replace(",", "")
+    fraction = match.group(2) or "0"
+    try:
+        price = float(f"{whole}.{fraction}")
+    except ValueError:
+        return None
+    return price if price > 0 else None
 
 
 class AdvisoryRating(str, Enum):
@@ -64,6 +92,14 @@ class RiskControls(BaseModel):
     required_controls: Optional[str] = Field(default=None, description="Full risk-control guidance from the risk manager.")
     stop_loss: Optional[str] = Field(default=None, description="Stop-loss or invalidation guidance.")
     take_profit: Optional[str] = Field(default=None, description="Take-profit or target guidance.")
+    stop_loss_price: Optional[float] = Field(
+        default=None,
+        description="Absolute stop-loss price level for broker protective orders, when known.",
+    )
+    take_profit_price: Optional[float] = Field(
+        default=None,
+        description="Absolute take-profit price level for broker protective orders, when known.",
+    )
     invalidation: Optional[str] = Field(default=None, description="Setup invalidation guidance.")
     max_position_size: Optional[str] = Field(default=None, description="Position-size or max exposure guidance.")
 
@@ -386,9 +422,12 @@ def build_trade_intent_from_risk_decision(
     if target == TargetPosition.SHORT and not allow_shorts:
         warnings.append("Short exposure is disabled for this session.")
 
-    if decision.required_controls or decision.stop_loss or decision.take_profit:
+    stop_loss_price = extract_protective_price(decision.stop_loss)
+    take_profit_price = extract_protective_price(decision.take_profit)
+    has_numeric_controls = bool(stop_loss_price or take_profit_price)
+    if (decision.required_controls or decision.stop_loss or decision.take_profit) and not has_numeric_controls:
         warnings.append(
-            "Risk controls are captured as advisory metadata; broker protective-order submission is not enabled in this execution path."
+            "Risk controls carry no absolute protective-order price levels; they remain advisory metadata."
         )
 
     risk_controls = RiskControls(
@@ -396,6 +435,8 @@ def build_trade_intent_from_risk_decision(
         required_controls=decision.required_controls,
         stop_loss=decision.stop_loss,
         take_profit=decision.take_profit,
+        stop_loss_price=stop_loss_price,
+        take_profit_price=take_profit_price,
         invalidation=decision.invalidation,
         max_position_size=decision.max_position_size,
     )
@@ -403,7 +444,7 @@ def build_trade_intent_from_risk_decision(
         allow_shorts=allow_shorts,
         asset_class=asset_class,
         requires_open_market=asset_class != "crypto",
-        broker_protective_orders_enabled=False,
+        broker_protective_orders_enabled=has_numeric_controls and asset_class != "crypto",
         warnings=warnings,
     )
 

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -10,8 +10,15 @@ from alpaca.data.requests import StockBarsRequest, CryptoBarsRequest, StockLates
 from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
 from alpaca.data.enums import DataFeed
 from alpaca.trading.client import TradingClient
-from alpaca.trading.requests import GetAssetsRequest, GetOrdersRequest, MarketOrderRequest, ClosePositionRequest
-from alpaca.trading.enums import AssetClass, AssetStatus, OrderSide, QueryOrderStatus, TimeInForce
+from alpaca.trading.requests import (
+    GetAssetsRequest,
+    GetOrdersRequest,
+    MarketOrderRequest,
+    ClosePositionRequest,
+    StopLossRequest,
+    TakeProfitRequest,
+)
+from alpaca.trading.enums import AssetClass, AssetStatus, OrderClass, OrderSide, QueryOrderStatus, TimeInForce
 from alpaca.common.enums import Sort
 from .config import get_api_key, get_alpaca_use_paper, get_config
 from .ticker_utils import TickerUtils
@@ -788,6 +795,77 @@ class AlpacaUtils:
             return {"success": False, "error": error_msg}
 
     @staticmethod
+    def place_protected_market_order(
+        symbol: str,
+        side: str,
+        qty: float,
+        stop_loss_price: float = None,
+        take_profit_price: float = None,
+    ) -> dict:
+        """Place a market order with broker-side protective child orders.
+
+        Uses order_class=bracket when both a stop and a target are given, and
+        order_class=oto for a single protective leg.  Equities only: Alpaca
+        does not support bracket/OTO orders for crypto, and protective legs
+        require a whole-share quantity (no notional sizing).  Time in force is
+        GTC so the protective legs survive past the trading day.
+        """
+        try:
+            if not stop_loss_price and not take_profit_price:
+                return {"success": False, "error": "No protective price supplied"}
+
+            client = get_alpaca_trading_client()
+            alpaca_symbol = symbol.upper().replace("/", "")
+            order_side = OrderSide.BUY if side.lower() == "buy" else OrderSide.SELL
+
+            stop_loss = (
+                StopLossRequest(stop_price=round(float(stop_loss_price), 2))
+                if stop_loss_price
+                else None
+            )
+            take_profit = (
+                TakeProfitRequest(limit_price=round(float(take_profit_price), 2))
+                if take_profit_price
+                else None
+            )
+            order_class = (
+                OrderClass.BRACKET if (stop_loss and take_profit) else OrderClass.OTO
+            )
+
+            order_request = MarketOrderRequest(
+                symbol=alpaca_symbol,
+                side=order_side,
+                time_in_force=TimeInForce.GTC,
+                qty=int(qty),
+                order_class=order_class,
+                stop_loss=stop_loss,
+                take_profit=take_profit,
+            )
+            order = client.submit_order(order_request)
+
+            return {
+                "success": True,
+                "order_id": order.id,
+                "symbol": order.symbol,
+                "side": order.side,
+                "qty": float(order.qty) if order.qty else None,
+                "status": order.status,
+                "order_class": "bracket" if order_class == OrderClass.BRACKET else "oto",
+                "stop_loss_price": float(stop_loss.stop_price) if stop_loss else None,
+                "take_profit_price": float(take_profit.limit_price) if take_profit else None,
+                "message": (
+                    f"Placed {side} {order_class.value} order for {symbol} "
+                    f"(stop={stop_loss.stop_price if stop_loss else None}, "
+                    f"target={take_profit.limit_price if take_profit else None})"
+                ),
+            }
+
+        except Exception as e:
+            error_msg = f"Error placing protected {side} order for {symbol}: {e}"
+            print(error_msg)
+            return {"success": False, "error": error_msg}
+
+    @staticmethod
     def close_position(symbol: str, percentage: float = 100.0) -> dict:
         """
         Close a position (partially or completely)
@@ -902,31 +980,98 @@ class AlpacaUtils:
             warnings.append(
                 f"Intent was generated with {intent.current_position.value} position; live position is {current_position}."
             )
-        if (
-            intent.risk_controls.mode == "advisory_only"
-            and (
-                intent.risk_controls.required_controls
-                or intent.risk_controls.stop_loss
-                or intent.risk_controls.take_profit
-            )
-        ):
-            warnings.append("Broker stop-loss/take-profit orders were not submitted; controls remain advisory.")
 
-        result = AlpacaUtils.execute_trading_action(
+        protective_prices = AlpacaUtils._resolve_protective_prices(
+            intent, signal, is_crypto, warnings
+        )
+
+        execute_kwargs = dict(
             symbol=symbol,
             current_position=current_position,
             signal=signal,
             dollar_amount=dollar_amount,
             allow_shorts=allow_shorts,
         )
+        if protective_prices:
+            execute_kwargs["protective_prices"] = protective_prices
+
+        result = AlpacaUtils.execute_trading_action(**execute_kwargs)
         result["trade_intent"] = intent.model_dump(mode="json")
+
+        protective_status = "advisory_only"
+        for action in result.get("actions", []):
+            action_result = action.get("result") or {}
+            if action_result.get("order_class") == "bracket":
+                protective_status = "submitted_bracket"
+            elif action_result.get("order_class") == "oto":
+                protective_status = "submitted_oto"
+            elif action_result.get("protective_fallback"):
+                protective_status = "bracket_rejected_fallback_plain"
+                warnings.append(
+                    "Protective order submission was rejected by the broker; "
+                    f"entered with a plain market order instead ({action_result.get('protective_error')})."
+                )
+        if protective_status == "advisory_only" and (
+            intent.risk_controls.required_controls
+            or intent.risk_controls.stop_loss
+            or intent.risk_controls.take_profit
+        ):
+            warnings.append("Broker stop-loss/take-profit orders were not submitted; controls remain advisory.")
+
         result["intent_warnings"] = warnings
-        result["protective_order_status"] = "advisory_only"
+        result["protective_order_status"] = protective_status
         return result
 
     @staticmethod
-    def execute_trading_action(symbol: str, current_position: str, signal: str, 
-                             dollar_amount: float, allow_shorts: bool = False) -> dict:
+    def _resolve_protective_prices(intent, signal, is_crypto, warnings):
+        """Decide which protective price levels can be submitted to the broker.
+
+        Returns a dict for place_protected_market_order, or None when the
+        intent must stay advisory (no numeric levels, crypto asset, disabled
+        by config, non-opening action, or inconsistent levels).
+        """
+        from tradingagents.agents.schemas import extract_protective_price
+
+        controls = intent.risk_controls
+        stop_price = controls.stop_loss_price or extract_protective_price(controls.stop_loss)
+        target_price = controls.take_profit_price or extract_protective_price(controls.take_profit)
+        if not stop_price and not target_price:
+            return None
+
+        opening_long = signal in {"BUY", "LONG"}
+        opening_short = signal == "SHORT"
+        if not opening_long and not opening_short:
+            return None  # closes/holds carry nothing to protect
+
+        if is_crypto:
+            warnings.append(
+                "Protective bracket/OTO orders are not supported for crypto assets; controls remain advisory."
+            )
+            return None
+
+        if not get_config().get("protective_bracket_orders_enabled", True):
+            warnings.append(
+                "Protective bracket orders are disabled by configuration; controls remain advisory."
+            )
+            return None
+
+        if stop_price and target_price:
+            inverted = (opening_long and stop_price >= target_price) or (
+                opening_short and target_price >= stop_price
+            )
+            if inverted:
+                warnings.append(
+                    f"Protective prices are inconsistent for a {'long' if opening_long else 'short'} entry "
+                    f"(stop={stop_price}, target={target_price}); controls remain advisory."
+                )
+                return None
+
+        return {"stop_loss_price": stop_price, "take_profit_price": target_price}
+
+    @staticmethod
+    def execute_trading_action(symbol: str, current_position: str, signal: str,
+                             dollar_amount: float, allow_shorts: bool = False,
+                             protective_prices: Optional[Dict[str, float]] = None) -> dict:
         """
         Execute trading action based on current position and signal
         
@@ -957,7 +1102,35 @@ class AlpacaUtils:
                 except Exception:
                     # Fallback: at least 1 share
                     return 1
-            
+
+            def _open_position(sym: str, side: str, amount: float) -> dict:
+                """Open a position, attaching broker protective orders when available.
+
+                Falls back to a plain market order if the protected submission is
+                rejected, so a broker-side validation error never blocks the entry
+                the agents decided on (matching previous behaviour).
+                """
+                is_crypto_sym = "/" in sym.upper()
+                if not is_crypto_sym and protective_prices:
+                    qty_int = _calc_qty(sym, amount)
+                    protected = AlpacaUtils.place_protected_market_order(
+                        sym,
+                        side,
+                        qty_int,
+                        stop_loss_price=protective_prices.get("stop_loss_price"),
+                        take_profit_price=protective_prices.get("take_profit_price"),
+                    )
+                    if protected.get("success"):
+                        return protected
+                    fallback = AlpacaUtils.place_market_order(sym, side, qty=qty_int)
+                    fallback["protective_fallback"] = True
+                    fallback["protective_error"] = protected.get("error")
+                    return fallback
+                if is_crypto_sym and side == "buy":
+                    # Crypto buys use exact notional sizing (no bracket support).
+                    return AlpacaUtils.place_market_order(sym, side, notional=amount)
+                return AlpacaUtils.place_market_order(sym, side, qty=_calc_qty(sym, amount))
+
             if allow_shorts:
                 # Trading mode: LONG/NEUTRAL/SHORT signals
                 signal = signal.upper()
@@ -980,9 +1153,7 @@ class AlpacaUtils:
                                 error_msg = f"Direct short selling not supported for crypto assets like {symbol}. Position closed but short not opened."
                                 results.append({"action": "open_short", "result": {"success": False, "error": error_msg}})
                             else:
-                                # Calculate integer quantity for short (fractional shares cannot be shorted)
-                                qty_int = _calc_qty(symbol, dollar_amount)
-                                short_result = AlpacaUtils.place_market_order(symbol, "sell", qty=qty_int)
+                                short_result = _open_position(symbol, "sell", dollar_amount)
                                 results.append({"action": "open_short", "result": short_result})
                 
                 elif current_position == "SHORT":
@@ -997,28 +1168,12 @@ class AlpacaUtils:
                         close_result = AlpacaUtils.close_position(symbol)
                         results.append({"action": "close_short", "result": close_result})
                         if close_result.get("success"):
-                            # Open LONG position - use notional amount for crypto, quantity for stocks
-                            is_crypto = "/" in symbol.upper()
-                            if is_crypto:
-                                # For crypto, use exact dollar amount (notional)
-                                long_result = AlpacaUtils.place_market_order(symbol, "buy", notional=dollar_amount)
-                            else:
-                                # For stocks, calculate quantity
-                                qty_int = _calc_qty(symbol, dollar_amount)
-                                long_result = AlpacaUtils.place_market_order(symbol, "buy", qty=qty_int)
+                            long_result = _open_position(symbol, "buy", dollar_amount)
                             results.append({"action": "open_long", "result": long_result})
                 
                 elif current_position == "NEUTRAL":
                     if signal == "LONG":
-                        # Open LONG position - use notional amount for crypto, quantity for stocks
-                        is_crypto = "/" in symbol.upper()
-                        if is_crypto:
-                            # For crypto, use exact dollar amount (notional)
-                            long_result = AlpacaUtils.place_market_order(symbol, "buy", notional=dollar_amount)
-                        else:
-                            # For stocks, calculate quantity
-                            qty_int = _calc_qty(symbol, dollar_amount)
-                            long_result = AlpacaUtils.place_market_order(symbol, "buy", qty=qty_int)
+                        long_result = _open_position(symbol, "buy", dollar_amount)
                         results.append({"action": "open_long", "result": long_result})
                     elif signal == "SHORT":
                         # Check if this is crypto - Alpaca doesn't support crypto short selling directly
@@ -1027,9 +1182,7 @@ class AlpacaUtils:
                             error_msg = f"Direct short selling not supported for crypto assets like {symbol}. Consider using derivatives or margin trading platforms."
                             results.append({"action": "open_short", "result": {"success": False, "error": error_msg}})
                         else:
-                            # For stocks, attempt short selling
-                            qty_int = _calc_qty(symbol, dollar_amount)
-                            short_result = AlpacaUtils.place_market_order(symbol, "sell", qty=qty_int)
+                            short_result = _open_position(symbol, "sell", dollar_amount)
                             results.append({"action": "open_short", "result": short_result})
                     elif signal == "NEUTRAL":
                         results.append({"action": "hold", "message": f"No position needed for {symbol}"})
@@ -1043,15 +1196,7 @@ class AlpacaUtils:
                     if has_position:
                         results.append({"action": "hold", "message": f"Already have position in {symbol}"})
                     else:
-                        # Buy position - use notional amount for crypto, quantity for stocks
-                        is_crypto = "/" in symbol.upper()
-                        if is_crypto:
-                            # For crypto, use exact dollar amount (notional)
-                            buy_result = AlpacaUtils.place_market_order(symbol, "buy", notional=dollar_amount)
-                        else:
-                            # For stocks, calculate quantity
-                            qty_int = _calc_qty(symbol, dollar_amount)
-                            buy_result = AlpacaUtils.place_market_order(symbol, "buy", qty=qty_int)
+                        buy_result = _open_position(symbol, "buy", dollar_amount)
                         results.append({"action": "buy", "result": buy_result})
                 
                 elif signal == "SELL":

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -51,6 +51,7 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 200,
     # Trading settings
     "allow_shorts": False,  # False = Investment mode (BUY/HOLD/SELL), True = Trading mode (LONG/NEUTRAL/SHORT)
+    "protective_bracket_orders_enabled": True,  # Submit stop-loss/take-profit as real bracket/OTO child orders on equity entries (crypto unsupported by Alpaca)
     # Execution settings
     "parallel_analysts": True,  # True = Run analysts in parallel for faster execution, False = Sequential execution
     "parallel_risk_first_round": True,  # Run Risky/Safe/Neutral in parallel only for round 1, then revert to linear flow


### PR DESCRIPTION
## Problem

`execute_trade_intent` always returned `protective_order_status: "advisory_only"` — the stop-loss and take-profit levels the risk team decided on **never reached the broker**. Every position opened by the agents was unprotected in the market, even though reports implied risk controls were in place.

## What this PR does

**Real protective orders on equity entries.** When a trade intent carries usable protective price levels, the opening market order is now submitted as:

- `order_class=bracket` (take-profit limit + stop-loss stop) when both levels are known
- `order_class=oto` when only one level is known
- `TimeInForce.GTC` so protective legs survive past the trading day, and whole-share `qty` (bracket orders don't support notional/fractional sizing)

**Conservative price resolution.** `extract_protective_price()` parses absolute levels from the risk manager's free-text guidance (`"Stop at $182.50 (ATR-based)"` → `182.50`) and deliberately refuses percentages (`"8% below entry"`) and qualitative guidance (`"below support"`). `RiskControls` also gains numeric `stop_loss_price` / `take_profit_price` fields, so a quantitative risk layer (e.g. #25) can inject exact levels directly without text parsing.

**Falls back to advisory (with an explicit warning) when submission would be wrong:**

| Case | Behavior |
|---|---|
| Crypto asset | Advisory — Alpaca spot has no bracket/OTO support |
| No numeric levels extractable | Advisory |
| Inconsistent levels (long: stop ≥ target; short: target ≥ stop) | Advisory |
| `protective_bracket_orders_enabled: False` in config | Advisory |
| Non-opening action (close / hold) | Advisory — nothing to protect |
| Broker rejects the protected order | Plain market entry + warning (`bracket_rejected_fallback_plain`) — matches previous entry behavior instead of silently blocking the trade |

**Honest status reporting.** `protective_order_status` now reports what actually happened: `submitted_bracket`, `submitted_oto`, `bracket_rejected_fallback_plain`, or `advisory_only`.

Config: `protective_bracket_orders_enabled` (default `True` — the change is purely protective; set `False` to restore advisory-only behavior).

## Testing

- 15 new tests in `tests/test_bracket_protective_orders.py`: price extraction (incl. rejection of percentages), intent building, bracket + OTO submission with real `MarketOrderRequest` construction through the alpaca-py SDK (validates the request schema), crypto/inverted/config/no-price advisory fallbacks, broker-rejection fallback, short-entry validation.
- Full suite: **68 passed**.

Note: live paper-account verification wasn't possible in this environment (expired keys), but the tests build genuine `MarketOrderRequest` objects through alpaca-py's own validation, so the bracket/OTO request shape is exercised end-to-end up to the HTTP boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
