### PR TITLE
fix: Pydantic 3-ready config in GPT5ChatModel (PydanticDeprecatedSince20)

### DIFF
--- a/tests/test_no_owned_deprecation_warnings.py
+++ b/tests/test_no_owned_deprecation_warnings.py
@@ -1,0 +1,40 @@
+"""Our own modules must not emit Pydantic deprecation warnings on import.
+
+Third-party warnings are out of scope; this guards the code we own so it
+keeps working when Pydantic 3 removes the deprecated class-based config.
+"""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+class OwnedDeprecationWarningTests(unittest.TestCase):
+    def test_gpt5_llm_import_emits_no_pydantic_deprecation(self):
+        code = (
+            "import warnings\n"
+            "from pydantic import PydanticDeprecatedSince20\n"
+            "with warnings.catch_warnings():\n"
+            "    warnings.simplefilter('error', PydanticDeprecatedSince20)\n"
+            "    import tradingagents.agents.utils.gpt5_llm\n"
+            "print('CLEAN')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            timeout=300,
+        )
+        self.assertIn(
+            "CLEAN",
+            result.stdout,
+            f"importing gpt5_llm raised a Pydantic deprecation:\n{result.stderr[-2000:]}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/agents/utils/gpt5_llm.py
+++ b/tradingagents/agents/utils/gpt5_llm.py
@@ -1,6 +1,7 @@
 """Custom LangChain wrapper for OpenAI reasoning models using Responses API."""
 
 from typing import Any, Dict, List, Optional
+from pydantic import ConfigDict
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.outputs import ChatResult, ChatGeneration
@@ -55,10 +56,9 @@ class GPT5ChatModel(BaseChatModel):
     
     # Internal client - not a pydantic field
     _client: Optional[OpenAI] = None
-    
-    class Config:
-        arbitrary_types_allowed = True
-    
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # Initialize the OpenAI client


### PR DESCRIPTION
Importing \	radingagents.agents.utils.gpt5_llm\ emitted \PydanticDeprecatedSince20\ — class-based \class Config\ support is removed in Pydantic 3, so this would become a hard break on the next major upgrade. Switched to \model_config = ConfigDict(arbitrary_types_allowed=True)\.

Includes a subprocess-based guard test that fails if importing the module raises any Pydantic deprecation warning. Remaining pytest warnings all originate in third-party packages (langgraph, langchain_core, websockets, chromadb) and are intentionally left untouched.

Full suite: 54 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)