### PR TITLE
ci: run the test suite on every push and PR via GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Run test suite
+        # No API keys are configured on purpose: the suite must stay runnable
+        # offline (network-dependent paths are mocked or skipped).
+        run: pytest tests/ -v --tb=short

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
           pip install -r requirements.txt pytest
 
       - name: Run test suite
-        # No API keys are configured on purpose: the suite must stay runnable
-        # offline (network-dependent paths are mocked or skipped).
-        run: pytest tests/ -v --tb=short
+        # `python -m pytest` puts the repo root on sys.path (the project is
+        # not pip-installable). No API keys are configured on purpose: the
+        # suite must stay runnable offline.
+        run: python -m pytest tests/ -v --tb=short


### PR DESCRIPTION
The repository currently has no CI, so regressions are only caught by whoever happens to run pytest locally. This adds a minimal GitHub Actions workflow:

- runs \python -m pytest tests/\ on **Python 3.11 and 3.12** (ubuntu-latest, pip cache, 30-min timeout, concurrency cancellation for superseded pushes)
- **no API keys configured on purpose** — the suite is designed to pass offline (network-dependent paths are mocked), so this also guards against accidentally introducing tests that need live credentials
- \python -m pytest\ (rather than bare \pytest\) puts the repo root on \sys.path\, since the project is not pip-installable

**Verified green** before proposing: both matrix jobs pass on my fork — see [this run](https://github.com/Solydos/AlpacaTradingAgent/actions/runs/29145533036) (52 tests, ~4 min with cold cache).

Note: as this is the repo's first workflow, GitHub may ask you to approve its first run on PRs from forks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)