### PR TITLE
feat: intensive teaching - seed agent memories from recorded backtest history

### DIFF
--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -241,6 +241,7 @@ class RunBacktestTests(unittest.TestCase):
             initial_cash=10_000,
             commission=0.0,
             position_pct=0.4,
+            slippage_bps=0.0,  # this test isolates lookahead, not costs
         )
         self.assertEqual(result.orders[0]["date"], "2026-01-06")
         self.assertAlmostEqual(result.orders[0]["price"], 200.0)
@@ -316,6 +317,108 @@ class RunBacktestTests(unittest.TestCase):
         result = run_backtest(prices, {"2026-01-05": "BUY"})
         payload = json.dumps(result.to_dict())
         self.assertIn("cumulative_return", payload)
+
+
+class SlippageTests(unittest.TestCase):
+    """Execution-cost realism: fills must be able to model slippage.
+
+    A zero-slippage assumption systematically inflates backtest results, so
+    a fixed basis-point model is on by default and a volatility-scaled model
+    is available for less liquid / more volatile symbols.
+    """
+
+    BUY = {"2026-01-05": "BUY"}
+
+    def test_fixed_bps_slippage_raises_buy_fill_price(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices, self.BUY, initial_cash=10_000, commission=0.0, slippage_bps=50.0
+        )
+        # 50 bps over the 100.0 next-bar open.
+        self.assertAlmostEqual(result.orders[0]["price"], 100.5)
+
+    def test_zero_bps_fills_exactly_at_open(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices, self.BUY, initial_cash=10_000, commission=0.0, slippage_bps=0.0
+        )
+        self.assertAlmostEqual(result.orders[0]["price"], 100.0)
+
+    def test_slippage_is_on_by_default(self):
+        prices = make_prices([100] * 6)
+        default = run_backtest(prices, self.BUY, initial_cash=10_000, commission=0.0)
+        self.assertGreater(default.orders[0]["price"], 100.0)
+
+    def test_sell_fill_price_slips_down(self):
+        prices = make_prices([100] * 8)
+        signals = {"2026-01-05": "BUY", "2026-01-08": "SELL"}
+        result = run_backtest(
+            prices, signals, initial_cash=10_000, commission=0.0, slippage_bps=50.0
+        )
+        sells = [o for o in result.orders if o["side"] == "sell"]
+        self.assertAlmostEqual(sells[0]["price"], 99.5)
+
+    def test_slippage_reduces_round_trip_equity(self):
+        prices = make_prices([100] * 8)
+        signals = {"2026-01-05": "BUY", "2026-01-08": "SELL"}
+        free = run_backtest(
+            prices, signals, initial_cash=10_000, commission=0.0, slippage_bps=0.0
+        )
+        slipped = run_backtest(
+            prices, signals, initial_cash=10_000, commission=0.0, slippage_bps=50.0
+        )
+        self.assertLess(slipped.equity_curve.iloc[-1], free.equity_curve.iloc[-1])
+
+    def test_volatility_model_scales_with_previous_bar_range(self):
+        # make_prices gives every bar high=101/low=99/close=100, so the
+        # previous-bar range fraction is 2%; with vol_fraction=0.1 the buy
+        # slips by 20 bps over the 100.0 open.
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices,
+            self.BUY,
+            initial_cash=10_000,
+            commission=0.0,
+            slippage_model="volatility",
+            slippage_vol_fraction=0.1,
+        )
+        self.assertAlmostEqual(result.orders[0]["price"], 100.2)
+
+    def test_volatility_model_respects_max_cap(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices,
+            self.BUY,
+            initial_cash=10_000,
+            commission=0.0,
+            slippage_model="volatility",
+            slippage_vol_fraction=0.1,
+            slippage_max_bps=5.0,
+        )
+        self.assertAlmostEqual(result.orders[0]["price"], 100.05)
+
+    def test_none_model_disables_slippage(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices,
+            self.BUY,
+            initial_cash=10_000,
+            commission=0.0,
+            slippage_model="none",
+            slippage_bps=50.0,
+        )
+        self.assertAlmostEqual(result.orders[0]["price"], 100.0)
+
+    def test_unknown_model_raises(self):
+        prices = make_prices([100] * 6)
+        with self.assertRaises(ValueError):
+            run_backtest(prices, self.BUY, slippage_model="quantum")
+
+    def test_result_reports_slippage_config(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(prices, self.BUY, slippage_bps=7.5)
+        self.assertEqual(result.to_dict()["slippage"]["model"], "fixed")
+        self.assertAlmostEqual(result.to_dict()["slippage"]["bps"], 7.5)
 
 
 class WalkForwardTests(unittest.TestCase):

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -1,0 +1,409 @@
+"""Tests for the walk-forward backtesting engine and its metrics."""
+
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from tradingagents.backtest import (
+    annualized_return,
+    cumulative_return,
+    load_recorded_signals,
+    max_drawdown,
+    normalize_action,
+    normalize_price_frame,
+    run_backtest,
+    run_recorded_backtest,
+    run_walk_forward,
+    sharpe_ratio,
+    summarize_performance,
+    win_rate,
+)
+
+
+def make_prices(closes, start="2026-01-05", opens=None, freq="B"):
+    """Build an OHLCV frame in AlpacaUtils.get_stock_data's output shape."""
+    closes = [float(c) for c in closes]
+    opens = [float(o) for o in opens] if opens is not None else list(closes)
+    dates = pd.bdate_range(start=start, periods=len(closes)) if freq == "B" else (
+        pd.date_range(start=start, periods=len(closes), freq=freq)
+    )
+    return pd.DataFrame(
+        {
+            "timestamp": dates,
+            "open": opens,
+            "high": [max(o, c) * 1.01 for o, c in zip(opens, closes)],
+            "low": [min(o, c) * 0.99 for o, c in zip(opens, closes)],
+            "close": closes,
+            "volume": [1_000_000] * len(closes),
+        }
+    )
+
+
+class MetricsTests(unittest.TestCase):
+    def test_cumulative_return_hand_computed(self):
+        self.assertAlmostEqual(cumulative_return([100.0, 125.0]), 0.25)
+        self.assertAlmostEqual(cumulative_return([100.0, 80.0]), -0.20)
+
+    def test_cumulative_return_degenerate_inputs(self):
+        self.assertIsNone(cumulative_return([]))
+        self.assertIsNone(cumulative_return([100.0]))
+        self.assertIsNone(cumulative_return([0.0, 50.0]))
+
+    def test_annualized_return_hand_computed(self):
+        # +10% over 126 periods at 252 periods/year => (1.1)^2 - 1 = 21%
+        curve = [100.0] + [100.0] * 125 + [110.0]
+        self.assertAlmostEqual(
+            annualized_return(curve, periods_per_year=252), 1.1**2 - 1.0, places=9
+        )
+
+    def test_sharpe_ratio_hand_computed(self):
+        # Alternating +1%/-1% daily returns: mean 0 => Sharpe ~ 0 (slightly
+        # negative because (1.01 * 0.99) < 1); must not be None.
+        curve = [100.0]
+        for i in range(20):
+            curve.append(curve[-1] * (1.01 if i % 2 == 0 else 0.99))
+        value = sharpe_ratio(curve)
+        self.assertIsNotNone(value)
+        self.assertLess(abs(value), 0.5)
+
+    def test_sharpe_ratio_zero_volatility_is_none(self):
+        self.assertIsNone(sharpe_ratio([100.0, 100.0, 100.0, 100.0]))
+        self.assertIsNone(sharpe_ratio([100.0, 101.0]))  # too short
+
+    def test_max_drawdown_hand_computed(self):
+        # Peak 120 -> trough 90 = 25% drawdown; later recovery must not hide it.
+        self.assertAlmostEqual(
+            max_drawdown([100.0, 120.0, 90.0, 130.0]), 0.25
+        )
+        self.assertAlmostEqual(max_drawdown([100.0, 110.0, 121.0]), 0.0)
+
+    def test_win_rate(self):
+        self.assertAlmostEqual(win_rate([10.0, -5.0, 3.0, -1.0]), 0.5)
+        self.assertIsNone(win_rate([]))
+        self.assertAlmostEqual(win_rate([0.0, 2.0]), 0.5)  # breakeven not a win
+
+    def test_summarize_performance_keys(self):
+        summary = summarize_performance([100.0, 105.0, 103.0], [4.0])
+        for key in (
+            "cumulative_return",
+            "annualized_return",
+            "sharpe_ratio",
+            "max_drawdown",
+            "win_rate",
+            "num_trades",
+            "num_periods",
+            "final_equity",
+        ):
+            self.assertIn(key, summary)
+        self.assertEqual(summary["num_trades"], 1)
+        self.assertEqual(summary["num_periods"], 2)
+        self.assertAlmostEqual(summary["final_equity"], 103.0)
+
+
+class SignalNormalizationTests(unittest.TestCase):
+    def test_all_aliases(self):
+        for raw, expected in {
+            "BUY": "BUY",
+            "long": "BUY",
+            " Short ": "SELL",
+            "sell": "SELL",
+            "HOLD": "HOLD",
+            "Neutral": "HOLD",
+        }.items():
+            with self.subTest(raw=raw):
+                self.assertEqual(normalize_action(raw), expected)
+
+    def test_unknown_inputs_are_none(self):
+        for raw in (None, "", "MAYBE", 42):
+            with self.subTest(raw=raw):
+                self.assertIsNone(normalize_action(raw))
+
+
+def write_run_log(root, symbol, trade_date, final_signal, status="completed", started_at=None):
+    runs_dir = Path(root) / symbol / "TradingAgentsStrategy_logs" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    started = started_at or f"{trade_date}T10:00:00+00:00"
+    payload = {
+        "run_id": f"{trade_date}_{started.replace(':', '')}",
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "started_at": started,
+        "status": status,
+        "summary": {"final_signal": final_signal} if final_signal else {},
+    }
+    path = runs_dir / f"{payload['run_id']}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+class LoadRecordedSignalsTests(unittest.TestCase):
+    def test_reads_completed_runs_and_normalizes(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "BUY")
+            write_run_log(root, "AAPL", "2026-01-06", "long")
+            write_run_log(root, "AAPL", "2026-01-07", "NEUTRAL")
+            signals = load_recorded_signals("AAPL", eval_results_dir=root)
+        self.assertEqual(
+            signals,
+            {"2026-01-05": "BUY", "2026-01-06": "BUY", "2026-01-07": "HOLD"},
+        )
+
+    def test_ignores_aborted_missing_signal_and_bad_dates(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "BUY", status="aborted")
+            write_run_log(root, "AAPL", "2026-01-06", None)
+            write_run_log(root, "AAPL", "not-a-date", "BUY")
+            self.assertEqual(load_recorded_signals("AAPL", eval_results_dir=root), {})
+
+    def test_latest_run_per_date_wins(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(
+                root, "AAPL", "2026-01-05", "BUY",
+                started_at="2026-01-05T09:00:00+00:00",
+            )
+            write_run_log(
+                root, "AAPL", "2026-01-05", "SELL",
+                started_at="2026-01-05T15:00:00+00:00",
+            )
+            signals = load_recorded_signals("AAPL", eval_results_dir=root)
+        self.assertEqual(signals, {"2026-01-05": "SELL"})
+
+    def test_crypto_symbol_path_sanitization(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "BTC_USD", "2026-01-05", "BUY")
+            signals = load_recorded_signals("BTC/USD", eval_results_dir=root)
+        self.assertEqual(signals, {"2026-01-05": "BUY"})
+
+    def test_missing_directory_returns_empty(self):
+        self.assertEqual(
+            load_recorded_signals("ZZZZ", eval_results_dir="definitely_missing_dir"),
+            {},
+        )
+
+
+class NormalizePriceFrameTests(unittest.TestCase):
+    def test_accepts_alpaca_layout(self):
+        frame = normalize_price_frame(make_prices([100, 101, 102]))
+        self.assertIsInstance(frame.index, pd.DatetimeIndex)
+        self.assertEqual(
+            list(frame.columns), ["open", "high", "low", "close", "volume"]
+        )
+
+    def test_strips_timezone_and_sorts(self):
+        prices = make_prices([100, 101, 102])
+        prices["timestamp"] = prices["timestamp"].dt.tz_localize("UTC")
+        prices = prices.iloc[::-1]  # reversed order on purpose
+        frame = normalize_price_frame(prices)
+        self.assertIsNone(frame.index.tz)
+        self.assertTrue(frame.index.is_monotonic_increasing)
+
+    def test_rejects_empty_and_missing_columns(self):
+        with self.assertRaises(ValueError):
+            normalize_price_frame(pd.DataFrame())
+        with self.assertRaises(ValueError):
+            normalize_price_frame(pd.DataFrame({"timestamp": ["2026-01-05"], "close": [1.0]}))
+
+
+class RunBacktestTests(unittest.TestCase):
+    def test_hold_only_keeps_cash_flat(self):
+        prices = make_prices([100, 120, 80, 150])
+        result = run_backtest(prices, {"2026-01-05": "HOLD"}, initial_cash=10_000)
+        self.assertAlmostEqual(result.equity_curve.iloc[-1], 10_000.0)
+        self.assertEqual(result.orders, [])
+        self.assertEqual(result.metrics["num_trades"], 0)
+
+    def test_buy_captures_uptrend(self):
+        closes = [100 + i for i in range(30)]
+        prices = make_prices(closes)
+        result = run_backtest(
+            prices, {"2026-01-05": "BUY"}, initial_cash=100_000, commission=0.0
+        )
+        self.assertGreater(result.equity_curve.iloc[-1], 100_000.0)
+        self.assertEqual(result.orders[0]["side"], "buy")
+
+    def test_no_lookahead_signal_fills_at_next_open(self):
+        # The signal-day close is 100 but the next open gaps to 200. A leaky
+        # engine filling at the signal-day close would buy 40 shares at 100
+        # and end at 14,000; correct next-open execution buys at 200 and the
+        # equity never captures the jump. (position_pct is small enough that
+        # the gapped-up order stays affordable.)
+        prices = make_prices(
+            closes=[100, 200, 200, 200],
+            opens=[100, 200, 200, 200],
+        )
+        result = run_backtest(
+            prices,
+            {"2026-01-05": "BUY"},
+            initial_cash=10_000,
+            commission=0.0,
+            position_pct=0.4,
+        )
+        self.assertEqual(result.orders[0]["date"], "2026-01-06")
+        self.assertAlmostEqual(result.orders[0]["price"], 200.0)
+        self.assertAlmostEqual(result.equity_curve.iloc[-1], 10_000.0, delta=1.0)
+
+    def test_unaffordable_gap_order_is_reported_not_silent(self):
+        # Full-size order computed at close=100 becomes unaffordable at the
+        # 200 open; the engine must record the rejection.
+        prices = make_prices(closes=[100, 200, 200], opens=[100, 200, 200])
+        result = run_backtest(
+            prices, {"2026-01-05": "BUY"}, initial_cash=10_000, commission=0.0
+        )
+        self.assertEqual(result.orders, [])
+        self.assertEqual(len(result.rejected_orders), 1)
+        self.assertEqual(result.rejected_orders[0]["status"], "margin")
+
+    def test_sell_when_flat_without_shorts_does_nothing(self):
+        prices = make_prices([100, 90, 80, 70])
+        result = run_backtest(
+            prices, {"2026-01-05": "SELL"}, initial_cash=10_000, allow_shorts=False
+        )
+        self.assertAlmostEqual(result.equity_curve.iloc[-1], 10_000.0)
+        self.assertEqual(result.orders, [])
+
+    def test_short_profits_in_downtrend_when_allowed(self):
+        closes = [100 - 2 * i for i in range(20)]
+        prices = make_prices(closes)
+        result = run_backtest(
+            prices,
+            {"2026-01-05": "SELL"},
+            initial_cash=100_000,
+            commission=0.0,
+            allow_shorts=True,
+        )
+        self.assertGreater(result.equity_curve.iloc[-1], 100_000.0)
+        self.assertEqual(result.orders[0]["side"], "sell")
+
+    def test_round_trip_produces_closed_trade(self):
+        closes = [100, 100, 110, 120, 120, 120]
+        prices = make_prices(closes)
+        result = run_backtest(
+            prices,
+            {"2026-01-05": "BUY", "2026-01-08": "SELL"},
+            initial_cash=100_000,
+            commission=0.0,
+        )
+        self.assertEqual(len(result.trade_pnls), 1)
+        self.assertGreater(result.trade_pnls[0], 0.0)
+        self.assertEqual(result.metrics["win_rate"], 1.0)
+
+    def test_weekend_signal_applies_on_next_bar(self):
+        # Business days 2026-01-05..09 and 12..13; 2026-01-10 is a Saturday,
+        # so the buy applies on Monday the 12th and fills at Tuesday's open.
+        prices = make_prices([100, 101, 102, 103, 104, 105, 106])
+        result = run_backtest(
+            prices, {"2026-01-10": "BUY"}, initial_cash=10_000, commission=0.0
+        )
+        self.assertEqual(len(result.orders), 1)
+        self.assertEqual(result.orders[0]["date"], "2026-01-13")
+
+    def test_commission_reduces_final_equity(self):
+        closes = [100] * 10
+        prices = make_prices(closes)
+        signals = {"2026-01-05": "BUY", "2026-01-09": "SELL"}
+        free = run_backtest(prices, signals, initial_cash=10_000, commission=0.0)
+        costly = run_backtest(prices, signals, initial_cash=10_000, commission=0.01)
+        self.assertLess(
+            costly.equity_curve.iloc[-1], free.equity_curve.iloc[-1]
+        )
+
+    def test_result_to_dict_is_json_serializable(self):
+        prices = make_prices([100, 101, 102])
+        result = run_backtest(prices, {"2026-01-05": "BUY"})
+        payload = json.dumps(result.to_dict())
+        self.assertIn("cumulative_return", payload)
+
+
+class WalkForwardTests(unittest.TestCase):
+    def test_windows_partition_all_bars(self):
+        prices = make_prices([100 + i for i in range(50)])
+        result = run_walk_forward(
+            prices, {"2026-01-05": "BUY"}, window_bars=20, commission=0.0
+        )
+        self.assertEqual(sum(w["bars"] for w in result.windows), 50)
+        # 20 + 20 + 10 -> the 10-bar remainder stands alone (>= min_window_bars)
+        self.assertEqual([w["bars"] for w in result.windows], [20, 20, 10])
+
+    def test_short_remainder_folds_into_last_window(self):
+        prices = make_prices([100 + i for i in range(43)])
+        result = run_walk_forward(
+            prices, {"2026-01-05": "BUY"}, window_bars=20, min_window_bars=5
+        )
+        self.assertEqual([w["bars"] for w in result.windows], [20, 23])
+
+    def test_each_window_has_metrics_and_full_period_present(self):
+        prices = make_prices([100 + i for i in range(30)])
+        result = run_walk_forward(prices, {"2026-01-05": "BUY"}, window_bars=10)
+        for window in result.windows:
+            self.assertIn("sharpe_ratio", window["metrics"])
+            self.assertIn("max_drawdown", window["metrics"])
+        self.assertIsNotNone(result.full_period)
+        self.assertEqual(result.full_period.metrics["num_periods"], 29)
+
+    def test_rejects_tiny_window(self):
+        prices = make_prices([100, 101, 102])
+        with self.assertRaises(ValueError):
+            run_walk_forward(prices, {}, window_bars=1)
+
+
+class RunRecordedBacktestTests(unittest.TestCase):
+    def test_end_to_end_with_recorded_runs_and_injected_prices(self):
+        closes = [100 + i for i in range(15)]
+        prices = make_prices(closes, start="2026-01-05")
+
+        def fake_loader(symbol, start, end):
+            self.assertEqual(symbol, "AAPL")
+            return prices
+
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "BUY")
+            write_run_log(root, "AAPL", "2026-01-12", "SELL")
+            result = run_recorded_backtest(
+                "AAPL",
+                eval_results_dir=root,
+                price_loader=fake_loader,
+                commission=0.0,
+            )
+        self.assertEqual(result.signals_used, 2)
+        self.assertEqual(len(result.trade_pnls), 1)
+        self.assertGreater(result.metrics["cumulative_return"], 0.0)
+
+    def test_raises_without_recorded_signals(self):
+        with tempfile.TemporaryDirectory() as root:
+            with self.assertRaises(ValueError):
+                run_recorded_backtest("AAPL", eval_results_dir=root)
+
+    def test_signals_before_start_date_are_dropped(self):
+        prices = make_prices([100 + i for i in range(10)], start="2026-02-02")
+
+        def fake_loader(symbol, start, end):
+            self.assertEqual(start, "2026-02-02")
+            return prices
+
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "SELL")
+            write_run_log(root, "AAPL", "2026-02-03", "BUY")
+            result = run_recorded_backtest(
+                "AAPL",
+                start_date="2026-02-02",
+                eval_results_dir=root,
+                price_loader=fake_loader,
+            )
+        self.assertEqual(result.signals_used, 1)
+
+    def test_raises_when_all_signals_predate_start(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "BUY")
+            with self.assertRaises(ValueError):
+                run_recorded_backtest(
+                    "AAPL", start_date="2026-06-01", eval_results_dir=root,
+                    price_loader=lambda s, a, b: make_prices([1, 2]),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_backtest_teach.py
+++ b/tests/test_backtest_teach.py
@@ -1,0 +1,294 @@
+"""Tests for the backtest -> self-learning-memory bridge (intensive teaching).
+
+The bridge replays decisions this deployment already recorded under
+eval_results/ against historical prices, computes each decision's realized
+outcome with the same next-open execution discipline the backtest engine
+uses, and injects one dated lesson per decision into the persistent
+per-agent ChromaDB memories — idempotently, so re-teaching never duplicates.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+import pandas as pd
+
+from tradingagents.agents.utils.memory import FinancialSituationMemory
+from tradingagents.backtest.teach import (
+    compute_decision_outcomes,
+    teach_memories_from_history,
+)
+
+
+def _fake_embedding(text):
+    seed = float(sum(ord(c) for c in text) % 97)
+    return [seed / 97.0 + i * 0.01 for i in range(8)]
+
+
+def _enable_fake_embeddings(memory):
+    memory.embeddings_enabled = True
+    memory.get_embedding = _fake_embedding
+
+
+def _make_memories():
+    # Unique collection names per call: chroma's ephemeral client is shared
+    # process-wide, so a fixed name would leak lessons between tests.
+    import uuid
+
+    suffix = uuid.uuid4().hex[:8]
+    names = ["bull", "bear", "trader", "invest_judge", "risk_manager"]
+    memories = {}
+    for name in names:
+        memory = FinancialSituationMemory(f"teach_test_{name}_{suffix}")
+        _enable_fake_embeddings(memory)
+        memories[name] = memory
+    return memories
+
+
+def _price_frame(start="2025-01-06", days=15, opens=None):
+    dates = pd.bdate_range(start=start, periods=days)
+    if opens is None:
+        opens = [100.0 + i for i in range(days)]
+    return pd.DataFrame(
+        {
+            "timestamp": dates,
+            "open": opens,
+            "high": [o + 1.0 for o in opens],
+            "low": [o - 1.0 for o in opens],
+            "close": [o + 0.5 for o in opens],
+            "volume": [1_000.0] * days,
+        }
+    )
+
+
+def _write_run(root, symbol, trade_date, final_signal, final_state=None, status="completed"):
+    runs_dir = Path(root) / symbol / "TradingAgentsStrategy_logs" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    started = f"{trade_date}T10:00:00+00:00"
+    payload = {
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "started_at": started,
+        "status": status,
+        "summary": {"final_signal": final_signal},
+        "snapshots": {"final_state": final_state} if final_state is not None else {},
+    }
+    name = f"{trade_date}_run.json"
+    (runs_dir / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _final_state(text):
+    return {
+        "market_report": f"market: {text}",
+        "sentiment_report": f"sentiment: {text}",
+        "news_report": f"news: {text}",
+        "fundamentals_report": f"fundamentals: {text}",
+        "final_trade_decision": f"decision text for {text}",
+    }
+
+
+class ComputeDecisionOutcomesTests(unittest.TestCase):
+    def test_buy_enters_next_open_and_exits_horizon_open(self):
+        prices = _price_frame(days=10)  # opens 100..109
+        outcomes = compute_decision_outcomes(
+            prices, {"2025-01-06": "BUY"}, horizon_bars=3
+        )
+        self.assertEqual(len(outcomes), 1)
+        out = outcomes[0]
+        # Decision on the first bar's date -> entry at second bar's open (101),
+        # exit 3 bars later at open 104.
+        self.assertEqual(out["entry_price"], 101.0)
+        self.assertEqual(out["exit_price"], 104.0)
+        self.assertAlmostEqual(out["asset_return"], 104.0 / 101.0 - 1.0)
+        self.assertAlmostEqual(out["decision_return"], out["asset_return"])
+        self.assertFalse(out["partial"])
+
+    def test_sell_decision_return_is_negated(self):
+        prices = _price_frame(days=10)
+        outcomes = compute_decision_outcomes(
+            prices, {"2025-01-06": "SELL"}, horizon_bars=3
+        )
+        out = outcomes[0]
+        self.assertAlmostEqual(out["decision_return"], -(out["asset_return"]))
+
+    def test_hold_decision_return_is_zero_but_asset_move_kept(self):
+        prices = _price_frame(days=10)
+        outcomes = compute_decision_outcomes(
+            prices, {"2025-01-06": "HOLD"}, horizon_bars=3
+        )
+        out = outcomes[0]
+        self.assertEqual(out["decision_return"], 0.0)
+        self.assertGreater(out["asset_return"], 0.0)
+
+    def test_truncated_horizon_is_partial(self):
+        prices = _price_frame(days=5)
+        # Entry at bar 1, horizon 10 runs past the data -> exit at last bar.
+        outcomes = compute_decision_outcomes(
+            prices, {"2025-01-06": "BUY"}, horizon_bars=10
+        )
+        out = outcomes[0]
+        self.assertTrue(out["partial"])
+        self.assertEqual(out["exit_price"], 104.0)
+
+    def test_signal_on_or_after_last_bar_is_skipped(self):
+        prices = _price_frame(days=5)  # last bar 2025-01-10
+        outcomes = compute_decision_outcomes(
+            prices, {"2025-01-10": "BUY", "2025-02-01": "BUY"}, horizon_bars=3
+        )
+        self.assertEqual(outcomes, [])
+
+    def test_weekend_signal_applies_to_next_bar(self):
+        prices = _price_frame(days=10)
+        # Saturday decision -> entry at Monday+1 bar open.
+        outcomes = compute_decision_outcomes(
+            prices, {"2025-01-11": "BUY"}, horizon_bars=2
+        )
+        self.assertEqual(len(outcomes), 1)
+        # First bar strictly after 2025-01-11 is Mon 2025-01-13 (open 105).
+        self.assertEqual(outcomes[0]["entry_price"], 105.0)
+
+
+class TeachMemoriesTests(unittest.TestCase):
+    def _teach(self, root, memories, **kwargs):
+        prices = _price_frame(days=15)
+        return teach_memories_from_history(
+            "AAPL",
+            memories,
+            price_loader=lambda symbol, start, end: prices,
+            eval_results_dir=root,
+            horizon_bars=3,
+            **kwargs,
+        )
+
+    def test_deterministic_lessons_written_to_all_memories(self):
+        memories = _make_memories()
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as root:
+            _write_run(root, "AAPL", "2025-01-06", "BUY", _final_state("day one"))
+            _write_run(root, "AAPL", "2025-01-08", "SELL", _final_state("day three"))
+            summary = self._teach(root, memories)
+
+        self.assertEqual(summary["decisions_taught"], 2)
+        for memory in memories.values():
+            self.assertEqual(memory.situation_collection.count(), 2)
+
+        # The lesson stored against the day-one situation carries the
+        # realized outcome. (The fake embedding is not semantic, so query
+        # with the exact situation text instead of a fragment.)
+        day_one = _final_state("day one")
+        situation = "\n\n".join(
+            day_one[k]
+            for k in (
+                "market_report",
+                "sentiment_report",
+                "news_report",
+                "fundamentals_report",
+            )
+        )
+        matches = memories["trader"].get_memories(situation, n_matches=1)
+        self.assertEqual(len(matches), 1)
+        self.assertIn("%", matches[0]["recommendation"])
+        self.assertIn("BUY", matches[0]["recommendation"])
+
+    def test_teaching_is_idempotent(self):
+        memories = _make_memories()
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as root:
+            _write_run(root, "AAPL", "2025-01-06", "BUY", _final_state("day one"))
+            first = self._teach(root, memories)
+            second = self._teach(root, memories)
+
+        self.assertEqual(first["decisions_taught"], 1)
+        self.assertEqual(second["decisions_taught"], 0)
+        self.assertEqual(second["decisions_skipped_duplicate"], 1)
+        for memory in memories.values():
+            self.assertEqual(memory.situation_collection.count(), 1)
+
+    def test_lessons_are_tagged_for_later_maintenance(self):
+        memories = _make_memories()
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as root:
+            _write_run(root, "AAPL", "2025-01-06", "BUY", _final_state("day one"))
+            self._teach(root, memories)
+
+        stored = memories["bull"].situation_collection.get(include=["metadatas"])
+        meta = stored["metadatas"][0]
+        self.assertEqual(meta["source"], "backtest_teach")
+        self.assertEqual(meta["symbol"], "AAPL")
+        self.assertEqual(meta["trade_date"], "2025-01-06")
+        self.assertEqual(meta["action"], "BUY")
+
+    def test_decision_without_final_state_is_skipped(self):
+        memories = _make_memories()
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as root:
+            _write_run(root, "AAPL", "2025-01-06", "BUY", final_state=None)
+            summary = self._teach(root, memories)
+
+        self.assertEqual(summary["decisions_taught"], 0)
+        self.assertEqual(summary["decisions_skipped_no_state"], 1)
+        for memory in memories.values():
+            self.assertEqual(memory.situation_collection.count(), 0)
+
+    def test_llm_mode_uses_reflector_lesson(self):
+        memories = _make_memories()
+        reflector = Mock()
+        reflector.reflect_on_final_decision.return_value = "LLM lesson about the trade"
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as root:
+            _write_run(root, "AAPL", "2025-01-06", "BUY", _final_state("day one"))
+            summary = self._teach(root, memories, reflector=reflector)
+
+        self.assertEqual(summary["decisions_taught"], 1)
+        reflector.reflect_on_final_decision.assert_called_once()
+        matches = memories["trader"].get_memories("market: day one", n_matches=1)
+        self.assertIn("LLM lesson", matches[0]["recommendation"])
+
+    def test_no_recorded_signals_raises(self):
+        memories = _make_memories()
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as root:
+            with self.assertRaises(ValueError):
+                self._teach(root, memories)
+
+
+class DefaultAgentMemoriesTests(unittest.TestCase):
+    def test_builds_the_five_reflection_memories(self):
+        from tradingagents.backtest.teach import default_agent_memories
+
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            memories = default_agent_memories({"agent_memory_dir": tmp})
+            self.assertEqual(
+                sorted(memories),
+                ["bear", "bull", "invest_judge", "risk_manager", "trader"],
+            )
+            # Collection names must match the ones TradingAgentsGraph uses,
+            # so taught lessons are retrieved by the live agents.
+            self.assertEqual(
+                memories["bull"].situation_collection.name, "bull_memory"
+            )
+
+
+class MemoryMetadataTests(unittest.TestCase):
+    def test_add_situations_accepts_extra_metadata(self):
+        memory = FinancialSituationMemory("teach_test_meta_memory")
+        _enable_fake_embeddings(memory)
+        memory.add_situations(
+            [("situation text", "advice text")],
+            extra_metadata={"source": "backtest_teach", "teach_key": "AAPL|2025-01-06"},
+        )
+        stored = memory.situation_collection.get(include=["metadatas"])
+        meta = stored["metadatas"][0]
+        self.assertEqual(meta["recommendation"], "advice text")
+        self.assertEqual(meta["teach_key"], "AAPL|2025-01-06")
+
+    def test_has_metadata_value(self):
+        memory = FinancialSituationMemory("teach_test_haskey_memory")
+        _enable_fake_embeddings(memory)
+        self.assertFalse(memory.has_metadata_value("teach_key", "AAPL|2025-01-06"))
+        memory.add_situations(
+            [("situation text", "advice text")],
+            extra_metadata={"teach_key": "AAPL|2025-01-06"},
+        )
+        self.assertTrue(memory.has_metadata_value("teach_key", "AAPL|2025-01-06"))
+        self.assertFalse(memory.has_metadata_value("teach_key", "AAPL|2025-01-07"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_backtest_webui.py
+++ b/tests/test_backtest_webui.py
@@ -16,6 +16,7 @@ class BacktestPanelWiringTests(unittest.TestCase):
             "backtest-run-btn",
             "backtest-equity-graph",
             "backtest-windows-table",
+            "backtest-slippage-model",
         ):
             self.assertIn(component_id, rendered)
 

--- a/tests/test_backtest_webui.py
+++ b/tests/test_backtest_webui.py
@@ -1,0 +1,74 @@
+"""Wiring tests for the backtest WebUI panel and callbacks."""
+
+import unittest
+
+import pandas as pd
+
+
+class BacktestPanelWiringTests(unittest.TestCase):
+    def test_panel_component_builds(self):
+        from webui.components.backtest_panel import create_backtest_panel
+
+        panel = create_backtest_panel()
+        rendered = str(panel)
+        for component_id in (
+            "backtest-symbol-input",
+            "backtest-run-btn",
+            "backtest-equity-graph",
+            "backtest-windows-table",
+        ):
+            self.assertIn(component_id, rendered)
+
+    def test_callbacks_register_on_fresh_app(self):
+        import dash
+
+        from webui.callbacks.backtest_callbacks import register_backtest_callbacks
+
+        app = dash.Dash(__name__, suppress_callback_exceptions=True)
+        register_backtest_callbacks(app)
+        # Callback map keys are derived from outputs.
+        self.assertTrue(
+            any("backtest-status" in key for key in app.callback_map),
+            f"backtest callback missing from callback map: {list(app.callback_map)}",
+        )
+
+    def test_metric_formatting_helpers(self):
+        from webui.callbacks.backtest_callbacks import _fmt_pct, _fmt_ratio
+
+        self.assertEqual(_fmt_pct(0.25), "+25.00%")
+        self.assertEqual(_fmt_pct(-0.031), "-3.10%")
+        self.assertEqual(_fmt_pct(None), "—")
+        self.assertEqual(_fmt_ratio(1.234), "1.23")
+        self.assertEqual(_fmt_ratio(None), "—")
+
+    def test_equity_figure_and_windows_table_render(self):
+        from webui.callbacks.backtest_callbacks import (
+            _build_equity_figure,
+            _build_windows_table,
+        )
+
+        curve = pd.Series(
+            [100.0, 101.0, 102.0],
+            index=pd.date_range("2026-01-05", periods=3),
+        )
+        figure = _build_equity_figure(curve, "AAPL")
+        self.assertEqual(len(figure.data), 1)
+
+        window = {
+            "start_date": "2026-01-05",
+            "end_date": "2026-02-05",
+            "bars": 21,
+            "metrics": {
+                "cumulative_return": 0.05,
+                "sharpe_ratio": 1.5,
+                "max_drawdown": 0.02,
+                "win_rate": 0.6,
+            },
+        }
+        # A single window adds nothing beyond the full-period metrics.
+        self.assertIsNone(_build_windows_table([window]))
+        self.assertIsNotNone(_build_windows_table([window, window]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_backtest_webui.py
+++ b/tests/test_backtest_webui.py
@@ -17,6 +17,8 @@ class BacktestPanelWiringTests(unittest.TestCase):
             "backtest-equity-graph",
             "backtest-windows-table",
             "backtest-slippage-model",
+            "backtest-teach-btn",
+            "backtest-teach-status",
         ):
             self.assertIn(component_id, rendered)
 
@@ -31,6 +33,10 @@ class BacktestPanelWiringTests(unittest.TestCase):
         self.assertTrue(
             any("backtest-status" in key for key in app.callback_map),
             f"backtest callback missing from callback map: {list(app.callback_map)}",
+        )
+        self.assertTrue(
+            any("backtest-teach-status" in key for key in app.callback_map),
+            f"teach callback missing from callback map: {list(app.callback_map)}",
         )
 
     def test_metric_formatting_helpers(self):

--- a/tests/test_data_fallback.py
+++ b/tests/test_data_fallback.py
@@ -25,6 +25,32 @@ class DataFallbackTests(unittest.TestCase):
         self.assertTrue(result.empty)
         yf_download.assert_not_called()
 
+    def test_nginx_401_html_error_triggers_fallback(self):
+        # Alpaca auth failures can surface as a raw nginx HTML page that says
+        # "401 Authorization Required" without the word "unauthorized".
+        fallback = pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2026-01-01", "2026-01-02"]),
+                "Open": [10.0, 11.0],
+                "High": [12.0, 12.5],
+                "Low": [9.5, 10.5],
+                "Close": [11.5, 12.0],
+                "Volume": [1000, 1100],
+            }
+        ).set_index("Date")
+
+        set_config({**self.original_config, "data_fallback_enabled": True})
+        nginx_error = ValueError(
+            "<html>\n<head><title>401 Authorization Required</title></head>\n</html>"
+        )
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_stock_client",
+            side_effect=nginx_error,
+        ), patch("yfinance.download", return_value=fallback):
+            result = AlpacaUtils.get_stock_data("AAPL", "2026-01-01", "2026-01-03")
+
+        self.assertFalse(result.empty)
+
     def test_yfinance_fallback_normalizes_ohlcv_columns(self):
         fallback = pd.DataFrame(
             {

--- a/tests/test_self_learning_memory.py
+++ b/tests/test_self_learning_memory.py
@@ -1,0 +1,249 @@
+"""Tests for the self-learning memory loop: persistence, snapshot recovery,
+and outcome-driven reflection into the per-agent ChromaDB memories."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from tradingagents.agents.utils.memory import FinancialSituationMemory
+from tradingagents.graph.reflection import Reflector
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.run_logger import load_final_state_snapshot
+
+
+def _fake_embedding(text):
+    # Deterministic 8-dim embedding so similar texts produce similar vectors.
+    seed = float(sum(ord(c) for c in text) % 97)
+    return [seed / 97.0 + i * 0.01 for i in range(8)]
+
+
+def _enable_fake_embeddings(memory):
+    memory.embeddings_enabled = True
+    memory.get_embedding = _fake_embedding
+
+
+class MemoryPersistenceTests(unittest.TestCase):
+    def test_default_memory_stays_in_process(self):
+        memory = FinancialSituationMemory("ephemeral_test_memory")
+        self.assertEqual(type(memory.chroma_client).__name__, "Client")
+
+    def test_persistent_memory_survives_reopen(self):
+        # ignore_cleanup_errors: chromadb keeps its store files open on
+        # Windows, so temp-dir removal can race the process handle.
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            config = {"agent_memory_dir": tmp}
+
+            first = FinancialSituationMemory("persist_test_memory", config)
+            _enable_fake_embeddings(first)
+            first.add_situations(
+                [("High inflation with rising rates", "Prefer defensive sectors")]
+            )
+            self.assertEqual(first.situation_collection.count(), 1)
+
+            second = FinancialSituationMemory("persist_test_memory", config)
+            _enable_fake_embeddings(second)
+            self.assertEqual(second.situation_collection.count(), 1)
+
+            matches = second.get_memories("High inflation with rising rates", n_matches=1)
+            self.assertEqual(len(matches), 1)
+            self.assertEqual(matches[0]["recommendation"], "Prefer defensive sectors")
+
+    def test_ids_do_not_collide_across_instances(self):
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            config = {"agent_memory_dir": tmp}
+            for i in range(3):
+                memory = FinancialSituationMemory("collision_test_memory", config)
+                _enable_fake_embeddings(memory)
+                memory.add_situations([(f"situation {i}", f"advice {i}")])
+            final = FinancialSituationMemory("collision_test_memory", config)
+            self.assertEqual(final.situation_collection.count(), 3)
+
+    def test_empty_agent_memory_dir_means_ephemeral(self):
+        memory = FinancialSituationMemory("cfg_test_memory", {"agent_memory_dir": ""})
+        self.assertEqual(type(memory.chroma_client).__name__, "Client")
+
+
+def _write_run(root, symbol, trade_date, status="completed", final_state=None, started_at=None):
+    runs_dir = Path(root) / symbol / "TradingAgentsStrategy_logs" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    started = started_at or f"{trade_date}T10:00:00+00:00"
+    payload = {
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "started_at": started,
+        "status": status,
+        "snapshots": {"final_state": final_state} if final_state is not None else {},
+    }
+    name = f"{trade_date}_{started.replace(':', '').replace('+', '')}.json"
+    (runs_dir / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+class LoadFinalStateSnapshotTests(unittest.TestCase):
+    def test_returns_latest_completed_snapshot_for_date(self):
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(
+                root, "AAPL", "2026-01-05",
+                final_state={"market_report": "old"},
+                started_at="2026-01-05T09:00:00+00:00",
+            )
+            _write_run(
+                root, "AAPL", "2026-01-05",
+                final_state={"market_report": "new"},
+                started_at="2026-01-05T15:00:00+00:00",
+            )
+            snapshot = load_final_state_snapshot("AAPL", "2026-01-05", eval_results_dir=root)
+        self.assertEqual(snapshot, {"market_report": "new"})
+
+    def test_ignores_failed_runs_other_dates_and_missing_snapshots(self):
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(root, "AAPL", "2026-01-05", status="failed",
+                       final_state={"market_report": "failed"})
+            _write_run(root, "AAPL", "2026-01-06", final_state={"market_report": "other day"})
+            _write_run(root, "AAPL", "2026-01-05", final_state=None)
+            self.assertIsNone(
+                load_final_state_snapshot("AAPL", "2026-01-05", eval_results_dir=root)
+            )
+
+    def test_missing_directory_returns_none(self):
+        self.assertIsNone(
+            load_final_state_snapshot("ZZZZ", "2026-01-05", eval_results_dir="no_such_dir")
+        )
+
+    def test_crypto_symbol_is_sanitized(self):
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(root, "BTC_USD", "2026-01-05", final_state={"market_report": "btc"})
+            snapshot = load_final_state_snapshot("BTC/USD", "2026-01-05", eval_results_dir=root)
+        self.assertEqual(snapshot, {"market_report": "btc"})
+
+
+def _full_state():
+    return {
+        "market_report": "market",
+        "sentiment_report": "sentiment",
+        "news_report": "news",
+        "fundamentals_report": "fundamentals",
+        "investment_debate_state": {
+            "bull_history": "bull said",
+            "bear_history": "bear said",
+            "judge_decision": "judge decided",
+        },
+        "trader_investment_plan": "trader plan",
+        "risk_debate_state": {"judge_decision": "risk decision"},
+    }
+
+
+class ReflectOnOutcomeTests(unittest.TestCase):
+    def _reflector(self):
+        llm = Mock()
+        llm.invoke.return_value = Mock(content="lesson learned")
+        return Reflector(llm)
+
+    def test_all_components_reflect_and_store(self):
+        reflector = self._reflector()
+        memories = {
+            name: Mock()
+            for name in ("bull", "bear", "trader", "invest_judge", "risk_manager")
+        }
+        results = reflector.reflect_on_outcome(_full_state(), "+5.0% realized", memories)
+
+        self.assertEqual(set(results), set(memories))
+        self.assertTrue(all(results.values()))
+        for memory in memories.values():
+            memory.add_situations.assert_called_once()
+            (pairs,), _ = memory.add_situations.call_args
+            situation, lesson = pairs[0]
+            self.assertIn("market", situation)
+            self.assertEqual(lesson, "lesson learned")
+
+    def test_one_failure_does_not_block_other_components(self):
+        reflector = self._reflector()
+        memories = {
+            "bull": Mock(add_situations=Mock(side_effect=RuntimeError("chroma down"))),
+            "trader": Mock(),
+        }
+        results = reflector.reflect_on_outcome(_full_state(), "-2.0% realized", memories)
+        self.assertFalse(results["bull"])
+        self.assertTrue(results["trader"])
+        memories["trader"].add_situations.assert_called_once()
+
+    def test_missing_memories_are_skipped(self):
+        reflector = self._reflector()
+        results = reflector.reflect_on_outcome(_full_state(), "+1.0%", {"bull": Mock()})
+        self.assertEqual(set(results), {"bull"})
+
+
+class OutcomeReflectionWiringTests(unittest.TestCase):
+    """Exercise TradingAgentsGraph._reflect_agents_on_outcome via a stub self."""
+
+    def _fake_graph(self, enabled=True):
+        fake = Mock(spec=TradingAgentsGraph)
+        fake.config = {"reflection_on_outcome_enabled": enabled}
+        fake.reflector = Mock()
+        for name in (
+            "bull_memory",
+            "bear_memory",
+            "trader_memory",
+            "invest_judge_memory",
+            "risk_manager_memory",
+        ):
+            setattr(fake, name, Mock())
+        return fake
+
+    def test_resolved_outcome_triggers_reflection_with_recovered_state(self):
+        fake = self._fake_graph()
+        state = _full_state()
+        with patch(
+            "tradingagents.run_logger.load_final_state_snapshot", return_value=state
+        ):
+            TradingAgentsGraph._reflect_agents_on_outcome(
+                fake, "AAPL", "2026-01-05", 0.05, 0.02, 5
+            )
+        fake.reflector.reflect_on_outcome.assert_called_once()
+        args, _ = fake.reflector.reflect_on_outcome.call_args
+        passed_state, returns_losses, memories = args
+        self.assertIs(passed_state, state)
+        self.assertIn("+5.0%", returns_losses)
+        self.assertIn("+2.0%", returns_losses)
+        self.assertEqual(
+            set(memories),
+            {"bull", "bear", "trader", "invest_judge", "risk_manager"},
+        )
+
+    def test_disabled_flag_skips_reflection(self):
+        fake = self._fake_graph(enabled=False)
+        with patch(
+            "tradingagents.run_logger.load_final_state_snapshot"
+        ) as loader:
+            TradingAgentsGraph._reflect_agents_on_outcome(
+                fake, "AAPL", "2026-01-05", 0.05, None, 5
+            )
+        loader.assert_not_called()
+        fake.reflector.reflect_on_outcome.assert_not_called()
+
+    def test_missing_snapshot_skips_reflection(self):
+        fake = self._fake_graph()
+        with patch(
+            "tradingagents.run_logger.load_final_state_snapshot", return_value=None
+        ):
+            TradingAgentsGraph._reflect_agents_on_outcome(
+                fake, "AAPL", "2026-01-05", 0.05, None, 5
+            )
+        fake.reflector.reflect_on_outcome.assert_not_called()
+
+    def test_reflection_errors_never_propagate(self):
+        fake = self._fake_graph()
+        fake.reflector.reflect_on_outcome.side_effect = RuntimeError("llm down")
+        with patch(
+            "tradingagents.run_logger.load_final_state_snapshot",
+            return_value=_full_state(),
+        ):
+            # Must not raise: outcome reflection is strictly best-effort.
+            TradingAgentsGraph._reflect_agents_on_outcome(
+                fake, "AAPL", "2026-01-05", 0.05, None, 5
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trading_graph_mocked.py
+++ b/tests/test_trading_graph_mocked.py
@@ -67,7 +67,9 @@ def _final_state(ticker, trade_date):
 
 class MockedTradingGraphTests(unittest.TestCase):
     def test_propagate_preserves_macro_and_safe_paths_with_checkpoint(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        # ignore_cleanup_errors: chromadb holds its store files open on
+        # Windows, so temp-dir removal can race the process handle.
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             tmp_path = Path(tmp)
             for ticker, safe_ticker in (("AAPL", "AAPL"), ("BTC/USD", "BTC_USD")):
                 with self.subTest(ticker=ticker):
@@ -81,6 +83,7 @@ class MockedTradingGraphTests(unittest.TestCase):
                             "data_cache_dir": str(tmp_path / f"cache-{safe_ticker}"),
                             "results_dir": str(tmp_path / "results"),
                             "memory_log_path": str(tmp_path / f"memory-{safe_ticker}.md"),
+                            "agent_memory_dir": str(tmp_path / f"agent-memory-{safe_ticker}"),
                             "checkpoint_enabled": True,
                         }
                     )
@@ -113,7 +116,9 @@ class MockedTradingGraphTests(unittest.TestCase):
         ]
 
         for provider, provider_config, expected_key, expected_value in cases:
-            with self.subTest(provider=provider), tempfile.TemporaryDirectory() as tmp:
+            with self.subTest(provider=provider), tempfile.TemporaryDirectory(
+                ignore_cleanup_errors=True
+            ) as tmp:
                 calls = []
 
                 def fake_create_llm_client(**kwargs):
@@ -129,6 +134,7 @@ class MockedTradingGraphTests(unittest.TestCase):
                         "data_cache_dir": str(Path(tmp) / "cache"),
                         "results_dir": str(Path(tmp) / "results"),
                         "memory_log_path": str(Path(tmp) / "memory.md"),
+                        "agent_memory_dir": str(Path(tmp) / "agent-memory"),
                         **provider_config,
                     }
                 )

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -59,8 +59,14 @@ class FinancialSituationMemory:
                 self._warned_embedding_failure = True
             return None
 
-    def add_situations(self, situations_and_advice):
-        """Add financial situations and their corresponding advice. Parameter is a list of tuples (situation, rec)"""
+    def add_situations(self, situations_and_advice, extra_metadata=None):
+        """Add financial situations and their corresponding advice.
+
+        `situations_and_advice` is a list of (situation, recommendation)
+        tuples. `extra_metadata`, when given, is merged into every entry's
+        metadata — used e.g. by batch teaching to tag lessons with their
+        source and an idempotency key.
+        """
         if not self.embeddings_enabled:
             return
 
@@ -85,10 +91,20 @@ class FinancialSituationMemory:
 
         self.situation_collection.add(
             documents=situations,
-            metadatas=[{"recommendation": rec} for rec in advice],
+            metadatas=[
+                {**(extra_metadata or {}), "recommendation": rec} for rec in advice
+            ],
             embeddings=embeddings,
             ids=ids,
         )
+
+    def has_metadata_value(self, key, value) -> bool:
+        """True when any stored entry carries `key == value` in its metadata."""
+        try:
+            found = self.situation_collection.get(where={key: value}, limit=1)
+        except Exception:
+            return False
+        return bool(found and found.get("ids"))
 
     def get_memories(self, current_situation, n_matches=1):
         """Find matching recommendations using OpenAI embeddings"""

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -4,18 +4,29 @@ from openai import OpenAI
 import numpy as np
 from pathlib import Path
 import re
+import uuid
 from tradingagents.dataflows.config import get_openai_client_config, get_openai_embedding_model
 from tradingagents.agents.utils.agent_trading_modes import extract_recommendation
 
 
 class FinancialSituationMemory:
-    def __init__(self, name):
+    def __init__(self, name, config: dict = None):
         client_config = get_openai_client_config()
         self.client = OpenAI(**client_config) if client_config else None
         self.embedding_model = get_openai_embedding_model()
         self.embeddings_enabled = self.client is not None
         self._warned_embedding_failure = False
-        self.chroma_client = chromadb.Client(Settings(allow_reset=True))
+        persist_dir = (config or {}).get("agent_memory_dir") or ""
+        if persist_dir:
+            # Persistent store: lessons written after outcome resolution
+            # survive process restarts, which is what makes the reflection
+            # loop cumulative instead of session-scoped.
+            Path(persist_dir).mkdir(parents=True, exist_ok=True)
+            self.chroma_client = chromadb.PersistentClient(
+                path=str(persist_dir), settings=Settings(allow_reset=True)
+            )
+        else:
+            self.chroma_client = chromadb.Client(Settings(allow_reset=True))
         self.situation_collection = self.chroma_client.get_or_create_collection(name=name)
 
     def get_embedding(self, text):
@@ -58,15 +69,15 @@ class FinancialSituationMemory:
         ids = []
         embeddings = []
 
-        offset = self.situation_collection.count()
-
-        for i, (situation, recommendation) in enumerate(situations_and_advice):
+        for situation, recommendation in situations_and_advice:
             embedding = self.get_embedding(situation)
             if embedding is None:
                 continue
             situations.append(situation)
             advice.append(recommendation)
-            ids.append(str(offset + i))
+            # Random ids: count-based ids collide across processes once the
+            # collection is persistent (two sessions can see the same count).
+            ids.append(uuid.uuid4().hex)
             embeddings.append(embedding)
 
         if not embeddings:

--- a/tradingagents/backtest/__init__.py
+++ b/tradingagents/backtest/__init__.py
@@ -1,0 +1,51 @@
+"""Deterministic backtesting and evaluation for agent trading decisions.
+
+Public surface:
+- run_backtest / run_walk_forward: replay dated BUY/SELL/HOLD signals over
+  OHLCV bars via backtrader with next-open execution (no lookahead).
+- run_recorded_backtest: evaluate the decisions already persisted under
+  eval_results/ without spending a single LLM call.
+- metrics: pure-math Sharpe / drawdown / win-rate helpers.
+"""
+
+from .engine import (
+    BacktestResult,
+    WalkForwardResult,
+    normalize_price_frame,
+    run_backtest,
+    run_recorded_backtest,
+    run_recorded_walk_forward,
+    run_walk_forward,
+)
+from .metrics import (
+    CRYPTO_DAYS_PER_YEAR,
+    TRADING_DAYS_PER_YEAR,
+    annualized_return,
+    cumulative_return,
+    max_drawdown,
+    sharpe_ratio,
+    summarize_performance,
+    win_rate,
+)
+from .signals import ACTION_ALIASES, load_recorded_signals, normalize_action
+
+__all__ = [
+    "ACTION_ALIASES",
+    "BacktestResult",
+    "CRYPTO_DAYS_PER_YEAR",
+    "TRADING_DAYS_PER_YEAR",
+    "WalkForwardResult",
+    "annualized_return",
+    "cumulative_return",
+    "load_recorded_signals",
+    "max_drawdown",
+    "normalize_action",
+    "normalize_price_frame",
+    "run_backtest",
+    "run_recorded_backtest",
+    "run_recorded_walk_forward",
+    "run_walk_forward",
+    "sharpe_ratio",
+    "summarize_performance",
+    "win_rate",
+]

--- a/tradingagents/backtest/__init__.py
+++ b/tradingagents/backtest/__init__.py
@@ -28,6 +28,11 @@ from .metrics import (
     win_rate,
 )
 from .signals import ACTION_ALIASES, load_recorded_signals, normalize_action
+from .teach import (
+    compute_decision_outcomes,
+    default_agent_memories,
+    teach_memories_from_history,
+)
 
 __all__ = [
     "ACTION_ALIASES",
@@ -36,7 +41,9 @@ __all__ = [
     "TRADING_DAYS_PER_YEAR",
     "WalkForwardResult",
     "annualized_return",
+    "compute_decision_outcomes",
     "cumulative_return",
+    "default_agent_memories",
     "load_recorded_signals",
     "max_drawdown",
     "normalize_action",
@@ -47,5 +54,6 @@ __all__ = [
     "run_walk_forward",
     "sharpe_ratio",
     "summarize_performance",
+    "teach_memories_from_history",
     "win_rate",
 ]

--- a/tradingagents/backtest/engine.py
+++ b/tradingagents/backtest/engine.py
@@ -24,6 +24,57 @@ from .metrics import (
 from .signals import load_recorded_signals
 
 
+_BPS = 1e-4  # one basis point as a fraction
+
+
+class _VolatilitySlippageBroker(bt.brokers.BackBroker):
+    """Backtesting broker whose slippage scales with recent volatility.
+
+    Each fill slips by ``vol_fraction`` of the previous completed bar's range
+    (high - low, as a fraction of its close), clamped to
+    [``min_bps``, ``max_bps``] basis points.  Calm tape costs little; wide
+    bars — where market orders realistically eat through the book — cost
+    more.  The fill-bar's own range is never used, so the model needs no
+    intrabar knowledge.
+    """
+
+    def __init__(self, vol_fraction=0.1, min_bps=1.0, max_bps=50.0):
+        super().__init__()
+        self._vol_fraction = float(vol_fraction)
+        self._min_perc = float(min_bps) * _BPS
+        self._max_perc = float(max_bps) * _BPS
+        self._slippage_feed = None
+        # Base-class slippage plumbing reads p.slip_perc; make fills at the
+        # open slip like set_slippage_perc() would.
+        self.p.slip_open = True
+        self.p.slip_match = True
+        self.p.slip_out = False
+
+    def set_slippage_feed(self, data) -> None:
+        self._slippage_feed = data
+
+    def _dynamic_perc(self) -> float:
+        feed = self._slippage_feed
+        try:
+            close = float(feed.close[-1])
+            bar_range = max(float(feed.high[-1]) - float(feed.low[-1]), 0.0)
+            if close <= 0:
+                return self._min_perc
+            perc = self._vol_fraction * bar_range / close
+        except (IndexError, TypeError, AttributeError):
+            # First bar (no completed predecessor) or no feed registered.
+            return self._min_perc
+        return min(max(perc, self._min_perc), self._max_perc)
+
+    def _slip_up(self, pmax, price, doslip=True, lim=False):
+        self.p.slip_perc = self._dynamic_perc()
+        return super()._slip_up(pmax, price, doslip=doslip, lim=lim)
+
+    def _slip_down(self, pmin, price, doslip=True, lim=False):
+        self.p.slip_perc = self._dynamic_perc()
+        return super()._slip_down(pmin, price, doslip=doslip, lim=lim)
+
+
 class _SignalReplayStrategy(bt.Strategy):
     """Executes an externally supplied {date: action} map, nothing else."""
 
@@ -101,6 +152,7 @@ class BacktestResult:
     start_date: Optional[str] = None
     end_date: Optional[str] = None
     rejected_orders: List[dict] = field(default_factory=list)
+    slippage: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
@@ -110,6 +162,7 @@ class BacktestResult:
             "end_date": self.end_date,
             "num_orders": len(self.orders),
             "rejected_orders": list(self.rejected_orders),
+            "slippage": dict(self.slippage),
             "equity_curve": {
                 ts.date().isoformat(): value
                 for ts, value in self.equity_curve.items()
@@ -171,12 +224,56 @@ def run_backtest(
     allow_shorts: bool = False,
     position_pct: float = 0.95,
     periods_per_year: int = TRADING_DAYS_PER_YEAR,
+    slippage_model: str = "fixed",
+    slippage_bps: float = 5.0,
+    slippage_vol_fraction: float = 0.1,
+    slippage_min_bps: float = 1.0,
+    slippage_max_bps: float = 50.0,
 ) -> BacktestResult:
-    """Replay dated signals over price history and measure performance."""
+    """Replay dated signals over price history and measure performance.
+
+    Slippage models (zero-slippage backtests systematically overstate
+    performance, so a small fixed cost is applied by default):
+
+    - ``"fixed"``: every fill slips by ``slippage_bps`` basis points against
+      the trade (default 5 bps).
+    - ``"volatility"``: the slip is ``slippage_vol_fraction`` of the previous
+      bar's high-low range (as a fraction of its close), clamped to
+      [``slippage_min_bps``, ``slippage_max_bps``] — cheap in calm tape,
+      expensive across wide bars.
+    - ``"none"``: frictionless fills (not recommended outside tests).
+    """
     frame = normalize_price_frame(prices)
 
     cerebro = bt.Cerebro()
-    cerebro.adddata(bt.feeds.PandasData(dataname=frame))
+    data_feed = bt.feeds.PandasData(dataname=frame)
+    cerebro.adddata(data_feed)
+
+    if slippage_model == "volatility":
+        broker = _VolatilitySlippageBroker(
+            vol_fraction=slippage_vol_fraction,
+            min_bps=slippage_min_bps,
+            max_bps=slippage_max_bps,
+        )
+        broker.set_slippage_feed(data_feed)
+        cerebro.setbroker(broker)
+        slippage_config = {
+            "model": "volatility",
+            "vol_fraction": float(slippage_vol_fraction),
+            "min_bps": float(slippage_min_bps),
+            "max_bps": float(slippage_max_bps),
+        }
+    elif slippage_model == "fixed":
+        if float(slippage_bps) > 0:
+            cerebro.broker.set_slippage_perc(float(slippage_bps) * _BPS)
+        slippage_config = {"model": "fixed", "bps": float(slippage_bps)}
+    elif slippage_model == "none":
+        slippage_config = {"model": "none"}
+    else:
+        raise ValueError(
+            f"Unknown slippage_model {slippage_model!r}; expected 'fixed', 'volatility', or 'none'."
+        )
+
     cerebro.broker.setcash(float(initial_cash))
     cerebro.broker.setcommission(commission=float(commission))
     cerebro.addstrategy(
@@ -204,6 +301,7 @@ def run_backtest(
         start_date=frame.index[0].date().isoformat(),
         end_date=frame.index[-1].date().isoformat(),
         rejected_orders=list(strategy.rejected_orders),
+        slippage=slippage_config,
     )
 
 

--- a/tradingagents/backtest/engine.py
+++ b/tradingagents/backtest/engine.py
@@ -1,0 +1,335 @@
+"""Walk-forward backtesting engine built on backtrader.
+
+The engine replays a series of dated BUY/SELL/HOLD signals against
+historical OHLCV bars. Orders are submitted when a bar closes and fill at
+the *next* bar's open (backtrader's default, cheat-on-open disabled), so a
+decision made on day t can never benefit from day t's own price — the same
+information-set discipline required to avoid lookahead bias in walk-forward
+evaluation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+import backtrader as bt
+import pandas as pd
+
+from .metrics import (
+    CRYPTO_DAYS_PER_YEAR,
+    TRADING_DAYS_PER_YEAR,
+    summarize_performance,
+)
+from .signals import load_recorded_signals
+
+
+class _SignalReplayStrategy(bt.Strategy):
+    """Executes an externally supplied {date: action} map, nothing else."""
+
+    params = (
+        ("signals", None),  # dict[str iso-date, "BUY"|"SELL"|"HOLD"]
+        ("allow_shorts", False),
+        ("position_pct", 0.95),  # fraction of portfolio value per full position
+    )
+
+    def __init__(self):
+        self.equity_dates: List[pd.Timestamp] = []
+        self.equity_values: List[float] = []
+        self.closed_trade_pnls: List[float] = []
+        self.executed_orders: List[dict] = []
+        self.rejected_orders: List[dict] = []
+        # Signals sorted by date so ones falling on non-trading days (weekends,
+        # halts) apply on the next available bar instead of silently dropping.
+        self._pending = sorted((self.p.signals or {}).items())
+        self._cursor = 0
+
+    def _consume_signals_up_to(self, bar_date: str) -> Optional[str]:
+        action = None
+        while self._cursor < len(self._pending) and self._pending[self._cursor][0] <= bar_date:
+            action = self._pending[self._cursor][1]
+            self._cursor += 1
+        return action
+
+    def next(self):
+        bar_date = self.data.datetime.date(0)
+        self.equity_dates.append(pd.Timestamp(bar_date))
+        self.equity_values.append(float(self.broker.getvalue()))
+
+        action = self._consume_signals_up_to(bar_date.isoformat())
+        if action == "BUY":
+            self.order_target_percent(target=self.p.position_pct)
+        elif action == "SELL":
+            target = -self.p.position_pct if self.p.allow_shorts else 0.0
+            self.order_target_percent(target=target)
+        # HOLD / None: keep the current position untouched.
+
+    def notify_order(self, order):
+        if order.status == order.Completed:
+            self.executed_orders.append(
+                {
+                    "date": self.data.datetime.date(0).isoformat(),
+                    "side": "buy" if order.isbuy() else "sell",
+                    "size": float(order.executed.size),
+                    "price": float(order.executed.price),
+                }
+            )
+        elif order.status in (order.Margin, order.Rejected):
+            # Sizing uses the signal bar's close but fills at the next open;
+            # a large overnight gap can make the order unaffordable. Surface
+            # that instead of letting the trade vanish silently.
+            self.rejected_orders.append(
+                {
+                    "date": self.data.datetime.date(0).isoformat(),
+                    "side": "buy" if order.isbuy() else "sell",
+                    "status": "margin" if order.status == order.Margin else "rejected",
+                }
+            )
+
+    def notify_trade(self, trade):
+        if trade.isclosed:
+            self.closed_trade_pnls.append(float(trade.pnlcomm))
+
+
+@dataclass
+class BacktestResult:
+    equity_curve: pd.Series
+    trade_pnls: List[float]
+    orders: List[dict]
+    metrics: dict
+    signals_used: int
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    rejected_orders: List[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "metrics": dict(self.metrics),
+            "signals_used": self.signals_used,
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+            "num_orders": len(self.orders),
+            "rejected_orders": list(self.rejected_orders),
+            "equity_curve": {
+                ts.date().isoformat(): value
+                for ts, value in self.equity_curve.items()
+            },
+        }
+
+
+@dataclass
+class WalkForwardResult:
+    windows: List[dict] = field(default_factory=list)
+    full_period: Optional[BacktestResult] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "windows": list(self.windows),
+            "full_period": self.full_period.to_dict() if self.full_period else None,
+        }
+
+
+def normalize_price_frame(prices: pd.DataFrame) -> pd.DataFrame:
+    """Coerce an OHLCV frame into the shape backtrader's PandasData expects.
+
+    Accepts the ['timestamp', open, high, low, close, volume] layout produced
+    by AlpacaUtils.get_stock_data (any column casing) or a frame already
+    indexed by datetime. Raises ValueError on anything unusable.
+    """
+    if prices is None or len(prices) == 0:
+        raise ValueError("No price data supplied for backtest.")
+
+    frame = prices.copy()
+    frame.columns = [str(c).lower() for c in frame.columns]
+
+    if "timestamp" in frame.columns:
+        frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+        frame = frame.set_index("timestamp")
+    elif not isinstance(frame.index, pd.DatetimeIndex):
+        raise ValueError("Price data needs a 'timestamp' column or a DatetimeIndex.")
+
+    if getattr(frame.index, "tz", None) is not None:
+        frame.index = frame.index.tz_localize(None)
+
+    required = {"open", "high", "low", "close"}
+    missing = required - set(frame.columns)
+    if missing:
+        raise ValueError(f"Price data is missing columns: {sorted(missing)}")
+    if "volume" not in frame.columns:
+        frame["volume"] = 0.0
+
+    frame = frame[["open", "high", "low", "close", "volume"]].astype(float)
+    frame = frame[~frame.index.duplicated(keep="last")].sort_index()
+    return frame
+
+
+def run_backtest(
+    prices: pd.DataFrame,
+    signals: Dict[str, str],
+    initial_cash: float = 100_000.0,
+    commission: float = 0.001,
+    allow_shorts: bool = False,
+    position_pct: float = 0.95,
+    periods_per_year: int = TRADING_DAYS_PER_YEAR,
+) -> BacktestResult:
+    """Replay dated signals over price history and measure performance."""
+    frame = normalize_price_frame(prices)
+
+    cerebro = bt.Cerebro()
+    cerebro.adddata(bt.feeds.PandasData(dataname=frame))
+    cerebro.broker.setcash(float(initial_cash))
+    cerebro.broker.setcommission(commission=float(commission))
+    cerebro.addstrategy(
+        _SignalReplayStrategy,
+        signals=dict(signals or {}),
+        allow_shorts=allow_shorts,
+        position_pct=position_pct,
+    )
+    strategy = cerebro.run()[0]
+
+    equity_curve = pd.Series(
+        strategy.equity_values, index=strategy.equity_dates, dtype=float
+    )
+    metrics = summarize_performance(
+        equity_curve,
+        strategy.closed_trade_pnls,
+        periods_per_year=periods_per_year,
+    )
+    return BacktestResult(
+        equity_curve=equity_curve,
+        trade_pnls=list(strategy.closed_trade_pnls),
+        orders=list(strategy.executed_orders),
+        metrics=metrics,
+        signals_used=len(signals or {}),
+        start_date=frame.index[0].date().isoformat(),
+        end_date=frame.index[-1].date().isoformat(),
+        rejected_orders=list(strategy.rejected_orders),
+    )
+
+
+def run_walk_forward(
+    prices: pd.DataFrame,
+    signals: Dict[str, str],
+    window_bars: int = 63,
+    min_window_bars: int = 5,
+    **backtest_kwargs,
+) -> WalkForwardResult:
+    """Evaluate signals over consecutive non-overlapping out-of-sample windows.
+
+    LLM decision replay has no parameters to re-fit between folds, so the
+    walk-forward's purpose here is robustness: instead of one full-period
+    number, each ~quarterly window (63 trading bars by default) restarts with
+    fresh capital and reports its own metrics, exposing regime dependence a
+    single lucky backtest would hide. A trailing window shorter than
+    `min_window_bars` is folded into its predecessor.
+    """
+    frame = normalize_price_frame(prices)
+    if window_bars < 2:
+        raise ValueError("window_bars must be at least 2.")
+
+    boundaries = list(range(0, len(frame), window_bars))
+    windows: List[dict] = []
+    for start in boundaries:
+        end = start + window_bars
+        # Absorb a too-short trailing remainder into the final window.
+        if len(frame) - end < min_window_bars:
+            end = len(frame)
+        chunk = frame.iloc[start:end]
+        if len(chunk) < 2:
+            break
+        result = run_backtest(chunk, signals, **backtest_kwargs)
+        windows.append(
+            {
+                "start_date": result.start_date,
+                "end_date": result.end_date,
+                "bars": len(chunk),
+                "metrics": result.metrics,
+            }
+        )
+        if end == len(frame):
+            break
+
+    full = run_backtest(frame, signals, **backtest_kwargs)
+    return WalkForwardResult(windows=windows, full_period=full)
+
+
+def run_recorded_backtest(
+    symbol: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    eval_results_dir: str = "eval_results",
+    price_loader: Optional[Callable[[str, str, Optional[str]], pd.DataFrame]] = None,
+    **backtest_kwargs,
+) -> BacktestResult:
+    """Backtest the signals this deployment has already produced for `symbol`.
+
+    Pulls decisions from the persisted run logs (zero LLM cost) and prices
+    from Alpaca (with its existing yfinance fallback). `price_loader` exists
+    for tests and alternative data sources.
+    """
+    signals = load_recorded_signals(symbol, eval_results_dir=eval_results_dir)
+    if not signals:
+        raise ValueError(
+            f"No recorded completed runs with final signals found for {symbol} "
+            f"under {eval_results_dir}/."
+        )
+
+    first_signal = min(signals)
+    start = start_date or first_signal
+    if start > first_signal:
+        # Signals before the price window would misleadingly fire on its
+        # first bar; drop them so the backtest matches the requested range.
+        signals = {d: a for d, a in signals.items() if d >= start}
+        if not signals:
+            raise ValueError(
+                f"All recorded signals for {symbol} predate start_date={start}."
+            )
+
+    if price_loader is None:
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        price_loader = AlpacaUtils.get_stock_data
+
+    prices = price_loader(symbol, start, end_date)
+    backtest_kwargs.setdefault(
+        "periods_per_year",
+        CRYPTO_DAYS_PER_YEAR if "/" in symbol else TRADING_DAYS_PER_YEAR,
+    )
+    return run_backtest(prices, signals, **backtest_kwargs)
+
+
+def run_recorded_walk_forward(
+    symbol: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    eval_results_dir: str = "eval_results",
+    price_loader: Optional[Callable[[str, str, Optional[str]], pd.DataFrame]] = None,
+    window_bars: int = 63,
+    **backtest_kwargs,
+) -> WalkForwardResult:
+    """Walk-forward evaluation of this deployment's recorded decisions."""
+    signals = load_recorded_signals(symbol, eval_results_dir=eval_results_dir)
+    if not signals:
+        raise ValueError(
+            f"No recorded completed runs with final signals found for {symbol} "
+            f"under {eval_results_dir}/."
+        )
+
+    start = start_date or min(signals)
+    signals = {d: a for d, a in signals.items() if d >= start}
+    if not signals:
+        raise ValueError(
+            f"All recorded signals for {symbol} predate start_date={start}."
+        )
+
+    if price_loader is None:
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        price_loader = AlpacaUtils.get_stock_data
+
+    prices = price_loader(symbol, start, end_date)
+    backtest_kwargs.setdefault(
+        "periods_per_year",
+        CRYPTO_DAYS_PER_YEAR if "/" in symbol else TRADING_DAYS_PER_YEAR,
+    )
+    return run_walk_forward(prices, signals, window_bars=window_bars, **backtest_kwargs)

--- a/tradingagents/backtest/metrics.py
+++ b/tradingagents/backtest/metrics.py
@@ -1,0 +1,108 @@
+"""Pure-math performance metrics for backtest evaluation.
+
+All functions operate on plain sequences / pandas objects and never touch
+the network, the broker, or an LLM, so every number shown in the UI is
+reproducible in a unit test. Metric names follow the TradingAgents paper
+(arXiv:2412.20138): cumulative return, annualized return, Sharpe ratio,
+and maximum drawdown, plus win rate over closed trades.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Sequence
+
+import pandas as pd
+
+TRADING_DAYS_PER_YEAR = 252
+CRYPTO_DAYS_PER_YEAR = 365
+
+
+def _as_series(equity_curve) -> pd.Series:
+    if isinstance(equity_curve, pd.Series):
+        return equity_curve.astype(float)
+    return pd.Series(list(equity_curve), dtype=float)
+
+
+def cumulative_return(equity_curve) -> Optional[float]:
+    """Total return over the whole curve, e.g. 0.25 for +25%."""
+    curve = _as_series(equity_curve)
+    if len(curve) < 2 or curve.iloc[0] <= 0:
+        return None
+    return float(curve.iloc[-1] / curve.iloc[0] - 1.0)
+
+
+def annualized_return(equity_curve, periods_per_year: int = TRADING_DAYS_PER_YEAR) -> Optional[float]:
+    """Geometric annualized return assuming one curve point per period."""
+    curve = _as_series(equity_curve)
+    total = cumulative_return(curve)
+    if total is None:
+        return None
+    periods = len(curve) - 1
+    growth = 1.0 + total
+    if growth <= 0:
+        return -1.0
+    return float(growth ** (periods_per_year / periods) - 1.0)
+
+
+def sharpe_ratio(
+    equity_curve,
+    risk_free_rate: float = 0.0,
+    periods_per_year: int = TRADING_DAYS_PER_YEAR,
+) -> Optional[float]:
+    """Annualized Sharpe ratio from per-period equity values.
+
+    `risk_free_rate` is annual; it is converted to a per-period rate.
+    Returns None when the curve is too short or volatility is zero,
+    rather than fabricating a number.
+    """
+    curve = _as_series(equity_curve)
+    if len(curve) < 3:
+        return None
+    returns = curve.pct_change().dropna()
+    if len(returns) < 2:
+        return None
+    per_period_rf = (1.0 + risk_free_rate) ** (1.0 / periods_per_year) - 1.0
+    excess = returns - per_period_rf
+    std = float(excess.std(ddof=1))
+    if not math.isfinite(std) or std == 0.0:
+        return None
+    return float(excess.mean() / std * math.sqrt(periods_per_year))
+
+
+def max_drawdown(equity_curve) -> Optional[float]:
+    """Largest peak-to-trough decline as a positive fraction (0.2 = -20%)."""
+    curve = _as_series(equity_curve)
+    if len(curve) < 2:
+        return None
+    running_peak = curve.cummax()
+    drawdowns = 1.0 - curve / running_peak
+    return float(drawdowns.max())
+
+
+def win_rate(trade_pnls: Sequence[float]) -> Optional[float]:
+    """Fraction of closed trades with positive net PnL; None when no trades."""
+    pnls = [float(p) for p in trade_pnls]
+    if not pnls:
+        return None
+    return sum(1 for p in pnls if p > 0) / len(pnls)
+
+
+def summarize_performance(
+    equity_curve,
+    trade_pnls: Sequence[float] = (),
+    risk_free_rate: float = 0.0,
+    periods_per_year: int = TRADING_DAYS_PER_YEAR,
+) -> dict:
+    """All headline metrics in one dict (values may be None when undefined)."""
+    curve = _as_series(equity_curve)
+    return {
+        "cumulative_return": cumulative_return(curve),
+        "annualized_return": annualized_return(curve, periods_per_year),
+        "sharpe_ratio": sharpe_ratio(curve, risk_free_rate, periods_per_year),
+        "max_drawdown": max_drawdown(curve),
+        "win_rate": win_rate(trade_pnls),
+        "num_trades": len(list(trade_pnls)),
+        "num_periods": max(len(curve) - 1, 0),
+        "final_equity": float(curve.iloc[-1]) if len(curve) else None,
+    }

--- a/tradingagents/backtest/signals.py
+++ b/tradingagents/backtest/signals.py
@@ -1,0 +1,84 @@
+"""Signal sources for backtesting.
+
+The primary source replays decisions the multi-agent pipeline already made
+and persisted under ``eval_results/`` (see tradingagents/run_logger.py), so
+evaluating past agent behavior costs zero LLM calls. Signals are normalized
+to a common BUY/SELL/HOLD vocabulary; trading-mode outputs map onto it
+(LONG->BUY, SHORT->SELL, NEUTRAL->HOLD).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, Optional
+
+ACTION_ALIASES = {
+    "BUY": "BUY",
+    "LONG": "BUY",
+    "SELL": "SELL",
+    "SHORT": "SELL",
+    "HOLD": "HOLD",
+    "NEUTRAL": "HOLD",
+}
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def normalize_action(raw) -> Optional[str]:
+    """Map any recognized signal spelling to BUY/SELL/HOLD, else None."""
+    if raw is None:
+        return None
+    return ACTION_ALIASES.get(str(raw).strip().upper())
+
+
+def _sanitize_symbol_for_path(symbol: str) -> str:
+    # Must mirror run_logger._sanitize_for_path so we find its output dirs
+    # (importing it would trigger the module's stale-log recovery side effect).
+    sanitized = re.sub(r"[^\w\-.]+", "_", symbol.strip())
+    return sanitized or "unknown"
+
+
+def load_recorded_signals(
+    symbol: str,
+    eval_results_dir: str = "eval_results",
+) -> Dict[str, str]:
+    """Read persisted run logs and return {trade_date: normalized_action}.
+
+    Only completed runs with a recognizable final signal count. When several
+    runs exist for the same trade date, the most recently started one wins —
+    it reflects the newest configuration of the pipeline.
+    """
+    runs_dir = (
+        Path(eval_results_dir)
+        / _sanitize_symbol_for_path(symbol)
+        / "TradingAgentsStrategy_logs"
+        / "runs"
+    )
+    if not runs_dir.is_dir():
+        return {}
+
+    best_per_date: Dict[str, tuple] = {}  # date -> (started_at, action)
+    for path in sorted(runs_dir.glob("*.json")):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        if payload.get("status") != "completed":
+            continue
+        trade_date = str(payload.get("trade_date") or "").strip()
+        if not _DATE_RE.match(trade_date):
+            continue
+        action = normalize_action((payload.get("summary") or {}).get("final_signal"))
+        if action is None:
+            continue
+
+        started_at = str(payload.get("started_at") or "")
+        current = best_per_date.get(trade_date)
+        if current is None or started_at > current[0]:
+            best_per_date[trade_date] = (started_at, action)
+
+    return {date: action for date, (_, action) in sorted(best_per_date.items())}

--- a/tradingagents/backtest/teach.py
+++ b/tradingagents/backtest/teach.py
@@ -1,0 +1,281 @@
+"""Backtest -> self-learning-memory bridge ("intensive teaching").
+
+Replays the decisions this deployment already recorded under
+``eval_results/`` against historical prices and injects one dated lesson per
+decision into the persistent per-agent ChromaDB memories, so a fresh agent
+starts with the distilled experience of its own recorded history instead of
+an empty memory (FinMem's train-then-test warm-up, arXiv:2311.13743).
+
+Discipline mirrors the backtest engine: a decision made on day t enters at
+the *next* bar's open and its outcome is measured at the open ``horizon_bars``
+later — no lookahead. Lessons are built strictly from what the run log
+recorded at decision time plus that realized outcome; no new LLM forecasts
+are generated for historical dates, so pretraining contamination cannot leak
+into the replayed decisions.
+
+Teaching is idempotent: every lesson carries a ``teach_key`` and memories
+that already hold it are skipped, so re-running the bridge never duplicates.
+Lessons are also tagged ``source=backtest_teach`` so later memory
+maintenance can treat batch-taught lessons differently from live ones.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Optional
+
+import pandas as pd
+
+from .engine import normalize_price_frame
+from .signals import load_recorded_signals
+
+_REPORT_KEYS = (
+    "market_report",
+    "sentiment_report",
+    "news_report",
+    "fundamentals_report",
+)
+
+
+def compute_decision_outcomes(
+    prices: pd.DataFrame,
+    signals: Dict[str, str],
+    horizon_bars: int = 5,
+) -> List[dict]:
+    """Realized outcome of each dated decision under next-open execution.
+
+    For a decision dated t, entry is the open of the first bar strictly
+    after t and exit is the open ``horizon_bars`` bars later (or the last
+    bar, flagged ``partial``). ``decision_return`` is signed by the action:
+    BUY earns the asset move, SELL earns its negation, HOLD earns nothing
+    (the asset move is still reported so a lesson can describe what holding
+    avoided or missed). Decisions with no bar after them are dropped.
+    """
+    if horizon_bars < 1:
+        raise ValueError("horizon_bars must be at least 1.")
+
+    frame = normalize_price_frame(prices)
+    bar_dates = [ts.date().isoformat() for ts in frame.index]
+    opens = frame["open"].tolist()
+
+    outcomes: List[dict] = []
+    for trade_date, action in sorted((signals or {}).items()):
+        # First bar strictly after the decision date.
+        entry_idx = next(
+            (i for i, d in enumerate(bar_dates) if d > trade_date), None
+        )
+        if entry_idx is None:
+            continue
+
+        exit_idx = entry_idx + horizon_bars
+        partial = exit_idx > len(frame) - 1
+        if partial:
+            exit_idx = len(frame) - 1
+        if exit_idx <= entry_idx:
+            continue
+
+        entry_price = float(opens[entry_idx])
+        exit_price = float(opens[exit_idx])
+        if entry_price <= 0:
+            continue
+        asset_return = exit_price / entry_price - 1.0
+
+        if action == "BUY":
+            decision_return = asset_return
+        elif action == "SELL":
+            decision_return = -asset_return
+        else:  # HOLD
+            decision_return = 0.0
+
+        outcomes.append(
+            {
+                "trade_date": trade_date,
+                "action": action,
+                "entry_date": bar_dates[entry_idx],
+                "entry_price": entry_price,
+                "exit_date": bar_dates[exit_idx],
+                "exit_price": exit_price,
+                "horizon_used": exit_idx - entry_idx,
+                "asset_return": asset_return,
+                "decision_return": decision_return,
+                "partial": partial,
+            }
+        )
+    return outcomes
+
+
+def _situation_from_state(state: dict) -> Optional[str]:
+    parts = [str(state[k]) for k in _REPORT_KEYS if state.get(k)]
+    return "\n\n".join(parts) if parts else None
+
+
+def _deterministic_lesson(symbol: str, outcome: dict) -> str:
+    action = outcome["action"]
+    horizon = outcome["horizon_used"]
+    asset_pct = f"{outcome['asset_return']:+.1%}"
+    span = "" if not outcome["partial"] else " (horizon truncated by data end)"
+
+    if action == "HOLD":
+        body = (
+            f"HOLD meant not participating in a {asset_pct} move over the next "
+            f"{horizon} bars{span}."
+        )
+        if abs(outcome["asset_return"]) >= 0.02:
+            verdict = (
+                "A move this size suggests the situation carried a tradable "
+                "signal that the HOLD decision left unused — look for what the "
+                "reports underweighted."
+            )
+        else:
+            verdict = "The quiet follow-through supports having stayed flat."
+    else:
+        realized = f"{outcome['decision_return']:+.1%}"
+        body = (
+            f"The {action} decision realized {realized} over the next {horizon} "
+            f"bars{span} (asset moved {asset_pct}; entry at the next open "
+            f"{outcome['entry_price']:.4g} on {outcome['entry_date']}, exit at "
+            f"the open {outcome['exit_price']:.4g} on {outcome['exit_date']})."
+        )
+        if outcome["decision_return"] > 0:
+            verdict = (
+                "The reasoning behind this call was validated by the market — "
+                "weight similar setups accordingly."
+            )
+        else:
+            verdict = (
+                "The market went against this call — in similar situations, "
+                "re-examine the evidence that drove it before repeating the trade."
+            )
+
+    return (
+        f"[Backtest lesson] {symbol} on {outcome['trade_date']}: final decision "
+        f"was {action}. {body} {verdict}"
+    )
+
+
+def default_agent_memories(config: Optional[dict] = None) -> Dict[str, object]:
+    """The five reflection memories, named exactly as TradingAgentsGraph names
+    them so batch-taught lessons are what the live agents later retrieve.
+
+    Imports are deferred: tradingagents.agents pulls dataflows at import
+    time, and the backtest package must stay importable without it.
+    """
+    from tradingagents.agents.utils.memory import FinancialSituationMemory
+
+    if config is None:
+        from tradingagents.default_config import DEFAULT_CONFIG
+
+        config = DEFAULT_CONFIG
+    return {
+        name: FinancialSituationMemory(f"{name}_memory", config)
+        for name in ("bull", "bear", "trader", "invest_judge", "risk_manager")
+    }
+
+
+def teach_memories_from_history(
+    symbol: str,
+    memories: Dict[str, object],
+    price_loader: Optional[Callable[[str, str, Optional[str]], pd.DataFrame]] = None,
+    reflector=None,
+    horizon_bars: int = 5,
+    eval_results_dir: str = "eval_results",
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> dict:
+    """Batch-inject realized-outcome lessons for `symbol` into agent memories.
+
+    `memories` maps component name -> FinancialSituationMemory (the same map
+    reflect_on_outcome uses). When `reflector` is given, each decision's
+    lesson is written by one quick-LLM call
+    (``reflect_on_final_decision``); otherwise a deterministic template is
+    used — zero LLM cost, embeddings only.
+
+    Returns a summary dict; raises ValueError when the symbol has no
+    recorded completed decisions to teach from.
+    """
+    signals = load_recorded_signals(symbol, eval_results_dir=eval_results_dir)
+    if start_date:
+        signals = {d: a for d, a in signals.items() if d >= start_date}
+    if end_date:
+        signals = {d: a for d, a in signals.items() if d <= end_date}
+    if not signals:
+        raise ValueError(
+            f"No recorded completed runs with final signals found for {symbol} "
+            f"under {eval_results_dir}/."
+        )
+
+    if price_loader is None:
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        price_loader = AlpacaUtils.get_stock_data
+
+    prices = price_loader(symbol, min(signals), end_date)
+    outcomes = compute_decision_outcomes(prices, signals, horizon_bars=horizon_bars)
+
+    from tradingagents.run_logger import load_final_state_snapshot
+
+    summary = {
+        "symbol": symbol,
+        "signals_found": len(signals),
+        "outcomes_computed": len(outcomes),
+        "decisions_taught": 0,
+        "decisions_skipped_duplicate": 0,
+        "decisions_skipped_no_state": 0,
+        "lessons_written": 0,
+    }
+
+    for outcome in outcomes:
+        trade_date = outcome["trade_date"]
+        teach_key = f"{symbol}|{trade_date}|{horizon_bars}"
+
+        targets = {
+            name: memory
+            for name, memory in memories.items()
+            if memory is not None
+            and not memory.has_metadata_value("teach_key", teach_key)
+        }
+        if not targets:
+            summary["decisions_skipped_duplicate"] += 1
+            continue
+
+        state = load_final_state_snapshot(
+            symbol, trade_date, eval_results_dir=eval_results_dir
+        )
+        situation = _situation_from_state(state) if state else None
+        if not situation:
+            summary["decisions_skipped_no_state"] += 1
+            continue
+
+        if reflector is not None:
+            final_decision = str(
+                state.get("final_trade_decision") or outcome["action"]
+            )
+            lesson = reflector.reflect_on_final_decision(
+                final_decision,
+                raw_return=outcome["decision_return"],
+                alpha_return=None,
+            )
+        else:
+            lesson = _deterministic_lesson(symbol, outcome)
+
+        metadata = {
+            "source": "backtest_teach",
+            "teach_key": teach_key,
+            "symbol": symbol,
+            "trade_date": trade_date,
+            "action": outcome["action"],
+            "decision_return": float(outcome["decision_return"]),
+            "horizon_bars": int(horizon_bars),
+        }
+        written = 0
+        for memory in targets.values():
+            before = memory.situation_collection.count()
+            memory.add_situations([(situation, lesson)], extra_metadata=metadata)
+            written += memory.situation_collection.count() - before
+
+        # written == 0 means embeddings were unavailable and nothing stored;
+        # such decisions are simply not counted as taught.
+        if written:
+            summary["decisions_taught"] += 1
+            summary["lessons_written"] += written
+
+    return summary

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -15,7 +15,10 @@ from alpaca.trading.enums import AssetClass, AssetStatus, OrderSide, QueryOrderS
 from alpaca.common.enums import Sort
 from .config import get_api_key, get_alpaca_use_paper, get_config
 from .ticker_utils import TickerUtils
-from tradingagents.agents.schemas import TradeIntent, trade_intent_action
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tradingagents.agents.schemas import TradeIntent
 
 
 # Fallback dictionary for company names
@@ -227,6 +230,8 @@ def _is_supported_data_fallback_error(error: Exception) -> bool:
             "subscription",
             "permission",
             "unauthorized",
+            # nginx-level 401s arrive as HTML pages with this phrasing
+            "authorization required",
             "forbidden",
             "not found",
             "empty",
@@ -835,7 +840,7 @@ class AlpacaUtils:
     def execute_trade_intent(
         symbol: str,
         current_position: str,
-        trade_intent: Union[TradeIntent, Dict[str, Any]],
+        trade_intent: Union["TradeIntent", Dict[str, Any]],
         dollar_amount: float,
         allow_shorts: bool = False,
     ) -> dict:
@@ -845,6 +850,11 @@ class AlpacaUtils:
         method intentionally delegates to the existing simple market/close
         execution path until bracket/OCO/OTO order placement is implemented.
         """
+        # Imported lazily: a module-level import of the agents package from
+        # here creates a dataflows <-> agents import cycle that breaks
+        # whenever dataflows is imported first.
+        from tradingagents.agents.schemas import TradeIntent, trade_intent_action
+
         try:
             intent = (
                 trade_intent

--- a/tradingagents/dataflows/reddit_utils.py
+++ b/tradingagents/dataflows/reddit_utils.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from typing import Annotated, List
 import os
 import re
-from .alpaca_utils import AlpacaUtils
 
 REDDIT_USER_AGENT = "TradingAgents/1.0"
 REDDIT_CATEGORY_SUBREDDITS = {
@@ -46,6 +45,11 @@ def get_company_name(ticker: str) -> str:
     normalized = (ticker or "").strip().upper()
     if not normalized:
         return ticker
+
+    # Imported here, not at module level: alpaca_utils pulls in the agents
+    # package, which imports dataflows.interface, which imports this module —
+    # a top-level import breaks whenever dataflows is imported before agents.
+    from .alpaca_utils import AlpacaUtils
 
     company_name = AlpacaUtils.get_company_name(normalized)
     if company_name and company_name.strip().upper() != normalized:

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -10,6 +10,15 @@ DEFAULT_CONFIG = {
         os.path.join(_TRADINGAGENTS_HOME, "memory", "trading_memory.md"),
     ),
     "memory_log_max_entries": None,
+    # Self-learning memory: when set, the per-agent ChromaDB reflection
+    # memories persist across restarts instead of resetting each session.
+    "agent_memory_dir": os.getenv(
+        "TRADINGAGENTS_AGENT_MEMORY_DIR",
+        os.path.join(_TRADINGAGENTS_HOME, "memory", "agent_memory"),
+    ),
+    # Feed realized outcomes back into the per-agent memories (5 quick-LLM
+    # reflection calls per resolved decision). Requires OpenAI embeddings.
+    "reflection_on_outcome_enabled": True,
     "checkpoint_enabled": False,
     # "data_dir": "/Users/yluo/Documents/Code/ScAI/FR1-data",
     "data_dir": "data/ScAI/FR1-data",

--- a/tradingagents/graph/reflection.py
+++ b/tradingagents/graph/reflection.py
@@ -96,6 +96,39 @@ class Reflector:
         )
         risk_manager_memory.add_situations([(situation, result)])
 
+    def reflect_on_outcome(
+        self,
+        state: Dict[str, Any],
+        returns_losses: str,
+        memories: Dict[str, Any],
+    ) -> Dict[str, bool]:
+        """Run every per-agent reflection against a realized outcome.
+
+        `state` is a final_state dict (live or recovered from a run log) and
+        `memories` maps component name -> FinancialSituationMemory. Each
+        component is isolated: one failure (missing key, LLM error) must not
+        block the remaining lessons from being written.
+        """
+        reflectors = {
+            "bull": self.reflect_bull_researcher,
+            "bear": self.reflect_bear_researcher,
+            "trader": self.reflect_trader,
+            "invest_judge": self.reflect_invest_judge,
+            "risk_manager": self.reflect_risk_manager,
+        }
+        results: Dict[str, bool] = {}
+        for name, reflect in reflectors.items():
+            memory = memories.get(name)
+            if memory is None:
+                continue
+            try:
+                reflect(state, returns_losses, memory)
+                results[name] = True
+            except Exception as exc:
+                print(f"[REFLECTION] Skipped {name} reflection: {exc}")
+                results[name] = False
+        return results
+
     def reflect_on_final_decision(
         self,
         final_decision: str,

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -135,12 +135,12 @@ class TradingAgentsGraph:
         
         self.toolkit = Toolkit(config=self.config)
 
-        # Initialize memories
-        self.bull_memory = FinancialSituationMemory("bull_memory")
-        self.bear_memory = FinancialSituationMemory("bear_memory")
-        self.trader_memory = FinancialSituationMemory("trader_memory")
-        self.invest_judge_memory = FinancialSituationMemory("invest_judge_memory")
-        self.risk_manager_memory = FinancialSituationMemory("risk_manager_memory")
+        # Initialize memories (persistent when agent_memory_dir is configured)
+        self.bull_memory = FinancialSituationMemory("bull_memory", self.config)
+        self.bear_memory = FinancialSituationMemory("bear_memory", self.config)
+        self.trader_memory = FinancialSituationMemory("trader_memory", self.config)
+        self.invest_judge_memory = FinancialSituationMemory("invest_judge_memory", self.config)
+        self.risk_manager_memory = FinancialSituationMemory("risk_manager_memory", self.config)
         self.memory_log = TradingMemoryLog(self.config)
 
         # Create tool nodes
@@ -301,6 +301,55 @@ class TradingAgentsGraph:
                 holding_days=holding_days,
                 reflection=reflection,
             )
+            self._reflect_agents_on_outcome(
+                ticker, entry_date_text, raw_return, alpha_return, holding_days
+            )
+
+    def _reflect_agents_on_outcome(
+        self,
+        ticker: str,
+        trade_date: str,
+        raw_return: float,
+        alpha_return: Optional[float],
+        holding_days: int,
+    ) -> None:
+        """Feed a realized outcome back into the per-agent ChromaDB memories.
+
+        Recovers the original run's final_state from the persisted run log,
+        so each agent reflects on the exact situation it saw when the
+        decision was made — not on today's state. Best-effort by design:
+        reflection failures must never affect the current analysis run.
+        """
+        if not self.config.get("reflection_on_outcome_enabled", True):
+            return
+        try:
+            from tradingagents.run_logger import load_final_state_snapshot
+
+            state = load_final_state_snapshot(ticker, trade_date)
+            if not state:
+                return
+            alpha_text = (
+                f"{alpha_return:+.1%} vs benchmark"
+                if alpha_return is not None
+                else "n/a"
+            )
+            returns_losses = (
+                f"Realized return over {holding_days} trading days: "
+                f"{raw_return:+.1%} (alpha: {alpha_text})."
+            )
+            self.reflector.reflect_on_outcome(
+                state,
+                returns_losses,
+                {
+                    "bull": self.bull_memory,
+                    "bear": self.bear_memory,
+                    "trader": self.trader_memory,
+                    "invest_judge": self.invest_judge_memory,
+                    "risk_manager": self.risk_manager_memory,
+                },
+            )
+        except Exception as exc:
+            print(f"[REFLECTION] Outcome reflection skipped for {ticker} {trade_date}: {exc}")
 
     def _create_tool_nodes(self) -> Dict[str, ToolNode]:
         """Create tool nodes for different data sources."""

--- a/tradingagents/run_logger.py
+++ b/tradingagents/run_logger.py
@@ -389,6 +389,49 @@ class RunAuditLogger:
             json.dump(run_data, f, indent=2, ensure_ascii=False)
 
 
+def load_final_state_snapshot(
+    symbol: str,
+    trade_date: str,
+    eval_results_dir: str = "eval_results",
+) -> Optional[Dict[str, Any]]:
+    """Return the final_state snapshot of the newest completed run for a date.
+
+    Lets outcome-time consumers (reflection, evaluation) recover the exact
+    market situation a past decision was made in, without keeping every run
+    in process memory. Returns None when no matching completed run exists.
+    """
+    runs_dir = (
+        Path(eval_results_dir)
+        / _sanitize_for_path(symbol or "unknown")
+        / "TradingAgentsStrategy_logs"
+        / "runs"
+    )
+    if not runs_dir.is_dir():
+        return None
+
+    best_payload = None
+    best_started_at = ""
+    for path in runs_dir.glob("*.json"):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except Exception:
+            continue
+        if payload.get("status") != "completed":
+            continue
+        if str(payload.get("trade_date")) != str(trade_date):
+            continue
+        final_state = (payload.get("snapshots") or {}).get("final_state")
+        if not isinstance(final_state, dict):
+            continue
+        started_at = str(payload.get("started_at") or "")
+        if started_at >= best_started_at:
+            best_started_at = started_at
+            best_payload = final_state
+
+    return best_payload
+
+
 _RUN_AUDIT_LOGGER = RunAuditLogger()
 
 

--- a/webui/callbacks/__init__.py
+++ b/webui/callbacks/__init__.py
@@ -10,6 +10,7 @@ from .control_callbacks import register_control_callbacks
 from .trading_callbacks import register_trading_callbacks
 from .storage_callbacks import register_storage_callbacks
 from .api_config_callbacks import register_api_config_callbacks
+from .backtest_callbacks import register_backtest_callbacks
 
 def register_all_callbacks(app):
     """Register all callback functions with the Dash app"""
@@ -19,4 +20,5 @@ def register_all_callbacks(app):
     register_control_callbacks(app)
     register_trading_callbacks(app)
     register_storage_callbacks(app)
-    register_api_config_callbacks(app) 
+    register_api_config_callbacks(app)
+    register_backtest_callbacks(app)

--- a/webui/callbacks/backtest_callbacks.py
+++ b/webui/callbacks/backtest_callbacks.py
@@ -1,0 +1,215 @@
+"""
+Backtest callbacks for TradingAgents WebUI
+Runs the walk-forward backtest over recorded agent decisions and renders
+metrics, the equity curve, and per-window robustness results.
+"""
+
+import dash_bootstrap_components as dbc
+import plotly.graph_objects as go
+from dash import Input, Output, State, html
+
+from webui.config.constants import COLORS
+
+
+def _fmt_pct(value):
+    return "—" if value is None else f"{value:+.2%}"
+
+
+def _fmt_ratio(value):
+    return "—" if value is None else f"{value:.2f}"
+
+
+def _metric_color(value, invert=False):
+    if value is None:
+        return COLORS["pending"]
+    good = value < 0 if invert else value > 0
+    return COLORS["completed"] if good else COLORS["error"]
+
+
+def _metric_card(label, text, color):
+    return dbc.Col(
+        dbc.Card(
+            dbc.CardBody(
+                [
+                    html.Div(label, className="text-muted small"),
+                    html.Div(text, style={"color": color, "fontSize": "1.3rem", "fontWeight": 600}),
+                ],
+                className="p-2 text-center",
+            ),
+            style={"backgroundColor": COLORS["card"], "border": f"1px solid {COLORS['border']}"},
+        ),
+        md=2,
+        xs=6,
+        className="mb-2",
+    )
+
+
+def _build_metric_cards(metrics, signals_used):
+    sharpe = metrics.get("sharpe_ratio")
+    return dbc.Row(
+        [
+            _metric_card(
+                "Cumulative Return",
+                _fmt_pct(metrics.get("cumulative_return")),
+                _metric_color(metrics.get("cumulative_return")),
+            ),
+            _metric_card(
+                "Annualized Return",
+                _fmt_pct(metrics.get("annualized_return")),
+                _metric_color(metrics.get("annualized_return")),
+            ),
+            _metric_card("Sharpe Ratio", _fmt_ratio(sharpe), _metric_color(sharpe)),
+            _metric_card(
+                "Max Drawdown",
+                "—" if metrics.get("max_drawdown") is None else f"-{metrics['max_drawdown']:.2%}",
+                _metric_color(metrics.get("max_drawdown"), invert=True)
+                if metrics.get("max_drawdown")
+                else COLORS["pending"],
+            ),
+            _metric_card(
+                "Win Rate",
+                "—" if metrics.get("win_rate") is None else f"{metrics['win_rate']:.0%}",
+                COLORS["primary"],
+            ),
+            _metric_card(
+                "Trades / Signals",
+                f"{metrics.get('num_trades', 0)} / {signals_used}",
+                COLORS["text"],
+            ),
+        ],
+        className="g-2",
+    )
+
+
+def _build_equity_figure(equity_curve, symbol):
+    figure = go.Figure()
+    figure.add_trace(
+        go.Scatter(
+            x=list(equity_curve.index),
+            y=list(equity_curve.values),
+            mode="lines",
+            name="Equity",
+            line={"color": COLORS["primary"], "width": 2},
+            fill="tozeroy",
+            fillcolor="rgba(59, 130, 246, 0.08)",
+        )
+    )
+    figure.update_layout(
+        title=f"Equity Curve — {symbol}",
+        template="plotly_dark",
+        paper_bgcolor=COLORS["card"],
+        plot_bgcolor=COLORS["card"],
+        margin={"l": 40, "r": 20, "t": 40, "b": 30},
+        yaxis={"title": "Portfolio value ($)", "tickformat": ",.0f"},
+        showlegend=False,
+    )
+    return figure
+
+
+def _build_windows_table(windows):
+    if len(windows) < 2:
+        return None
+    header = html.Thead(
+        html.Tr(
+            [
+                html.Th("Window"),
+                html.Th("Bars"),
+                html.Th("Return"),
+                html.Th("Sharpe"),
+                html.Th("Max DD"),
+                html.Th("Win Rate"),
+            ]
+        )
+    )
+    rows = []
+    for window in windows:
+        metrics = window["metrics"]
+        cum = metrics.get("cumulative_return")
+        rows.append(
+            html.Tr(
+                [
+                    html.Td(f"{window['start_date']} → {window['end_date']}"),
+                    html.Td(window["bars"]),
+                    html.Td(
+                        _fmt_pct(cum),
+                        style={"color": _metric_color(cum)},
+                    ),
+                    html.Td(_fmt_ratio(metrics.get("sharpe_ratio"))),
+                    html.Td(
+                        "—" if metrics.get("max_drawdown") is None else f"-{metrics['max_drawdown']:.2%}"
+                    ),
+                    html.Td(
+                        "—" if metrics.get("win_rate") is None else f"{metrics['win_rate']:.0%}"
+                    ),
+                ]
+            )
+        )
+    return html.Div(
+        [
+            html.H6("Out-of-sample windows", className="mt-2"),
+            dbc.Table([header, html.Tbody(rows)], bordered=False, hover=True, size="sm", striped=True),
+        ]
+    )
+
+
+def register_backtest_callbacks(app):
+    """Register backtest callbacks with the Dash app"""
+
+    @app.callback(
+        [
+            Output("backtest-status", "children"),
+            Output("backtest-metrics", "children"),
+            Output("backtest-equity-graph", "figure"),
+            Output("backtest-graph-container", "style"),
+            Output("backtest-windows-table", "children"),
+        ],
+        Input("backtest-run-btn", "n_clicks"),
+        [
+            State("backtest-symbol-input", "value"),
+            State("backtest-start-date", "value"),
+            State("backtest-end-date", "value"),
+            State("backtest-window-bars", "value"),
+            State("backtest-allow-shorts", "value"),
+        ],
+        prevent_initial_call=True,
+    )
+    def run_backtest_callback(n_clicks, symbol, start_date, end_date, window_bars, allow_shorts):
+        hidden = {"display": "none"}
+        empty = go.Figure()
+
+        symbol = (symbol or "").strip().upper()
+        if not symbol:
+            alert = dbc.Alert("Enter a symbol to backtest.", color="warning", className="mb-0")
+            return alert, None, empty, hidden, None
+
+        try:
+            from tradingagents.backtest import run_recorded_walk_forward
+
+            result = run_recorded_walk_forward(
+                symbol,
+                start_date=start_date or None,
+                end_date=end_date or None,
+                window_bars=int(window_bars or 63),
+                allow_shorts=bool(allow_shorts),
+            )
+        except ValueError as e:
+            alert = dbc.Alert(str(e), color="warning", className="mb-0")
+            return alert, None, empty, hidden, None
+        except Exception as e:
+            alert = dbc.Alert(f"Backtest failed: {e}", color="danger", className="mb-0")
+            return alert, None, empty, hidden, None
+
+        full = result.full_period
+        status_bits = [
+            f"{full.start_date} → {full.end_date}",
+            f"{full.signals_used} recorded signal(s)",
+            "execution: next-bar open",
+        ]
+        if full.rejected_orders:
+            status_bits.append(f"{len(full.rejected_orders)} order(s) rejected on gaps")
+        status = html.Div(" · ".join(status_bits), className="text-muted small")
+
+        metrics_cards = _build_metric_cards(full.metrics, full.signals_used)
+        figure = _build_equity_figure(full.equity_curve, symbol)
+        windows_table = _build_windows_table(result.windows)
+        return status, metrics_cards, figure, {"display": "block"}, windows_table

--- a/webui/callbacks/backtest_callbacks.py
+++ b/webui/callbacks/backtest_callbacks.py
@@ -222,3 +222,61 @@ def register_backtest_callbacks(app):
         figure = _build_equity_figure(full.equity_curve, symbol)
         windows_table = _build_windows_table(result.windows)
         return status, metrics_cards, figure, {"display": "block"}, windows_table
+
+    @app.callback(
+        Output("backtest-teach-status", "children"),
+        Input("backtest-teach-btn", "n_clicks"),
+        [
+            State("backtest-symbol-input", "value"),
+            State("backtest-start-date", "value"),
+            State("backtest-end-date", "value"),
+        ],
+        prevent_initial_call=True,
+    )
+    def teach_memory_callback(n_clicks, symbol, start_date, end_date):
+        symbol = (symbol or "").strip().upper()
+        if not symbol:
+            return dbc.Alert(
+                "Enter a symbol to teach from.", color="warning", className="mb-0"
+            )
+
+        try:
+            from tradingagents.backtest import (
+                default_agent_memories,
+                teach_memories_from_history,
+            )
+
+            summary = teach_memories_from_history(
+                symbol,
+                default_agent_memories(),
+                start_date=start_date or None,
+                end_date=end_date or None,
+            )
+        except ValueError as e:
+            return dbc.Alert(str(e), color="warning", className="mb-0")
+        except Exception as e:
+            return dbc.Alert(f"Teaching failed: {e}", color="danger", className="mb-0")
+
+        taught = summary["decisions_taught"]
+        if not taught and summary["decisions_skipped_duplicate"]:
+            text = (
+                f"Nothing new to teach for {symbol}: "
+                f"{summary['decisions_skipped_duplicate']} decision(s) already in memory."
+            )
+            return dbc.Alert(text, color="info", className="mb-0")
+        if not taught:
+            text = (
+                f"No teachable decisions for {symbol} "
+                f"({summary['outcomes_computed']} outcome(s) computed, "
+                f"{summary['decisions_skipped_no_state']} without a recorded final state; "
+                "teaching also requires OpenAI embeddings)."
+            )
+            return dbc.Alert(text, color="warning", className="mb-0")
+
+        text = (
+            f"Taught {taught} decision(s) for {symbol} — "
+            f"{summary['lessons_written']} lesson(s) written to the agent memories "
+            f"({summary['decisions_skipped_duplicate']} duplicate(s) skipped, "
+            f"{summary['decisions_skipped_no_state']} without final state)."
+        )
+        return dbc.Alert(text, color="success", className="mb-0")

--- a/webui/callbacks/backtest_callbacks.py
+++ b/webui/callbacks/backtest_callbacks.py
@@ -170,10 +170,11 @@ def register_backtest_callbacks(app):
             State("backtest-end-date", "value"),
             State("backtest-window-bars", "value"),
             State("backtest-allow-shorts", "value"),
+            State("backtest-slippage-model", "value"),
         ],
         prevent_initial_call=True,
     )
-    def run_backtest_callback(n_clicks, symbol, start_date, end_date, window_bars, allow_shorts):
+    def run_backtest_callback(n_clicks, symbol, start_date, end_date, window_bars, allow_shorts, slippage_model):
         hidden = {"display": "none"}
         empty = go.Figure()
 
@@ -191,6 +192,7 @@ def register_backtest_callbacks(app):
                 end_date=end_date or None,
                 window_bars=int(window_bars or 63),
                 allow_shorts=bool(allow_shorts),
+                slippage_model=slippage_model or "fixed",
             )
         except ValueError as e:
             alert = dbc.Alert(str(e), color="warning", className="mb-0")
@@ -200,10 +202,17 @@ def register_backtest_callbacks(app):
             return alert, None, empty, hidden, None
 
         full = result.full_period
+        slippage = full.slippage or {}
+        slippage_text = {
+            "fixed": f"slippage: {slippage.get('bps', 0):g} bps",
+            "volatility": "slippage: volatility-scaled",
+            "none": "slippage: none",
+        }.get(slippage.get("model"), "slippage: n/a")
         status_bits = [
             f"{full.start_date} → {full.end_date}",
             f"{full.signals_used} recorded signal(s)",
             "execution: next-bar open",
+            slippage_text,
         ]
         if full.rejected_orders:
             status_bits.append(f"{len(full.rejected_orders)} order(s) rejected on gaps")

--- a/webui/components/backtest_panel.py
+++ b/webui/components/backtest_panel.py
@@ -25,7 +25,7 @@ def create_backtest_panel():
                         debounce=True,
                     ),
                 ],
-                md=3,
+                md=2,
             ),
             dbc.Col(
                 [
@@ -50,6 +50,21 @@ def create_backtest_panel():
                         value=63,
                         min=2,
                         step=1,
+                    ),
+                ],
+                md=1,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label("Slippage", html_for="backtest-slippage-model", className="small"),
+                    dbc.Select(
+                        id="backtest-slippage-model",
+                        options=[
+                            {"label": "Fixed (5 bps)", "value": "fixed"},
+                            {"label": "Volatility-scaled", "value": "volatility"},
+                            {"label": "None (frictionless)", "value": "none"},
+                        ],
+                        value="fixed",
                     ),
                 ],
                 md=2,

--- a/webui/components/backtest_panel.py
+++ b/webui/components/backtest_panel.py
@@ -1,0 +1,117 @@
+"""
+webui/components/backtest_panel.py - Walk-forward backtest dashboard panel
+
+Replays the decisions already recorded under eval_results/ against
+historical prices (zero LLM cost) and reports the TradingAgents-paper
+metric set: cumulative/annualized return, Sharpe ratio, max drawdown,
+plus win rate, per walk-forward window and for the full period.
+"""
+
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+
+def create_backtest_panel():
+    """Create the backtest panel card for the web UI."""
+    controls = dbc.Row(
+        [
+            dbc.Col(
+                [
+                    dbc.Label("Symbol", html_for="backtest-symbol-input", className="small"),
+                    dbc.Input(
+                        id="backtest-symbol-input",
+                        type="text",
+                        placeholder="e.g. AAPL or BTC/USD",
+                        debounce=True,
+                    ),
+                ],
+                md=3,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label("Start date (optional)", html_for="backtest-start-date", className="small"),
+                    dbc.Input(id="backtest-start-date", type="date"),
+                ],
+                md=2,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label("End date (optional)", html_for="backtest-end-date", className="small"),
+                    dbc.Input(id="backtest-end-date", type="date"),
+                ],
+                md=2,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label("Window (bars)", html_for="backtest-window-bars", className="small"),
+                    dbc.Input(
+                        id="backtest-window-bars",
+                        type="number",
+                        value=63,
+                        min=2,
+                        step=1,
+                    ),
+                ],
+                md=2,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label(" ", className="small d-block"),
+                    dbc.Switch(
+                        id="backtest-allow-shorts",
+                        label="Allow shorts",
+                        value=False,
+                    ),
+                ],
+                md=1,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label(" ", className="small d-block"),
+                    dbc.Button(
+                        [html.I(className="fas fa-flask me-2"), "Run Backtest"],
+                        id="backtest-run-btn",
+                        color="primary",
+                        className="w-100",
+                    ),
+                ],
+                md=2,
+            ),
+        ],
+        className="g-2 align-items-end mb-3",
+    )
+
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.H4("Walk-Forward Backtest", className="mb-1"),
+                html.Div(
+                    "Replays this deployment's recorded agent decisions on historical "
+                    "prices — signals execute at the next bar's open (no lookahead).",
+                    className="text-muted small mb-3",
+                ),
+                controls,
+                dcc.Loading(
+                    id="backtest-loading",
+                    type="default",
+                    children=html.Div(
+                        [
+                            html.Div(id="backtest-status", className="mb-2"),
+                            html.Div(id="backtest-metrics", className="mb-3"),
+                            html.Div(
+                                dcc.Graph(
+                                    id="backtest-equity-graph",
+                                    config={"displayModeBar": False, "responsive": True},
+                                    style={"height": "320px", "width": "100%"},
+                                ),
+                                id="backtest-graph-container",
+                                style={"display": "none"},
+                            ),
+                            html.Div(id="backtest-windows-table"),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+        className="mb-4",
+    )

--- a/webui/components/backtest_panel.py
+++ b/webui/components/backtest_panel.py
@@ -96,6 +96,30 @@ def create_backtest_panel():
         className="g-2 align-items-end mb-3",
     )
 
+    teach_row = dbc.Row(
+        [
+            dbc.Col(
+                dbc.Button(
+                    [html.I(className="fas fa-graduation-cap me-2"), "Teach Memory"],
+                    id="backtest-teach-btn",
+                    color="secondary",
+                    outline=True,
+                    size="sm",
+                ),
+                width="auto",
+            ),
+            dbc.Col(
+                html.Div(
+                    "Injects one dated lesson per recorded decision (with its "
+                    "realized next-open return) into the persistent agent "
+                    "memories — idempotent, zero LLM cost.",
+                    className="text-muted small",
+                ),
+            ),
+        ],
+        className="g-2 align-items-center mb-2",
+    )
+
     return dbc.Card(
         dbc.CardBody(
             [
@@ -106,6 +130,12 @@ def create_backtest_panel():
                     className="text-muted small mb-3",
                 ),
                 controls,
+                teach_row,
+                dcc.Loading(
+                    id="backtest-teach-loading",
+                    type="default",
+                    children=html.Div(id="backtest-teach-status", className="mb-2"),
+                ),
                 dcc.Loading(
                     id="backtest-loading",
                     type="default",

--- a/webui/layout.py
+++ b/webui/layout.py
@@ -12,6 +12,7 @@ from webui.components.status_panel import create_status_panel
 from webui.components.chart_panel import create_chart_panel
 from webui.components.decision_panel import create_decision_panel
 from webui.components.reports_panel import create_reports_panel
+from webui.components.backtest_panel import create_backtest_panel
 from webui.components.alpaca_account import render_alpaca_account_section
 from webui.components.api_config_modal import create_api_config_modal
 from webui.config.constants import COLORS, REFRESH_INTERVALS
@@ -176,6 +177,7 @@ def create_main_layout():
                 ], md=6)
             ]),
             reports_card,
+            create_backtest_panel(),
             html.Div(className="mt-4"),
             create_footer(),
         ],


### PR DESCRIPTION
## What

Bridges two pending features — the walk-forward backtest engine (#26) and the self-learning memory loop (#27) — into an **intensive teaching mode**: replay the decisions this deployment already recorded under `eval_results/`, compute each decision's realized outcome, and batch-inject one dated lesson per decision into the five persistent per-agent ChromaDB memories.

A fresh deployment stops starting from a blank memory: it boots with the distilled experience of its own recorded history — the same train-then-test warm-up FinMem (arXiv:2311.13743) uses to make an LLM trading agent competitive from day one of the test period.

> **Stacked PR:** this branch is built on top of `feature/backtesting-engine` (#26) and `feature/self-learning-memory` (#27) and includes their commits. Merging those two first reduces this PR to the bridge commit alone.

## How it works

```
eval_results/ run logs ──► recorded signals + final_state snapshots
        │
        ▼
compute_decision_outcomes()          ◄── prices (Alpaca / yfinance fallback)
  entry: first bar open AFTER the decision date (no lookahead)
  exit:  open `horizon_bars` later (partial flagged at data end)
  BUY = asset move · SELL = its negation · HOLD = move it sat out
        │
        ▼
teach_memories_from_history()
  one lesson per decision ──► bull / bear / trader / invest_judge / risk_manager
  metadata: teach_key (idempotency) · source=backtest_teach · action · return
```

- **Zero LLM cost by default**: lessons come from a deterministic template (situation + decision + realized return + verdict); only embeddings are needed. Passing a `Reflector` upgrades each lesson to one quick-LLM call (`reflect_on_final_decision`).
- **Idempotent**: every lesson carries a `teach_key`; re-teaching skips memories that already hold it. Safe to run after every backtest.
- **No lookahead / no contamination**: outcomes use the engine's next-open execution discipline, and no new LLM forecasts are generated for historical dates — decisions are the ones actually recorded at the time.
- **Maintenance-ready**: `source=backtest_teach` tags let future memory-pruning treat batch-taught lessons separately from live reflections.

## Surface

- `tradingagents/backtest/teach.py` — `compute_decision_outcomes`, `teach_memories_from_history`, `default_agent_memories` (collection names match `TradingAgentsGraph`, so live agents retrieve the taught lessons).
- `FinancialSituationMemory.add_situations(..., extra_metadata=)` + `has_metadata_value()` — shared metadata and the idempotency probe.
- WebUI: **Teach Memory** button on the backtest panel with a taught / duplicates / no-state summary.

## Tests

19 new tests (outcome arithmetic incl. weekend roll-forward and partial horizons, idempotency, metadata tagging, LLM-mode delegation, WebUI wiring). Full suite: **134 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
