### PR TITLE
test: chaos suite for the safety layer + fix NaN/HTML broker-data defects it found

### DIFF
--- a/tests/test_chaos_resilience.py
+++ b/tests/test_chaos_resilience.py
@@ -1,0 +1,263 @@
+"""Chaos tests: inject broker/data failures at the system's boundaries and
+verify the safety layer degrades gracefully instead of guessing or dying.
+
+Each test states its hypothesis in the name. No network, no live keys — all
+failures are injected via mocks at the Alpaca boundary, and every SafetyGuard
+gets its own temp state so experiments never leak into each other.
+"""
+
+import math
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+# Importing dataflows first trips a known circular import on main (fixed in
+# the backtesting-engine PR); importing agents first is the production-safe
+# order until that lands.
+import tradingagents.agents  # noqa: F401
+from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+from tradingagents.safety.guardrails import SafetyGuard
+
+
+def _guard(tmp, **config):
+    merged = {"safety_enabled": True}
+    merged.update(config)
+    return SafetyGuard(
+        config=merged,
+        state_path=Path(tmp) / "state.json",
+        kill_switch_path=Path(tmp) / "KILL_SWITCH",
+    )
+
+
+class NanAndGarbageEquityTests(unittest.TestCase):
+    """Anomalous account data must read as 'unavailable', never as a number."""
+
+    def test_nan_equity_does_not_poison_high_water_mark(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            guard.check_order(
+                "AAPL", 1000.0, account={"equity": float("nan"), "last_equity": 100000.0}
+            )
+            hwm = guard._state.get("high_water_mark")
+            self.assertTrue(hwm is None or math.isfinite(float(hwm)))
+
+    def test_drawdown_breaker_survives_a_nan_day(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, max_drawdown_halt_pct=15.0)
+            # Healthy day establishes the mark, then a NaN day, then a crash day.
+            guard.check_order("AAPL", 0.0, account={"equity": 100000.0})
+            guard.check_order("AAPL", 0.0, account={"equity": float("nan")})
+            verdict = guard.check_order("AAPL", 0.0, account={"equity": 80000.0})
+            self.assertFalse(verdict.allowed)
+            self.assertEqual(verdict.checks["drawdown"]["status"], "fail")
+
+    def test_nan_equity_skips_account_breakers_instead_of_passing_them(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, daily_loss_halt_pct=10.0, max_drawdown_halt_pct=15.0)
+            verdict = guard.check_order(
+                "AAPL",
+                1000.0,
+                account={"equity": float("nan"), "last_equity": float("nan")},
+            )
+            self.assertEqual(verdict.checks["daily_loss"]["status"], "skipped")
+            self.assertEqual(verdict.checks["drawdown"]["status"], "skipped")
+
+    def test_nginx_html_in_account_fields_does_not_crash_the_guard(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            verdict = guard.check_order(
+                "AAPL",
+                1000.0,
+                account={
+                    "equity": "<html><body>401 Authorization Required</body></html>",
+                    "last_equity": "<html>",
+                },
+            )
+            # Cheap checks still run; account-based ones are skipped.
+            self.assertTrue(verdict.allowed)
+            self.assertEqual(verdict.checks["daily_loss"]["status"], "skipped")
+            self.assertEqual(verdict.checks["drawdown"]["status"], "skipped")
+
+    def test_infinite_equity_reads_as_unavailable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            verdict = guard.check_order(
+                "AAPL", 1000.0, account={"equity": float("inf"), "last_equity": 1.0}
+            )
+            self.assertEqual(verdict.checks["drawdown"]["status"], "skipped")
+            hwm = guard._state.get("high_water_mark")
+            self.assertTrue(hwm is None or math.isfinite(float(hwm)))
+
+    def test_nan_position_value_does_not_disable_concentration_cap(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, max_symbol_concentration_pct=25.0)
+            verdict = guard.check_order(
+                "AAPL",
+                30000.0,
+                account={"equity": 100000.0},
+                position_value=float("nan"),
+            )
+            # NaN exposure must not silently pass the cap: the $30k order alone
+            # exceeds 25% of $100k equity.
+            self.assertFalse(verdict.allowed)
+            self.assertEqual(verdict.checks["concentration"]["status"], "fail")
+
+    def test_zero_last_equity_skips_daily_loss_without_dividing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, daily_loss_halt_pct=10.0)
+            verdict = guard.check_order(
+                "AAPL", 1000.0, account={"equity": 50000.0, "last_equity": 0.0}
+            )
+            self.assertEqual(verdict.checks["daily_loss"]["status"], "skipped")
+
+
+class MidFlipOutageTests(unittest.TestCase):
+    """API dies between closing one side and opening the other."""
+
+    def _run_flip(self, guard, close_result, open_side_effect):
+        with patch.object(AlpacaUtils, "close_position", return_value=close_result), \
+             patch.object(
+                 AlpacaUtils, "place_market_order", side_effect=open_side_effect
+             ), \
+             patch.object(AlpacaUtils, "_safety_context", return_value=(None, None)), \
+             patch.object(
+                 AlpacaUtils,
+                 "get_latest_quote",
+                 return_value={"bid_price": 100.0, "ask_price": 100.1},
+             ), \
+             patch("tradingagents.safety.get_safety_guard", return_value=guard):
+            return AlpacaUtils.execute_trading_action(
+                symbol="AAPL",
+                current_position="LONG",
+                signal="SHORT",
+                dollar_amount=5000.0,
+                allow_shorts=True,
+            )
+
+    def test_open_leg_failure_reports_failure_and_feeds_the_breaker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, max_consecutive_rejections=5)
+            outcome = self._run_flip(
+                guard,
+                close_result={"success": True, "message": "closed"},
+                open_side_effect=[{"success": False, "error": "connection reset"}],
+            )
+            self.assertFalse(outcome["success"])
+            actions = [a["action"] for a in outcome["actions"]]
+            self.assertEqual(actions, ["close_long", "open_short"])
+            # One success (close) then one rejection (open): streak is 1.
+            self.assertEqual(guard.consecutive_rejections(), 1)
+
+    def test_close_leg_failure_never_attempts_the_open_leg(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            open_order = Mock()
+            outcome = self._run_flip(
+                guard,
+                close_result={"success": False, "error": "504 gateway timeout"},
+                open_side_effect=open_order,
+            )
+            self.assertFalse(outcome["success"])
+            open_order.assert_not_called()
+
+    def test_unexpected_exception_mid_flip_returns_error_dict(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            outcome = self._run_flip(
+                guard,
+                close_result={"success": True},
+                open_side_effect=ConnectionError("socket closed mid-request"),
+            )
+            self.assertFalse(outcome["success"])
+            self.assertIn("error", outcome)
+
+
+class KillSwitchAndBreakerFlowTests(unittest.TestCase):
+    def test_kill_switch_blocks_before_any_broker_call(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            guard.engage_kill_switch("chaos drill")
+            broker_call = Mock()
+            with patch.object(AlpacaUtils, "close_position", broker_call), \
+                 patch.object(AlpacaUtils, "place_market_order", broker_call), \
+                 patch.object(
+                     AlpacaUtils, "_safety_context", return_value=(None, None)
+                 ), \
+                 patch("tradingagents.safety.get_safety_guard", return_value=guard):
+                outcome = AlpacaUtils.execute_trading_action(
+                    symbol="AAPL",
+                    current_position="NEUTRAL",
+                    signal="BUY",
+                    dollar_amount=1000.0,
+                    allow_shorts=False,
+                )
+            self.assertFalse(outcome["success"])
+            self.assertTrue(outcome.get("safety_blocked"))
+            broker_call.assert_not_called()
+
+    def test_rejection_streak_halts_subsequent_order_flow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, max_consecutive_rejections=3)
+            for _ in range(3):
+                guard.record_order_result(False)
+            verdict = guard.check_order("AAPL", 1000.0)
+            self.assertFalse(verdict.allowed)
+            self.assertEqual(verdict.checks["rejection_streak"]["status"], "fail")
+
+    def test_unreachable_account_degrades_to_cheap_checks_only(self):
+        """Broker down: orders are not wrongly blocked by absent breakers."""
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, daily_loss_halt_pct=10.0, max_drawdown_halt_pct=15.0)
+            with patch.object(
+                AlpacaUtils,
+                "place_market_order",
+                return_value={"success": True, "message": "ok"},
+            ), \
+                 patch.object(
+                     AlpacaUtils, "_safety_context", return_value=(None, None)
+                 ), \
+                 patch.object(
+                     AlpacaUtils,
+                     "get_latest_quote",
+                     return_value={"bid_price": 100.0, "ask_price": 100.1},
+                 ), \
+                 patch("tradingagents.safety.get_safety_guard", return_value=guard):
+                outcome = AlpacaUtils.execute_trading_action(
+                    symbol="AAPL",
+                    current_position="NEUTRAL",
+                    signal="BUY",
+                    dollar_amount=1000.0,
+                    allow_shorts=False,
+                )
+            self.assertTrue(outcome["success"])
+
+
+class MalformedBrokerPayloadTests(unittest.TestCase):
+    def test_garbage_position_payload_reads_as_neutral(self):
+        bad_position = Mock()
+        bad_position.symbol = "AAPL"
+        bad_position.qty = "<html>502 Bad Gateway</html>"
+        client = Mock()
+        client.get_all_positions.return_value = [bad_position]
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
+            return_value=client,
+        ):
+            state = AlpacaUtils.get_current_position_state("AAPL")
+        self.assertEqual(state, "NEUTRAL")
+
+    def test_account_fetch_outage_returns_zeroed_info_not_exception(self):
+        client = Mock()
+        client.get_account.side_effect = ConnectionError("nginx: 502")
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
+            return_value=client,
+        ):
+            info = AlpacaUtils.get_account_info()
+        self.assertEqual(info["buying_power"], 0)
+        self.assertEqual(info["cash"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_safety_guardrails.py
+++ b/tests/test_safety_guardrails.py
@@ -1,0 +1,281 @@
+"""Tests for the deterministic production safety layer.
+
+The safety layer is intentionally independent of agent logic: every check is
+pure arithmetic over injected account/order state, so nothing here mocks an
+LLM. Each guard is exercised on both sides of its threshold.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tradingagents.safety import (
+    DEFAULT_SAFETY_CONFIG,
+    SafetyGuard,
+    SafetyVerdict,
+    get_safety_guard,
+    reset_safety_guard,
+)
+
+
+def make_guard(tmp, **overrides):
+    config = dict(DEFAULT_SAFETY_CONFIG)
+    config.update(overrides)
+    return SafetyGuard(
+        config=config,
+        state_path=Path(tmp) / "state.json",
+        kill_switch_path=Path(tmp) / "KILL_SWITCH",
+    )
+
+
+ACCOUNT_OK = {"equity": 100_000.0, "last_equity": 100_000.0}
+
+
+class KillSwitchTests(unittest.TestCase):
+    def test_engage_blocks_all_orders_and_release_restores(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp)
+            self.assertTrue(guard.check_order("AAPL", 100.0, account=ACCOUNT_OK).allowed)
+
+            guard.engage_kill_switch("manual test halt")
+            verdict = guard.check_order("AAPL", 100.0, account=ACCOUNT_OK)
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("kill switch" in r.lower() for r in verdict.reasons))
+            self.assertIn("manual test halt", guard.kill_switch_reason())
+
+            guard.release_kill_switch()
+            self.assertFalse(guard.kill_switch_active())
+            self.assertTrue(guard.check_order("AAPL", 100.0, account=ACCOUNT_OK).allowed)
+
+    def test_kill_switch_file_created_externally_is_honored(self):
+        # Ops can halt trading by touching the file - no Python required.
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "KILL_SWITCH").write_text("halted by ops", encoding="utf-8")
+            guard = make_guard(tmp)
+            self.assertTrue(guard.kill_switch_active())
+            self.assertFalse(guard.check_order("AAPL", 100.0).allowed)
+
+
+class PreTradeCheckTests(unittest.TestCase):
+    def test_notional_above_cap_is_blocked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_trade_notional_usd=5_000.0)
+            self.assertTrue(guard.check_order("AAPL", 5_000.0, account=ACCOUNT_OK).allowed)
+            verdict = guard.check_order("AAPL", 5_000.01, account=ACCOUNT_OK)
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("notional" in r.lower() for r in verdict.reasons))
+
+    def test_concentration_limit_counts_existing_position(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_symbol_concentration_pct=25.0)
+            # 20k existing + 10k new = 30% of 100k equity -> blocked
+            verdict = guard.check_order(
+                "AAPL", 10_000.0, account=ACCOUNT_OK, position_value=20_000.0
+            )
+            self.assertFalse(verdict.allowed)
+            # 20k existing + 4k new = 24% -> allowed
+            self.assertTrue(
+                guard.check_order(
+                    "AAPL", 4_000.0, account=ACCOUNT_OK, position_value=20_000.0
+                ).allowed
+            )
+
+    def test_concentration_skipped_without_account_data(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_symbol_concentration_pct=25.0)
+            verdict = guard.check_order("AAPL", 1_000.0, position_value=90_000.0)
+            self.assertTrue(verdict.allowed)
+            self.assertEqual(verdict.checks["concentration"]["status"], "skipped")
+
+
+class CircuitBreakerTests(unittest.TestCase):
+    def test_daily_loss_breaker_trips_beyond_threshold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, daily_loss_halt_pct=10.0)
+            ok = {"equity": 95_000.0, "last_equity": 100_000.0}  # -5%
+            self.assertTrue(guard.check_order("AAPL", 100.0, account=ok).allowed)
+            tripped = {"equity": 89_000.0, "last_equity": 100_000.0}  # -11%
+            verdict = guard.check_order("AAPL", 100.0, account=tripped)
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("daily loss" in r.lower() for r in verdict.reasons))
+
+    def test_drawdown_breaker_uses_persisted_high_water_mark(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_drawdown_halt_pct=15.0)
+            # Establish a 120k high-water mark.
+            guard.check_order("AAPL", 100.0, account={"equity": 120_000.0, "last_equity": 120_000.0})
+
+            # A fresh instance must read the same HWM from disk.
+            guard2 = make_guard(tmp, max_drawdown_halt_pct=15.0)
+            verdict = guard2.check_order(
+                "AAPL", 100.0, account={"equity": 100_000.0, "last_equity": 100_000.0}
+            )  # -16.7% from HWM
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("drawdown" in r.lower() for r in verdict.reasons))
+
+    def test_consecutive_rejections_trip_and_success_resets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_consecutive_rejections=3)
+            for _ in range(3):
+                guard.record_order_result(False)
+            verdict = guard.check_order("AAPL", 100.0, account=ACCOUNT_OK)
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("rejected" in r.lower() for r in verdict.reasons))
+
+            guard.record_order_result(True)
+            self.assertTrue(guard.check_order("AAPL", 100.0, account=ACCOUNT_OK).allowed)
+
+
+class LLMBudgetTests(unittest.TestCase):
+    def test_budget_exhaustion_blocks_new_analysis(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, daily_llm_token_budget=1_000_000)
+            guard.record_llm_tokens(400_000, when="2026-07-11")
+            self.assertTrue(guard.check_llm_budget(when="2026-07-11").allowed)
+            guard.record_llm_tokens(700_000, when="2026-07-11")
+            verdict = guard.check_llm_budget(when="2026-07-11")
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("budget" in r.lower() for r in verdict.reasons))
+
+    def test_budget_resets_each_day(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, daily_llm_token_budget=1_000_000)
+            guard.record_llm_tokens(2_000_000, when="2026-07-10")
+            self.assertTrue(guard.check_llm_budget(when="2026-07-11").allowed)
+
+    def test_zero_budget_means_unlimited(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, daily_llm_token_budget=0)
+            guard.record_llm_tokens(10_000_000, when="2026-07-11")
+            self.assertTrue(guard.check_llm_budget(when="2026-07-11").allowed)
+
+    def test_token_usage_persists_across_instances(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            make_guard(tmp).record_llm_tokens(123, when="2026-07-11")
+            self.assertEqual(
+                make_guard(tmp).llm_tokens_used(when="2026-07-11"), 123
+            )
+
+
+class StatusAndTogglesTests(unittest.TestCase):
+    def test_disabled_safety_allows_everything(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, safety_enabled=False, max_trade_notional_usd=1.0)
+            guard.engage_kill_switch("halt")
+            verdict = guard.check_order("AAPL", 1_000_000.0, account=ACCOUNT_OK)
+            self.assertTrue(verdict.allowed)
+
+    def test_status_reports_every_guard(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp)
+            status = guard.status(account={"equity": 89_000.0, "last_equity": 100_000.0})
+            for name in (
+                "kill_switch",
+                "trade_notional",
+                "concentration",
+                "daily_loss",
+                "drawdown",
+                "rejection_streak",
+                "llm_budget",
+            ):
+                self.assertIn(name, status["guards"], name)
+            self.assertFalse(status["guards"]["daily_loss"]["ok"])  # -11% today
+            self.assertTrue(status["guards"]["kill_switch"]["ok"])
+
+    def test_singleton_helper_returns_guard_and_resets(self):
+        reset_safety_guard()
+        guard = get_safety_guard()
+        self.assertIsInstance(guard, SafetyGuard)
+        self.assertIs(guard, get_safety_guard())
+        reset_safety_guard()
+
+
+class ExecutionIntegrationTests(unittest.TestCase):
+    """execute_trading_action must consult the safety layer before any order."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Importing dataflows first trips a known circular import on main;
+        # importing agents first is the production-safe order.
+        import tradingagents.agents  # noqa: F401
+
+    def _blocked_guard(self):
+        guard = MagicMock(spec=SafetyGuard)
+        guard.enabled = True
+        guard.check_order.return_value = SafetyVerdict(
+            allowed=False, reasons=["max trade notional exceeded"]
+        )
+        return guard
+
+    def test_blocked_verdict_prevents_broker_calls(self):
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        guard = self._blocked_guard()
+        with patch("tradingagents.safety.get_safety_guard", return_value=guard), patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client"
+        ) as client_factory:
+            result = AlpacaUtils.execute_trading_action(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                signal="BUY",
+                dollar_amount=1_000_000.0,
+                allow_shorts=False,
+            )
+
+        self.assertFalse(result["success"])
+        self.assertTrue(result.get("safety_blocked"))
+        self.assertIn("max trade notional exceeded", result["error"])
+        client_factory.assert_not_called()
+
+    def test_order_results_feed_rejection_tracker(self):
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        guard = MagicMock(spec=SafetyGuard)
+        guard.enabled = True
+        guard.check_order.return_value = SafetyVerdict(allowed=True)
+        with patch("tradingagents.safety.get_safety_guard", return_value=guard), patch.object(
+            AlpacaUtils, "place_market_order", return_value={"success": True}
+        ), patch.object(
+            AlpacaUtils, "get_latest_quote", return_value={"bid_price": 100.0}
+        ):
+            AlpacaUtils.execute_trading_action(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                signal="BUY",
+                dollar_amount=1_000.0,
+                allow_shorts=False,
+            )
+
+        guard.record_order_result.assert_called_with(True)
+
+
+class RunLoggerBudgetFeedTests(unittest.TestCase):
+    def test_llm_call_events_feed_token_counter(self):
+        import os
+
+        from tradingagents.run_logger import RunAuditLogger
+
+        guard = MagicMock(spec=SafetyGuard)
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)  # RunAuditLogger writes to ./eval_results
+            try:
+                with patch("tradingagents.safety.get_safety_guard", return_value=guard):
+                    logger = RunAuditLogger()
+                    run_id = logger.start_run(symbol="AAPL", trade_date="2026-07-11")
+                    logger.log_event(
+                        "llm_call",
+                        symbol="AAPL",
+                        run_id=run_id,
+                        payload={"usage": {"total_tokens": 555}},
+                    )
+            finally:
+                os.chdir(cwd)
+
+        guard.record_llm_tokens.assert_called_with(555)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_safety_webui.py
+++ b/tests/test_safety_webui.py
@@ -1,0 +1,94 @@
+"""Wiring tests for the safety guardrails WebUI panel and callbacks."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tradingagents.safety import DEFAULT_SAFETY_CONFIG, SafetyGuard
+
+
+def _guard(tmp, **overrides):
+    config = dict(DEFAULT_SAFETY_CONFIG)
+    config.update(overrides)
+    return SafetyGuard(
+        config=config,
+        state_path=Path(tmp) / "state.json",
+        kill_switch_path=Path(tmp) / "KILL_SWITCH",
+    )
+
+
+class SafetyPanelWiringTests(unittest.TestCase):
+    def test_panel_component_builds(self):
+        from webui.components.safety_panel import create_safety_panel
+
+        rendered = str(create_safety_panel())
+        for component_id in (
+            "safety-status-container",
+            "safety-kill-switch-btn",
+            "safety-release-btn",
+            "safety-refresh-interval",
+            "safety-action-status",
+        ):
+            self.assertIn(component_id, rendered)
+
+    def test_callbacks_register_on_fresh_app(self):
+        import dash
+
+        from webui.callbacks.safety_callbacks import register_safety_callbacks
+
+        app = dash.Dash(__name__, suppress_callback_exceptions=True)
+        register_safety_callbacks(app)
+        self.assertTrue(
+            any("safety-status-container" in key for key in app.callback_map),
+            f"safety callback missing from callback map: {list(app.callback_map)}",
+        )
+
+    def test_status_cards_render_green_and_red(self):
+        from webui.callbacks.safety_callbacks import _status_cards
+
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            healthy = str(
+                _status_cards(
+                    guard.status(account={"equity": 100_000.0, "last_equity": 100_000.0})
+                )
+            )
+            self.assertIn("Kill Switch", healthy)
+            self.assertIn("LLM Budget", healthy)
+            self.assertIn("fa-check-circle", healthy)
+
+            guard.engage_kill_switch("test halt")
+            tripped = str(
+                _status_cards(
+                    guard.status(account={"equity": 100_000.0, "last_equity": 100_000.0})
+                )
+            )
+            self.assertIn("fa-exclamation-triangle", tripped)
+            self.assertIn("test halt", tripped)
+
+    def test_analysis_start_is_gated_by_llm_budget(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, daily_llm_token_budget=100)
+            guard.record_llm_tokens(500)
+            with patch("tradingagents.safety.get_safety_guard", return_value=guard):
+                from webui.components.analysis import start_analysis
+
+                message = start_analysis(
+                    ticker="AAPL",
+                    analysts_market=True,
+                    analysts_social=False,
+                    analysts_news=False,
+                    analysts_fundamentals=False,
+                    analysts_macro=False,
+                    research_depth="Shallow",
+                    allow_shorts=False,
+                    quick_llm="gpt-test",
+                    deep_llm="gpt-test",
+                )
+            self.assertIsInstance(message, str)
+            self.assertIn("budget", message.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -925,7 +925,36 @@ class AlpacaUtils:
         return result
 
     @staticmethod
-    def execute_trading_action(symbol: str, current_position: str, signal: str, 
+    def _safety_context(symbol: str):
+        """Best-effort account snapshot for the safety layer's breakers.
+
+        Returns (account, position_value); either may be None when the broker
+        is unreachable — the guard reports those checks as skipped instead of
+        guessing.
+        """
+        try:
+            client = get_alpaca_trading_client()
+            acct = client.get_account()
+            account = {
+                "equity": float(acct.equity),
+                "last_equity": float(acct.last_equity),
+            }
+        except Exception:
+            return None, None
+
+        position_value = 0.0
+        try:
+            key = symbol.upper().replace("/", "")
+            for pos in client.get_all_positions():
+                if pos.symbol.upper() == key:
+                    position_value = abs(float(pos.market_value))
+                    break
+        except Exception:
+            position_value = None
+        return account, position_value
+
+    @staticmethod
+    def execute_trading_action(symbol: str, current_position: str, signal: str,
                              dollar_amount: float, allow_shorts: bool = False) -> dict:
         """
         Execute trading action based on current position and signal
@@ -941,8 +970,45 @@ class AlpacaUtils:
             Dictionary with execution results
         """
         try:
+            # Deterministic safety gate — consulted before any broker call and
+            # entirely independent of the agents' reasoning. Cheap local checks
+            # (kill switch, notional cap, rejection streak) run first; account-
+            # based circuit breakers run only if those pass.
+            guard = None
+            try:
+                from tradingagents.safety import get_safety_guard
+
+                guard = get_safety_guard()
+            except Exception:
+                guard = None
+
+            if guard is not None and guard.enabled:
+                verdict = guard.check_order(symbol, dollar_amount)
+                if verdict.allowed:
+                    account_state, position_value = AlpacaUtils._safety_context(symbol)
+                    if account_state:
+                        verdict = guard.check_order(
+                            symbol,
+                            dollar_amount,
+                            account=account_state,
+                            position_value=position_value,
+                        )
+                if not verdict.allowed:
+                    error_msg = "Safety layer blocked order flow: " + " ".join(verdict.reasons)
+                    print(f"[SAFETY] {error_msg}")
+                    return {
+                        "success": False,
+                        "safety_blocked": True,
+                        "symbol": symbol,
+                        "current_position": current_position,
+                        "signal": signal,
+                        "actions": [],
+                        "error": error_msg,
+                        "safety_checks": verdict.checks,
+                    }
+
             results = []
-            
+
             # Helper to calculate integer quantity for any orders (used by both trading modes)
             def _calc_qty(sym: str, amount: float) -> int:
                 """Return integer share qty based on latest quote price."""
@@ -1078,10 +1144,18 @@ class AlpacaUtils:
             # Check if any critical actions failed
             has_failures = False
             for action in results:
-                if "result" in action and not action["result"].get("success", True):
-                    has_failures = True
-                    break
-                    
+                if "result" in action:
+                    order_success = bool(action["result"].get("success", True))
+                    if guard is not None and guard.enabled:
+                        # Feed the consecutive-rejection circuit breaker.
+                        try:
+                            guard.record_order_result(order_success)
+                        except Exception:
+                            pass
+                    if not order_success:
+                        has_failures = True
+
+
             return {
                 "success": not has_failures,
                 "symbol": symbol,

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -51,6 +51,14 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 200,
     # Trading settings
     "allow_shorts": False,  # False = Investment mode (BUY/HOLD/SELL), True = Trading mode (LONG/NEUTRAL/SHORT)
+    # Production safety layer (deterministic, independent of agent logic)
+    "safety_enabled": True,  # Master switch for pre-trade checks + circuit breakers + kill switch
+    "max_trade_notional_usd": 25000.0,  # Per-order notional cap; 0 = uncapped
+    "max_symbol_concentration_pct": 25.0,  # Max per-symbol exposure as % of equity; 0 = uncapped
+    "daily_loss_halt_pct": 10.0,  # Circuit breaker: halt trading when equity falls this % vs yesterday
+    "max_drawdown_halt_pct": 15.0,  # Circuit breaker: halt when equity falls this % below the high-water mark
+    "max_consecutive_rejections": 5,  # Circuit breaker: halt after this many broker rejections in a row
+    "daily_llm_token_budget": 0,  # Refuse new analyses after this many LLM tokens per day; 0 = unlimited
     # Execution settings
     "parallel_analysts": True,  # True = Run analysts in parallel for faster execution, False = Sequential execution
     "parallel_risk_first_round": True,  # Run Risky/Safe/Neutral in parallel only for round 1, then revert to linear flow

--- a/tradingagents/run_logger.py
+++ b/tradingagents/run_logger.py
@@ -233,9 +233,17 @@ class RunAuditLogger:
                 run_data["summary"]["total_llm_output_tokens"] += int(
                     usage.get("output_tokens", 0) or 0
                 )
-                run_data["summary"]["total_llm_tokens"] += int(
-                    usage.get("total_tokens", 0) or 0
-                )
+                total_tokens = int(usage.get("total_tokens", 0) or 0)
+                run_data["summary"]["total_llm_tokens"] += total_tokens
+                if total_tokens:
+                    # Feed the safety layer's daily LLM token budget; logging
+                    # must never fail because the guard is unavailable.
+                    try:
+                        from tradingagents.safety import get_safety_guard
+
+                        get_safety_guard().record_llm_tokens(total_tokens)
+                    except Exception:
+                        pass
             elif event_type == "agent_output":
                 run_data["summary"]["agent_output_events"] += 1
             elif event_type == "node_execution":

--- a/tradingagents/safety/__init__.py
+++ b/tradingagents/safety/__init__.py
@@ -1,0 +1,17 @@
+"""Deterministic production safety layer — independent of all agent logic."""
+
+from .guardrails import (
+    DEFAULT_SAFETY_CONFIG,
+    SafetyGuard,
+    SafetyVerdict,
+    get_safety_guard,
+    reset_safety_guard,
+)
+
+__all__ = [
+    "DEFAULT_SAFETY_CONFIG",
+    "SafetyGuard",
+    "SafetyVerdict",
+    "get_safety_guard",
+    "reset_safety_guard",
+]

--- a/tradingagents/safety/guardrails.py
+++ b/tradingagents/safety/guardrails.py
@@ -1,0 +1,360 @@
+"""Deterministic production safety layer.
+
+Every guard here is plain arithmetic over injected state — zero LLM calls,
+zero imports from the agent stack — so it cannot be talked out of a halt by
+a model and keeps working when providers misbehave. Three stages:
+
+- pre-trade checks: per-order notional cap, per-symbol concentration cap
+- circuit breakers: daily loss halt, drawdown-from-high-water-mark halt,
+  consecutive-rejection halt (a data/connectivity glitch signal)
+- kill switch: a flag file that stops all order flow no matter what the
+  agents decide (ops can engage it by touching the file, no Python needed)
+
+A daily LLM token budget rides along: run logs already count tokens, the
+guard accumulates them per day and can refuse to start new analyses.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DEFAULT_SAFETY_CONFIG: Dict[str, Any] = {
+    "safety_enabled": True,
+    # Pre-trade checks
+    "max_trade_notional_usd": 25_000.0,  # 0 = uncapped
+    "max_symbol_concentration_pct": 25.0,  # of account equity; 0 = uncapped
+    # Circuit breakers
+    "daily_loss_halt_pct": 10.0,  # halt when equity drops this % vs yesterday
+    "max_drawdown_halt_pct": 15.0,  # halt when equity drops this % vs high-water mark
+    "max_consecutive_rejections": 5,  # halt after this many broker rejections in a row
+    # LLM cost cap
+    "daily_llm_token_budget": 0,  # tokens/day across all runs; 0 = unlimited
+}
+
+_SAFETY_HOME = Path(os.path.expanduser("~")) / ".tradingagents" / "safety"
+
+
+@dataclass
+class SafetyVerdict:
+    allowed: bool
+    reasons: List[str] = field(default_factory=list)
+    checks: Dict[str, dict] = field(default_factory=dict)
+
+
+def _today(when: Optional[str] = None) -> str:
+    return when or date.today().isoformat()
+
+
+class SafetyGuard:
+    """Thread-safe guard with a small JSON state file.
+
+    Persisted state: equity high-water mark, current rejection streak, and
+    per-day LLM token counts. The kill switch is a separate flag file so a
+    human (or cron job) can engage it with `touch`.
+    """
+
+    def __init__(
+        self,
+        config: Optional[Dict[str, Any]] = None,
+        state_path: Optional[Path] = None,
+        kill_switch_path: Optional[Path] = None,
+    ):
+        merged = dict(DEFAULT_SAFETY_CONFIG)
+        for key in merged:
+            if config and config.get(key) is not None:
+                merged[key] = config[key]
+        self.config = merged
+        self.state_path = Path(state_path or (_SAFETY_HOME / "state.json"))
+        self.kill_switch_path = Path(
+            kill_switch_path or (_SAFETY_HOME / "KILL_SWITCH")
+        )
+        self._lock = threading.RLock()
+        self._state = self._load_state()
+
+    # ----- state persistence -------------------------------------------------
+
+    def _load_state(self) -> Dict[str, Any]:
+        try:
+            raw = json.loads(self.state_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                return raw
+        except (OSError, ValueError):
+            pass
+        return {"high_water_mark": None, "consecutive_rejections": 0, "llm_tokens": {}}
+
+    def _save_state(self) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.state_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._state, indent=2), encoding="utf-8")
+        os.replace(tmp, self.state_path)
+
+    # ----- kill switch --------------------------------------------------------
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.config.get("safety_enabled", True))
+
+    def kill_switch_active(self) -> bool:
+        return self.kill_switch_path.exists()
+
+    def kill_switch_reason(self) -> str:
+        try:
+            return self.kill_switch_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return ""
+
+    def engage_kill_switch(self, reason: str = "manual halt") -> None:
+        self.kill_switch_path.parent.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).isoformat()
+        self.kill_switch_path.write_text(f"{reason} (engaged {stamp})", encoding="utf-8")
+
+    def release_kill_switch(self) -> None:
+        try:
+            self.kill_switch_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    # ----- order/rejection tracking -------------------------------------------
+
+    def record_order_result(self, success: bool) -> None:
+        with self._lock:
+            if success:
+                self._state["consecutive_rejections"] = 0
+            else:
+                self._state["consecutive_rejections"] = (
+                    int(self._state.get("consecutive_rejections", 0)) + 1
+                )
+            self._save_state()
+
+    def consecutive_rejections(self) -> int:
+        with self._lock:
+            return int(self._state.get("consecutive_rejections", 0))
+
+    # ----- LLM token budget ----------------------------------------------------
+
+    def record_llm_tokens(self, tokens: int, when: Optional[str] = None) -> None:
+        if not tokens:
+            return
+        day = _today(when)
+        with self._lock:
+            counts = self._state.setdefault("llm_tokens", {})
+            counts[day] = int(counts.get(day, 0)) + int(tokens)
+            # Keep the map from growing unbounded.
+            for old_day in sorted(counts)[:-31]:
+                del counts[old_day]
+            self._save_state()
+
+    def llm_tokens_used(self, when: Optional[str] = None) -> int:
+        day = _today(when)
+        with self._lock:
+            return int(self._state.get("llm_tokens", {}).get(day, 0))
+
+    def check_llm_budget(self, when: Optional[str] = None) -> SafetyVerdict:
+        budget = float(self.config.get("daily_llm_token_budget", 0) or 0)
+        used = self.llm_tokens_used(when)
+        if not self.enabled or budget <= 0 or used < budget:
+            return SafetyVerdict(
+                allowed=True,
+                checks={"llm_budget": {"status": "pass", "used": used, "budget": budget}},
+            )
+        return SafetyVerdict(
+            allowed=False,
+            reasons=[
+                f"Daily LLM token budget exhausted: {used:,.0f} of {budget:,.0f} tokens used."
+            ],
+            checks={"llm_budget": {"status": "fail", "used": used, "budget": budget}},
+        )
+
+    # ----- the main pre-order gate ----------------------------------------------
+
+    def check_order(
+        self,
+        symbol: str,
+        notional: float,
+        account: Optional[Dict[str, float]] = None,
+        position_value: Optional[float] = None,
+    ) -> SafetyVerdict:
+        """Deterministic gate every outbound order must pass.
+
+        `account` carries {"equity", "last_equity"} when available; checks
+        that need missing data are reported as skipped rather than guessed.
+        """
+        if not self.enabled:
+            return SafetyVerdict(
+                allowed=True, checks={"safety": {"status": "skipped", "detail": "disabled"}}
+            )
+
+        reasons: List[str] = []
+        checks: Dict[str, dict] = {}
+        equity = float(account["equity"]) if account and account.get("equity") else None
+        last_equity = (
+            float(account["last_equity"])
+            if account and account.get("last_equity")
+            else None
+        )
+
+        # Kill switch dominates everything.
+        if self.kill_switch_active():
+            reason = self.kill_switch_reason() or "engaged"
+            reasons.append(f"Kill switch is engaged: {reason}")
+            checks["kill_switch"] = {"status": "fail", "detail": reason}
+        else:
+            checks["kill_switch"] = {"status": "pass"}
+
+        # Pre-trade: per-order notional cap.
+        cap = float(self.config.get("max_trade_notional_usd", 0) or 0)
+        if cap > 0 and float(notional) > cap:
+            reasons.append(
+                f"Order notional ${float(notional):,.2f} exceeds max_trade_notional_usd ${cap:,.2f}."
+            )
+            checks["trade_notional"] = {"status": "fail", "notional": float(notional), "cap": cap}
+        else:
+            checks["trade_notional"] = {"status": "pass", "notional": float(notional), "cap": cap}
+
+        # Pre-trade: per-symbol concentration cap.
+        conc_pct = float(self.config.get("max_symbol_concentration_pct", 0) or 0)
+        if conc_pct > 0:
+            if equity:
+                exposure = float(position_value or 0.0) + float(notional)
+                limit = equity * conc_pct / 100.0
+                if exposure > limit:
+                    reasons.append(
+                        f"{symbol} exposure ${exposure:,.2f} would exceed "
+                        f"{conc_pct:g}% of equity (${limit:,.2f})."
+                    )
+                    checks["concentration"] = {
+                        "status": "fail",
+                        "exposure": exposure,
+                        "limit": limit,
+                    }
+                else:
+                    checks["concentration"] = {
+                        "status": "pass",
+                        "exposure": exposure,
+                        "limit": limit,
+                    }
+            else:
+                checks["concentration"] = {
+                    "status": "skipped",
+                    "detail": "account equity unavailable",
+                }
+        else:
+            checks["concentration"] = {"status": "pass", "detail": "uncapped"}
+
+        # Circuit breaker: daily loss.
+        halt_pct = float(self.config.get("daily_loss_halt_pct", 0) or 0)
+        if halt_pct > 0 and equity and last_equity:
+            change_pct = (equity - last_equity) / last_equity * 100.0
+            if change_pct <= -halt_pct:
+                reasons.append(
+                    f"Daily loss circuit breaker: equity is {change_pct:+.2f}% vs "
+                    f"yesterday (halt at -{halt_pct:g}%)."
+                )
+                checks["daily_loss"] = {"status": "fail", "change_pct": change_pct}
+            else:
+                checks["daily_loss"] = {"status": "pass", "change_pct": change_pct}
+        else:
+            checks["daily_loss"] = {
+                "status": "skipped" if halt_pct > 0 else "pass",
+                "detail": "account equity unavailable" if halt_pct > 0 else "uncapped",
+            }
+
+        # Circuit breaker: drawdown from persisted high-water mark.
+        dd_pct = float(self.config.get("max_drawdown_halt_pct", 0) or 0)
+        if equity:
+            with self._lock:
+                hwm = self._state.get("high_water_mark")
+                if hwm is None or equity > float(hwm):
+                    self._state["high_water_mark"] = equity
+                    self._save_state()
+                    hwm = equity
+            hwm = float(hwm)
+            if dd_pct > 0 and hwm > 0:
+                drawdown_pct = (hwm - equity) / hwm * 100.0
+                if drawdown_pct >= dd_pct:
+                    reasons.append(
+                        f"Drawdown circuit breaker: equity is {drawdown_pct:.2f}% below the "
+                        f"${hwm:,.2f} high-water mark (halt at {dd_pct:g}%)."
+                    )
+                    checks["drawdown"] = {"status": "fail", "drawdown_pct": drawdown_pct}
+                else:
+                    checks["drawdown"] = {"status": "pass", "drawdown_pct": drawdown_pct}
+            else:
+                checks["drawdown"] = {"status": "pass", "detail": "uncapped"}
+        else:
+            checks["drawdown"] = {
+                "status": "skipped" if dd_pct > 0 else "pass",
+                "detail": "account equity unavailable" if dd_pct > 0 else "uncapped",
+            }
+
+        # Circuit breaker: consecutive broker rejections (data-glitch signal).
+        max_rejects = int(self.config.get("max_consecutive_rejections", 0) or 0)
+        streak = self.consecutive_rejections()
+        if max_rejects > 0 and streak >= max_rejects:
+            reasons.append(
+                f"{streak} consecutive orders were rejected (halt at {max_rejects}); "
+                "possible data or connectivity problem."
+            )
+            checks["rejection_streak"] = {"status": "fail", "streak": streak}
+        else:
+            checks["rejection_streak"] = {"status": "pass", "streak": streak}
+
+        return SafetyVerdict(allowed=not reasons, reasons=reasons, checks=checks)
+
+    # ----- status for dashboards ---------------------------------------------
+
+    def status(self, account: Optional[Dict[str, float]] = None) -> Dict[str, Any]:
+        """Green/red snapshot of every guard for the WebUI panel."""
+        order_view = self.check_order("_status_", 0.0, account=account)
+        budget_view = self.check_llm_budget()
+        guards: Dict[str, dict] = {}
+        for name, check in {**order_view.checks, **budget_view.checks}.items():
+            guards[name] = {
+                "ok": check.get("status") != "fail",
+                "status": check.get("status"),
+                "detail": {k: v for k, v in check.items() if k != "status"},
+            }
+        return {
+            "enabled": self.enabled,
+            "kill_switch_active": self.kill_switch_active(),
+            "kill_switch_reason": self.kill_switch_reason(),
+            "reasons": list(order_view.reasons) + list(budget_view.reasons),
+            "guards": guards,
+            "config": dict(self.config),
+        }
+
+
+# ----- process-wide singleton ---------------------------------------------------
+
+_GUARD: Optional[SafetyGuard] = None
+_GUARD_LOCK = threading.Lock()
+
+
+def get_safety_guard() -> SafetyGuard:
+    """Process-wide guard configured from the runtime config (lazily)."""
+    global _GUARD
+    with _GUARD_LOCK:
+        if _GUARD is None:
+            config: Dict[str, Any] = {}
+            try:
+                # Imported lazily: the safety layer must stay importable even
+                # if the dataflows stack (and its dependencies) are not.
+                from tradingagents.dataflows.config import get_config
+
+                config = dict(get_config() or {})
+            except Exception:
+                config = {}
+            _GUARD = SafetyGuard(config=config)
+        return _GUARD
+
+
+def reset_safety_guard() -> None:
+    global _GUARD
+    with _GUARD_LOCK:
+        _GUARD = None

--- a/tradingagents/safety/guardrails.py
+++ b/tradingagents/safety/guardrails.py
@@ -17,6 +17,7 @@ guard accumulates them per day and can refuse to start new analyses.
 from __future__ import annotations
 
 import json
+import math
 import os
 import threading
 from dataclasses import dataclass, field
@@ -49,6 +50,22 @@ class SafetyVerdict:
 
 def _today(when: Optional[str] = None) -> str:
     return when or date.today().isoformat()
+
+
+def _finite_float(value) -> Optional[float]:
+    """Parse broker-supplied numbers defensively.
+
+    Outage artifacts show up here as NaN/inf equity or literal HTML error
+    pages in numeric fields. Anything non-finite or unparseable reads as
+    'unavailable' (None): a NaN that reaches a comparison silently passes
+    every breaker, and a NaN stored as the high-water mark disables the
+    drawdown breaker permanently.
+    """
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
 
 
 class SafetyGuard:
@@ -192,12 +209,10 @@ class SafetyGuard:
 
         reasons: List[str] = []
         checks: Dict[str, dict] = {}
-        equity = float(account["equity"]) if account and account.get("equity") else None
-        last_equity = (
-            float(account["last_equity"])
-            if account and account.get("last_equity")
-            else None
-        )
+        equity = _finite_float(account.get("equity")) if account else None
+        last_equity = _finite_float(account.get("last_equity")) if account else None
+        if last_equity == 0.0:
+            last_equity = None  # a 0 baseline can't produce a meaningful change %
 
         # Kill switch dominates everything.
         if self.kill_switch_active():
@@ -208,20 +223,21 @@ class SafetyGuard:
             checks["kill_switch"] = {"status": "pass"}
 
         # Pre-trade: per-order notional cap.
+        notional_value = _finite_float(notional) or 0.0
         cap = float(self.config.get("max_trade_notional_usd", 0) or 0)
-        if cap > 0 and float(notional) > cap:
+        if cap > 0 and notional_value > cap:
             reasons.append(
-                f"Order notional ${float(notional):,.2f} exceeds max_trade_notional_usd ${cap:,.2f}."
+                f"Order notional ${notional_value:,.2f} exceeds max_trade_notional_usd ${cap:,.2f}."
             )
-            checks["trade_notional"] = {"status": "fail", "notional": float(notional), "cap": cap}
+            checks["trade_notional"] = {"status": "fail", "notional": notional_value, "cap": cap}
         else:
-            checks["trade_notional"] = {"status": "pass", "notional": float(notional), "cap": cap}
+            checks["trade_notional"] = {"status": "pass", "notional": notional_value, "cap": cap}
 
         # Pre-trade: per-symbol concentration cap.
         conc_pct = float(self.config.get("max_symbol_concentration_pct", 0) or 0)
         if conc_pct > 0:
             if equity:
-                exposure = float(position_value or 0.0) + float(notional)
+                exposure = (_finite_float(position_value) or 0.0) + notional_value
                 limit = equity * conc_pct / 100.0
                 if exposure > limit:
                     reasons.append(

--- a/webui/callbacks/__init__.py
+++ b/webui/callbacks/__init__.py
@@ -10,6 +10,7 @@ from .control_callbacks import register_control_callbacks
 from .trading_callbacks import register_trading_callbacks
 from .storage_callbacks import register_storage_callbacks
 from .api_config_callbacks import register_api_config_callbacks
+from .safety_callbacks import register_safety_callbacks
 
 def register_all_callbacks(app):
     """Register all callback functions with the Dash app"""
@@ -19,4 +20,5 @@ def register_all_callbacks(app):
     register_control_callbacks(app)
     register_trading_callbacks(app)
     register_storage_callbacks(app)
-    register_api_config_callbacks(app) 
+    register_api_config_callbacks(app)
+    register_safety_callbacks(app)

--- a/webui/callbacks/safety_callbacks.py
+++ b/webui/callbacks/safety_callbacks.py
@@ -1,0 +1,155 @@
+"""
+Safety-layer callbacks for TradingAgents WebUI
+Renders live guardrail status and drives the kill switch.
+"""
+
+import dash_bootstrap_components as dbc
+from dash import Input, Output, ctx, html
+
+from webui.config.constants import COLORS
+
+_GUARD_LABELS = {
+    "kill_switch": "Kill Switch",
+    "trade_notional": "Trade Size Cap",
+    "concentration": "Concentration",
+    "daily_loss": "Daily Loss Breaker",
+    "drawdown": "Drawdown Breaker",
+    "rejection_streak": "Rejection Streak",
+    "llm_budget": "LLM Budget",
+}
+
+
+def _guard_detail_text(name, guard):
+    detail = guard.get("detail") or {}
+    if guard.get("status") == "skipped":
+        return str(detail.get("detail", "no account data"))
+    if name == "daily_loss" and "change_pct" in detail:
+        return f"{detail['change_pct']:+.2f}% today"
+    if name == "drawdown" and "drawdown_pct" in detail:
+        return f"-{detail['drawdown_pct']:.2f}% from peak"
+    if name == "rejection_streak":
+        return f"{detail.get('streak', 0)} in a row"
+    if name == "llm_budget":
+        budget = detail.get("budget") or 0
+        if not budget:
+            return "unlimited"
+        return f"{detail.get('used', 0):,.0f} / {budget:,.0f} tokens"
+    if name == "trade_notional":
+        cap = detail.get("cap") or 0
+        return f"cap ${cap:,.0f}" if cap else "uncapped"
+    if name == "concentration":
+        limit = detail.get("limit")
+        return f"limit ${limit:,.0f}" if limit else str(detail.get("detail", ""))
+    return ""
+
+
+def _status_cards(status):
+    cards = []
+    for name, label in _GUARD_LABELS.items():
+        guard = status["guards"].get(name)
+        if guard is None:
+            continue
+        if guard.get("status") == "skipped":
+            color = COLORS.get("pending", "#9ca3af")
+            icon = "fas fa-question-circle"
+        elif guard["ok"]:
+            color = COLORS.get("completed", "#22c55e")
+            icon = "fas fa-check-circle"
+        else:
+            color = COLORS.get("error", "#ef4444")
+            icon = "fas fa-exclamation-triangle"
+        cards.append(
+            dbc.Col(
+                dbc.Card(
+                    dbc.CardBody(
+                        [
+                            html.Div(
+                                [html.I(className=f"{icon} me-2", style={"color": color}), label],
+                                className="small fw-bold",
+                            ),
+                            html.Div(
+                                _guard_detail_text(name, guard),
+                                className="text-muted small",
+                            ),
+                        ],
+                        className="p-2",
+                    ),
+                    style={
+                        "backgroundColor": COLORS.get("card", "#1f2937"),
+                        "border": f"1px solid {color}",
+                    },
+                ),
+                md=3,
+                xs=6,
+                className="mb-2",
+            )
+        )
+    rows = [dbc.Row(cards, className="g-2")]
+    if status.get("reasons"):
+        rows.append(
+            dbc.Alert(
+                [html.Div(reason) for reason in status["reasons"]],
+                color="danger",
+                className="mt-2 mb-0 py-2 small",
+            )
+        )
+    if not status.get("enabled", True):
+        rows.append(
+            dbc.Alert(
+                "Safety layer is DISABLED via configuration (safety_enabled=False).",
+                color="warning",
+                className="mt-2 mb-0 py-2 small",
+            )
+        )
+    return html.Div(rows)
+
+
+def _account_snapshot():
+    try:
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        account, _ = AlpacaUtils._safety_context("_status_")
+        return account
+    except Exception:
+        return None
+
+
+def register_safety_callbacks(app):
+    """Register safety-layer callbacks with the Dash app"""
+
+    @app.callback(
+        [
+            Output("safety-status-container", "children"),
+            Output("safety-action-status", "children"),
+        ],
+        [
+            Input("safety-refresh-interval", "n_intervals"),
+            Input("safety-kill-switch-btn", "n_clicks"),
+            Input("safety-release-btn", "n_clicks"),
+        ],
+        prevent_initial_call=False,
+    )
+    def refresh_safety_panel(_n, _engage_clicks, _release_clicks):
+        from tradingagents.safety import get_safety_guard
+
+        guard = get_safety_guard()
+        action_message = None
+
+        trigger = ctx.triggered_id if ctx.triggered_id else None
+        if trigger == "safety-kill-switch-btn":
+            guard.engage_kill_switch("engaged from WebUI")
+            action_message = dbc.Alert(
+                "Kill switch ENGAGED — all order flow is halted.",
+                color="danger",
+                className="mb-0 py-2 small",
+            )
+        elif trigger == "safety-release-btn":
+            guard.release_kill_switch()
+            action_message = dbc.Alert(
+                "Kill switch released — order flow may resume.",
+                color="success",
+                className="mb-0 py-2 small",
+            )
+
+        status = guard.status(account=_account_snapshot())
+        return _status_cards(status), action_message

--- a/webui/components/analysis.py
+++ b/webui/components/analysis.py
@@ -389,6 +389,19 @@ def start_analysis(
 ):
     """Start real-time analysis function for the UI"""
 
+    # Deterministic LLM budget gate (production safety layer): refuse to burn
+    # tokens on a new analysis once the daily budget is exhausted.
+    try:
+        from tradingagents.safety import get_safety_guard
+
+        budget_verdict = get_safety_guard().check_llm_budget()
+    except Exception:
+        budget_verdict = None
+    if budget_verdict is not None and not budget_verdict.allowed:
+        message = " ".join(budget_verdict.reasons)
+        print(f"[SAFETY] {message}")
+        return message
+
     # Parse selected analysts
     selected_analysts = []
     if analysts_market:

--- a/webui/components/safety_panel.py
+++ b/webui/components/safety_panel.py
@@ -1,0 +1,71 @@
+"""
+webui/components/safety_panel.py - Production safety layer status panel
+
+Shows a green/red badge for every deterministic guard (kill switch,
+pre-trade checks, circuit breakers, LLM budget) plus a kill-switch toggle
+that halts all order flow immediately, regardless of agent decisions.
+"""
+
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+
+def create_safety_panel():
+    """Create the safety guardrails card for the web UI."""
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.H4("Safety Guardrails", className="mb-1"),
+                                html.Div(
+                                    "Deterministic pre-trade checks, circuit breakers, and a "
+                                    "kill switch — enforced before any order reaches the broker, "
+                                    "independent of agent decisions.",
+                                    className="text-muted small",
+                                ),
+                            ],
+                            md=8,
+                        ),
+                        dbc.Col(
+                            [
+                                dbc.ButtonGroup(
+                                    [
+                                        dbc.Button(
+                                            [
+                                                html.I(className="fas fa-hand-paper me-2"),
+                                                "Engage Kill Switch",
+                                            ],
+                                            id="safety-kill-switch-btn",
+                                            color="danger",
+                                            size="sm",
+                                        ),
+                                        dbc.Button(
+                                            "Release",
+                                            id="safety-release-btn",
+                                            color="secondary",
+                                            outline=True,
+                                            size="sm",
+                                        ),
+                                    ],
+                                    className="float-end",
+                                ),
+                            ],
+                            md=4,
+                        ),
+                    ],
+                    className="mb-3 align-items-start",
+                ),
+                html.Div(id="safety-action-status", className="mb-2"),
+                html.Div(id="safety-status-container"),
+                dcc.Interval(
+                    id="safety-refresh-interval",
+                    interval=30_000,  # 30s
+                    n_intervals=0,
+                ),
+            ]
+        ),
+        className="mb-4",
+    )

--- a/webui/layout.py
+++ b/webui/layout.py
@@ -13,6 +13,7 @@ from webui.components.chart_panel import create_chart_panel
 from webui.components.decision_panel import create_decision_panel
 from webui.components.reports_panel import create_reports_panel
 from webui.components.alpaca_account import render_alpaca_account_section
+from webui.components.safety_panel import create_safety_panel
 from webui.components.api_config_modal import create_api_config_modal
 from webui.config.constants import COLORS, REFRESH_INTERVALS
 
@@ -164,6 +165,7 @@ def create_main_layout():
             
             # Main content
             header,
+            create_safety_panel(),
             alpaca_account_card,
             dbc.Row([
                 dbc.Col(config_card, md=6),


### PR DESCRIPTION
## What

A chaos-engineering test suite that injects the failure modes a live deployment actually meets at the Alpaca boundary — and fixes the two real defects the probe run uncovered in the safety layer (#32).

> **Stacked PR:** built on `feature/production-safety-layer` (#32). Merging #32 first reduces this to the chaos commit alone.

## Defects found and fixed

Before writing the tests, each hypothesis was probed against the real guard. Two were confirmed as live bugs in `SafetyGuard.check_order`:

1. **NaN equity permanently disables the drawdown breaker.** `float("nan")` passed the truthiness gate, every NaN comparison is `False`, so a NaN arriving while the high-water mark was unset got **stored as the HWM** — after which `equity > nan` is always `False` and the drawdown breaker can never fire again, surviving restarts via the persisted state file.
2. **HTML error pages crash the guard.** An nginx `401 Authorization Required` body in an equity field raised `ValueError` inside `check_order` itself.

Fix: every broker-supplied number now parses through a finite-float gate — non-finite or unparseable values read as *unavailable*, dependent checks report `skipped` (never pass-by-NaN), and nothing non-finite can enter the high-water mark. NaN `notional` / `position_value` are sanitized too, so the concentration cap can't be silently defeated.

## Chaos scenarios (mock-injected, no network, no keys)

| Hypothesis | Verified behavior |
|---|---|
| NaN / inf / HTML in account fields | breakers `skipped`, HWM never poisoned, no crash |
| API dies mid position-flip (close leg OK, open leg fails/raises) | failure reported, rejection breaker fed, clean error dict |
| Close leg fails | open leg is **never attempted** |
| Kill switch engaged | **zero** broker calls |
| 3–5 consecutive rejections | order flow halted |
| Account endpoint unreachable | degrades to cheap checks; orders not wrongly blocked |
| Garbage positions/account payloads | read as NEUTRAL / zeroed info, no exception |

## Tests

15 new tests in `tests/test_chaos_resilience.py`; existing safety tests untouched and green. Full suite on this branch: **90 passed (+133 subtests)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
