### PR TITLE
feat: portfolio-level intelligence - correlation-aware, vol-scaled, exposure-capped sizing

### DIFF
--- a/tests/test_portfolio_intelligence.py
+++ b/tests/test_portfolio_intelligence.py
@@ -1,0 +1,239 @@
+"""Tests for the deterministic portfolio-intelligence layer.
+
+The layer sits above the per-symbol agent decisions and adjusts NEW
+position sizes only: positive correlation with existing positions above a
+threshold scales the size down, realized volatility above the target
+scales it down (inverse-volatility / simplified risk parity), and a gross
+exposure cap clips what remains. Factors never size a trade UP, missing
+data never punishes, and only an explicit exposure clip may zero a trade.
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from tradingagents.portfolio import (
+    PortfolioLimitsConfig,
+    adjust_new_position_notional,
+    assess_new_position,
+    daily_returns,
+    realized_daily_vol,
+)
+
+
+def _frame(closes, start="2025-01-06"):
+    dates = pd.bdate_range(start=start, periods=len(closes))
+    closes = list(closes)
+    return pd.DataFrame(
+        {
+            "timestamp": dates,
+            "open": closes,
+            "high": [c * 1.01 for c in closes],
+            "low": [c * 0.99 for c in closes],
+            "close": closes,
+            "volume": [1000.0] * len(closes),
+        }
+    )
+
+
+def _trending(n=80, drift=0.01, noise_seed=7, scale=0.001):
+    rng = np.random.default_rng(noise_seed)
+    returns = drift + rng.normal(0, scale, n)
+    return list(100 * np.cumprod(1 + returns))
+
+
+def _config(**overrides):
+    return PortfolioLimitsConfig(**overrides)
+
+
+class ReturnMathTests(unittest.TestCase):
+    def test_daily_returns_shape(self):
+        returns = daily_returns(_frame([100, 110, 99]))
+        self.assertEqual(len(returns), 2)
+        self.assertAlmostEqual(returns.iloc[0], 0.10)
+
+    def test_realized_vol_of_constant_series_is_zero(self):
+        vol = realized_daily_vol(daily_returns(_frame([100] * 30)))
+        self.assertEqual(vol, 0.0)
+
+
+class CorrelationPenaltyTests(unittest.TestCase):
+    def test_highly_correlated_candidate_is_scaled_down(self):
+        closes = _trending()
+        # Same series shifted in level: correlation ~1.
+        verdict = assess_new_position(
+            symbol="MSFT",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={"AAPL": 20_000.0},
+            price_history={"MSFT": _frame(closes), "AAPL": _frame([c * 2 for c in closes])},
+            config=_config(vol_sizing_enabled=False),
+        )
+        self.assertLess(verdict.adjusted_notional, 10_000.0)
+        self.assertAlmostEqual(
+            verdict.adjusted_notional, 10_000.0 * verdict.config.correlated_size_factor
+        )
+        self.assertTrue(any("correlation" in r.lower() for r in verdict.reasons))
+
+    def test_uncorrelated_candidate_keeps_full_size(self):
+        rng = np.random.default_rng(3)
+        a = list(100 * np.cumprod(1 + rng.normal(0, 0.01, 80)))
+        b = list(100 * np.cumprod(1 + rng.normal(0, 0.01, 80)))
+        verdict = assess_new_position(
+            symbol="GLD",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={"AAPL": 20_000.0},
+            price_history={"GLD": _frame(a), "AAPL": _frame(b)},
+            config=_config(vol_sizing_enabled=False),
+        )
+        self.assertEqual(verdict.adjusted_notional, 10_000.0)
+
+    def test_negative_correlation_is_not_punished(self):
+        closes = _trending()
+        inverse = [200 - c + 100 for c in closes]  # strongly negative corr
+        verdict = assess_new_position(
+            symbol="SH",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={"AAPL": 20_000.0},
+            price_history={"SH": _frame(inverse), "AAPL": _frame(closes)},
+            config=_config(vol_sizing_enabled=False),
+        )
+        self.assertEqual(verdict.adjusted_notional, 10_000.0)
+
+
+class VolatilitySizingTests(unittest.TestCase):
+    def test_high_vol_candidate_is_scaled_down(self):
+        rng = np.random.default_rng(11)
+        wild = list(100 * np.cumprod(1 + rng.normal(0, 0.06, 80)))  # ~6% daily vol
+        verdict = assess_new_position(
+            symbol="MEME",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={},
+            price_history={"MEME": _frame(wild)},
+            config=_config(target_daily_vol_pct=2.0),
+        )
+        self.assertLess(verdict.adjusted_notional, 10_000.0)
+        self.assertTrue(any("volatility" in r.lower() for r in verdict.reasons))
+
+    def test_calm_candidate_is_never_sized_up(self):
+        calm = list(np.linspace(100, 101, 80))  # tiny vol
+        verdict = assess_new_position(
+            symbol="BOND",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={},
+            price_history={"BOND": _frame(calm)},
+            config=_config(target_daily_vol_pct=2.0),
+        )
+        self.assertEqual(verdict.adjusted_notional, 10_000.0)
+
+
+class ExposureCapTests(unittest.TestCase):
+    def test_gross_exposure_headroom_clips_notional(self):
+        verdict = assess_new_position(
+            symbol="NVDA",
+            requested_notional=30_000.0,
+            equity=100_000.0,
+            open_positions={"AAPL": 80_000.0},
+            price_history={},
+            config=_config(max_gross_exposure_pct=100.0),
+        )
+        # Headroom is 100k - 80k = 20k.
+        self.assertEqual(verdict.adjusted_notional, 20_000.0)
+        self.assertTrue(any("exposure" in r.lower() for r in verdict.reasons))
+
+    def test_no_headroom_zeroes_the_trade_with_reason(self):
+        verdict = assess_new_position(
+            symbol="NVDA",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={"AAPL": 100_000.0},
+            price_history={},
+            config=_config(max_gross_exposure_pct=100.0),
+        )
+        self.assertEqual(verdict.adjusted_notional, 0.0)
+        self.assertFalse(verdict.allowed)
+
+
+class RobustnessTests(unittest.TestCase):
+    def test_missing_price_data_keeps_full_size_with_warning(self):
+        verdict = assess_new_position(
+            symbol="NEW",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={"AAPL": 10_000.0},
+            price_history={},  # nothing available
+            config=_config(),
+        )
+        self.assertEqual(verdict.adjusted_notional, 10_000.0)
+        self.assertTrue(verdict.allowed)
+        self.assertTrue(any("unavailable" in r.lower() for r in verdict.reasons))
+
+    def test_min_size_factor_floors_combined_penalties(self):
+        closes = _trending()
+        rng = np.random.default_rng(11)
+        wild = list(
+            np.array(closes) * np.cumprod(1 + rng.normal(0, 0.06, len(closes)))
+        )
+        config = _config(min_size_factor=0.25, target_daily_vol_pct=0.5)
+        verdict = assess_new_position(
+            symbol="MEME",
+            requested_notional=10_000.0,
+            equity=1_000_000.0,
+            open_positions={"AAPL": 10_000.0},
+            price_history={"MEME": _frame(wild), "AAPL": _frame(closes)},
+            config=config,
+        )
+        self.assertGreaterEqual(verdict.adjusted_notional, 2_500.0)
+
+    def test_adjust_helper_only_touches_new_long_exposure(self):
+        # SELL/HOLD and closes pass through untouched even with data present.
+        for action in ("SELL", "HOLD", "NEUTRAL"):
+            amount = adjust_new_position_notional(
+                symbol="AAPL",
+                action=action,
+                requested_notional=5_000.0,
+                gather_state=lambda: (100_000.0, {"MSFT": 50_000.0}, {}),
+                config=_config(),
+            )
+            self.assertEqual(amount, 5_000.0)
+
+    def test_adjust_helper_survives_gather_failure(self):
+        def broken_gather():
+            raise ConnectionError("broker down")
+
+        amount = adjust_new_position_notional(
+            symbol="AAPL",
+            action="BUY",
+            requested_notional=5_000.0,
+            gather_state=broken_gather,
+            config=_config(),
+        )
+        self.assertEqual(amount, 5_000.0)
+
+
+class ConfigTests(unittest.TestCase):
+    def test_default_config_exposes_portfolio_keys(self):
+        from tradingagents.default_config import DEFAULT_CONFIG
+
+        self.assertIn("portfolio_intelligence_enabled", DEFAULT_CONFIG)
+        self.assertIn("portfolio_high_correlation", DEFAULT_CONFIG)
+        self.assertIn("portfolio_max_gross_exposure_pct", DEFAULT_CONFIG)
+
+    def test_from_config_reads_project_keys(self):
+        config = PortfolioLimitsConfig.from_config(
+            {
+                "portfolio_high_correlation": 0.5,
+                "portfolio_max_gross_exposure_pct": 80.0,
+            }
+        )
+        self.assertEqual(config.high_correlation, 0.5)
+        self.assertEqual(config.max_gross_exposure_pct, 80.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -51,6 +51,15 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 200,
     # Trading settings
     "allow_shorts": False,  # False = Investment mode (BUY/HOLD/SELL), True = Trading mode (LONG/NEUTRAL/SHORT)
+    # Portfolio-level intelligence (deterministic sizing above per-symbol decisions)
+    "portfolio_intelligence_enabled": True,  # Master switch for portfolio-aware sizing of new long exposure
+    "portfolio_lookback_bars": 60,  # Daily bars used for correlation / volatility estimates
+    "portfolio_high_correlation": 0.6,  # Positive correlation above this = duplicated risk
+    "portfolio_correlated_size_factor": 0.5,  # Size multiplier applied on a correlation hit
+    "portfolio_vol_sizing_enabled": True,  # Inverse-volatility (simplified risk parity) sizing
+    "portfolio_target_daily_vol_pct": 2.0,  # Realized daily vol above this scales size by target/realized
+    "portfolio_max_gross_exposure_pct": 100.0,  # Total book value cap as % of equity; 0 = uncapped
+    "portfolio_min_size_factor": 0.25,  # Floor on combined penalties so trades never silently vanish
     # Execution settings
     "parallel_analysts": True,  # True = Run analysts in parallel for faster execution, False = Sequential execution
     "parallel_risk_first_round": True,  # Run Risky/Safe/Neutral in parallel only for round 1, then revert to linear flow

--- a/tradingagents/portfolio/__init__.py
+++ b/tradingagents/portfolio/__init__.py
@@ -1,0 +1,306 @@
+"""Deterministic portfolio-level intelligence.
+
+The agent pipeline analyzes each symbol in isolation; nothing ever looks at
+the book as a whole. This layer sits above the per-symbol decisions and
+adjusts the size of NEW long exposure with three plain-arithmetic guards —
+zero LLM involvement, so it cannot be argued out of a limit:
+
+- **Correlation penalty**: a candidate whose returns correlate above a
+  threshold (default 0.6 — the level practitioners treat as duplicated
+  risk) with any existing position is scaled down. Only positive
+  correlation is penalized; a strong negative correlation is a hedge.
+- **Inverse-volatility sizing** (simplified risk parity): realized daily
+  volatility above the target scales the size by target/realized. Chosen
+  over optimization because it needs no return forecasts and stays stable.
+- **Gross exposure cap**: total book value is clipped to a percentage of
+  equity; this is the only guard allowed to zero a trade, and it says why.
+
+Sizing rules: factors never size a trade UP (the agents' requested amount
+is the ceiling), missing data never punishes (factor 1.0 plus a warning),
+and combined penalties are floored so trades cannot silently vanish.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Tuple
+
+import pandas as pd
+
+_MIN_OVERLAP_BARS = 20  # fewer shared bars than this makes correlation noise
+
+
+@dataclass
+class PortfolioLimitsConfig:
+    enabled: bool = True
+    lookback_bars: int = 60
+    high_correlation: float = 0.6
+    correlated_size_factor: float = 0.5
+    vol_sizing_enabled: bool = True
+    target_daily_vol_pct: float = 2.0
+    max_gross_exposure_pct: float = 100.0
+    min_size_factor: float = 0.25
+
+    @classmethod
+    def from_config(cls, config: Optional[dict]) -> "PortfolioLimitsConfig":
+        cfg = config or {}
+        mapping = {
+            "enabled": "portfolio_intelligence_enabled",
+            "lookback_bars": "portfolio_lookback_bars",
+            "high_correlation": "portfolio_high_correlation",
+            "correlated_size_factor": "portfolio_correlated_size_factor",
+            "vol_sizing_enabled": "portfolio_vol_sizing_enabled",
+            "target_daily_vol_pct": "portfolio_target_daily_vol_pct",
+            "max_gross_exposure_pct": "portfolio_max_gross_exposure_pct",
+            "min_size_factor": "portfolio_min_size_factor",
+        }
+        kwargs = {}
+        for field_name, key in mapping.items():
+            if cfg.get(key) is not None:
+                kwargs[field_name] = cfg[key]
+        return cls(**kwargs)
+
+
+@dataclass
+class PortfolioVerdict:
+    symbol: str
+    requested_notional: float
+    adjusted_notional: float
+    allowed: bool
+    config: PortfolioLimitsConfig
+    correlations: Dict[str, float] = field(default_factory=dict)
+    factors: Dict[str, float] = field(default_factory=dict)
+    reasons: List[str] = field(default_factory=list)
+
+
+def daily_returns(prices) -> pd.Series:
+    """Close-to-close daily returns from an OHLCV frame or a close series."""
+    if isinstance(prices, pd.Series):
+        closes = prices.astype(float)
+    else:
+        frame = prices.copy()
+        frame.columns = [str(c).lower() for c in frame.columns]
+        if "timestamp" in frame.columns:
+            frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+            frame = frame.set_index("timestamp")
+        if "close" not in frame.columns:
+            raise ValueError("Price data needs a 'close' column.")
+        closes = frame["close"].astype(float)
+    return closes.pct_change().dropna()
+
+
+def realized_daily_vol(returns: pd.Series) -> float:
+    """Standard deviation of daily returns; 0.0 when undefined."""
+    if returns is None or len(returns) < 2:
+        return 0.0
+    vol = float(returns.std())
+    return vol if pd.notna(vol) else 0.0
+
+
+def _candidate_returns(
+    symbol: str, price_history: Dict[str, pd.DataFrame], lookback: int
+) -> Optional[pd.Series]:
+    frame = (price_history or {}).get(symbol)
+    if frame is None or len(frame) < 3:
+        return None
+    try:
+        return daily_returns(frame).tail(lookback)
+    except (ValueError, KeyError, TypeError):
+        return None
+
+
+def assess_new_position(
+    symbol: str,
+    requested_notional: float,
+    equity: Optional[float],
+    open_positions: Dict[str, float],
+    price_history: Dict[str, pd.DataFrame],
+    config: Optional[PortfolioLimitsConfig] = None,
+) -> PortfolioVerdict:
+    """Size a proposed NEW position against the whole book.
+
+    `open_positions` maps symbol -> absolute market value; `price_history`
+    maps symbol -> OHLCV frame (the candidate's own history included).
+    """
+    config = config or PortfolioLimitsConfig()
+    requested = max(float(requested_notional or 0.0), 0.0)
+    verdict = PortfolioVerdict(
+        symbol=symbol,
+        requested_notional=requested,
+        adjusted_notional=requested,
+        allowed=True,
+        config=config,
+    )
+
+    candidate = _candidate_returns(symbol, price_history, config.lookback_bars)
+    factor = 1.0
+
+    # --- correlation against every open position -----------------------------
+    if candidate is not None and open_positions:
+        max_positive = None
+        for other_symbol in open_positions:
+            if other_symbol == symbol:
+                continue
+            other = _candidate_returns(other_symbol, price_history, config.lookback_bars)
+            if other is None:
+                continue
+            aligned = pd.concat([candidate, other], axis=1, join="inner").dropna()
+            if len(aligned) < _MIN_OVERLAP_BARS:
+                continue
+            corr = float(aligned.iloc[:, 0].corr(aligned.iloc[:, 1]))
+            if pd.isna(corr):
+                continue
+            verdict.correlations[other_symbol] = corr
+            if max_positive is None or corr > max_positive:
+                max_positive = corr
+        if max_positive is not None and max_positive > config.high_correlation:
+            factor *= config.correlated_size_factor
+            verdict.factors["correlation"] = config.correlated_size_factor
+            worst = max(verdict.correlations, key=verdict.correlations.get)
+            verdict.reasons.append(
+                f"High correlation with open position {worst} "
+                f"({max_positive:+.2f} > {config.high_correlation:g}): "
+                f"size scaled by {config.correlated_size_factor:g}."
+            )
+
+    # --- inverse-volatility sizing -------------------------------------------
+    if config.vol_sizing_enabled and candidate is not None:
+        vol_pct = realized_daily_vol(candidate) * 100.0
+        if vol_pct > config.target_daily_vol_pct > 0:
+            vol_factor = config.target_daily_vol_pct / vol_pct
+            factor *= vol_factor
+            verdict.factors["volatility"] = vol_factor
+            verdict.reasons.append(
+                f"Realized daily volatility {vol_pct:.2f}% exceeds the "
+                f"{config.target_daily_vol_pct:g}% target: size scaled by {vol_factor:.2f}."
+            )
+
+    if candidate is None:
+        verdict.reasons.append(
+            f"Price history unavailable for {symbol} — correlation and "
+            "volatility sizing skipped, size unchanged."
+        )
+
+    # Penalties are floored so a trade the agents wanted cannot silently
+    # shrink to dust; only the exposure cap below may zero it.
+    if factor < config.min_size_factor:
+        factor = config.min_size_factor
+        verdict.factors["floor"] = config.min_size_factor
+    verdict.adjusted_notional = requested * factor
+
+    # --- gross exposure cap ----------------------------------------------------
+    cap_pct = float(config.max_gross_exposure_pct or 0)
+    equity_value = float(equity) if equity else None
+    if cap_pct > 0 and equity_value and equity_value > 0:
+        gross = sum(abs(float(v or 0.0)) for v in (open_positions or {}).values())
+        headroom = equity_value * cap_pct / 100.0 - gross
+        if verdict.adjusted_notional > headroom:
+            clipped = max(headroom, 0.0)
+            verdict.reasons.append(
+                f"Gross exposure ${gross:,.0f} against a "
+                f"{cap_pct:g}% cap of ${equity_value:,.0f} equity leaves "
+                f"${max(headroom, 0.0):,.0f} headroom: size clipped."
+            )
+            verdict.adjusted_notional = clipped
+    elif cap_pct > 0:
+        verdict.reasons.append(
+            "Account equity unavailable — gross exposure cap skipped."
+        )
+
+    verdict.allowed = verdict.adjusted_notional > 0
+    return verdict
+
+
+def adjust_new_position_notional(
+    symbol: str,
+    action: str,
+    requested_notional: float,
+    gather_state: Callable[[], Tuple[Optional[float], Dict[str, float], Dict[str, pd.DataFrame]]],
+    config: Optional[PortfolioLimitsConfig] = None,
+) -> float:
+    """Execution-time hook: portfolio-aware size for NEW long exposure only.
+
+    SELL/HOLD/NEUTRAL (closing or keeping) pass through untouched — the
+    layer limits what gets added to the book, never what leaves it. Any
+    failure in `gather_state` (broker down, bad data) returns the original
+    amount: the portfolio layer must never block a trade by breaking.
+    """
+    config = config or PortfolioLimitsConfig()
+    if not config.enabled or str(action or "").upper() not in ("BUY", "LONG"):
+        return requested_notional
+    try:
+        equity, open_positions, price_history = gather_state()
+        verdict = assess_new_position(
+            symbol,
+            requested_notional,
+            equity,
+            open_positions or {},
+            price_history or {},
+            config=config,
+        )
+        for reason in verdict.reasons:
+            print(f"[PORTFOLIO] {symbol}: {reason}")
+        if verdict.adjusted_notional != requested_notional:
+            print(
+                f"[PORTFOLIO] {symbol}: requested ${requested_notional:,.0f} -> "
+                f"adjusted ${verdict.adjusted_notional:,.0f}"
+            )
+        return verdict.adjusted_notional
+    except Exception as exc:
+        print(f"[PORTFOLIO] Sizing skipped for {symbol}: {exc}")
+        return requested_notional
+
+
+def gather_portfolio_state_via_alpaca(
+    symbol: str,
+    lookback_days: int = 120,
+) -> Tuple[Optional[float], Dict[str, float], Dict[str, pd.DataFrame]]:
+    """Collect (equity, open positions, price history) from Alpaca.
+
+    Imported lazily so this package stays importable without the dataflows
+    stack; the caller wraps failures via adjust_new_position_notional.
+    """
+    from datetime import date, timedelta
+
+    from tradingagents.dataflows.alpaca_utils import (
+        AlpacaUtils,
+        get_alpaca_trading_client,
+    )
+
+    client = get_alpaca_trading_client()
+    account = client.get_account()
+    try:
+        equity = float(account.equity)
+    except (TypeError, ValueError):
+        equity = None
+
+    open_positions: Dict[str, float] = {}
+    for pos in client.get_all_positions():
+        try:
+            open_positions[str(pos.symbol).upper()] = abs(float(pos.market_value))
+        except (TypeError, ValueError):
+            continue
+
+    start = (date.today() - timedelta(days=lookback_days)).isoformat()
+    price_history: Dict[str, pd.DataFrame] = {}
+    for wanted in {symbol.upper().replace("/", ""), *open_positions}:
+        try:
+            price_history[wanted] = AlpacaUtils.get_stock_data(wanted, start, None)
+        except Exception:
+            continue
+    # The candidate may have been requested with its display symbol.
+    key = symbol.upper().replace("/", "")
+    if key in price_history and symbol not in price_history:
+        price_history[symbol] = price_history[key]
+    return equity, open_positions, price_history
+
+
+__all__ = [
+    "PortfolioLimitsConfig",
+    "PortfolioVerdict",
+    "adjust_new_position_notional",
+    "assess_new_position",
+    "daily_returns",
+    "gather_portfolio_state_via_alpaca",
+    "realized_daily_vol",
+]

--- a/webui/components/analysis.py
+++ b/webui/components/analysis.py
@@ -67,6 +67,33 @@ def execute_trade_after_analysis(ticker, allow_shorts, trade_amount):
 
         print(f"[TRADE] Executing trade for {ticker}: {recommended_action} with ${trade_amount}")
 
+        # Portfolio-level sizing: deterministic layer above the per-symbol
+        # decision (correlation penalty, inverse-vol sizing, gross exposure
+        # cap). Failure-isolated: any problem keeps the requested amount.
+        try:
+            from tradingagents.dataflows.config import get_config
+            from tradingagents.portfolio import (
+                PortfolioLimitsConfig,
+                adjust_new_position_notional,
+                gather_portfolio_state_via_alpaca,
+            )
+
+            trade_amount = adjust_new_position_notional(
+                symbol=ticker,
+                action=recommended_action,
+                requested_notional=trade_amount,
+                gather_state=lambda: gather_portfolio_state_via_alpaca(ticker),
+                config=PortfolioLimitsConfig.from_config(get_config() or {}),
+            )
+            if trade_amount <= 0:
+                print(
+                    f"[TRADE] Portfolio layer zeroed the {ticker} order "
+                    "(no gross-exposure headroom); skipping execution."
+                )
+                return
+        except Exception as exc:
+            print(f"[TRADE] Portfolio sizing unavailable for {ticker}: {exc}")
+
         # Get current position
         current_position = AlpacaUtils.get_current_position_state(ticker)
         print(f"[TRADE] Current position for {ticker}: {current_position}")


### PR DESCRIPTION
## What

The biggest structural gap left in the pipeline: **every symbol is analyzed in isolation**. Nothing ever looks at the book as a whole, so three highly-correlated BUYs stack the same risk three times and a hot streak can quietly max out gross exposure.

This adds a deterministic portfolio layer above the per-symbol agent decisions — plain arithmetic, zero LLM involvement, so it cannot be argued out of a limit. Based on `origin/main` directly (no stack).

## The three guards

1. **Correlation penalty** — a candidate whose daily returns correlate above **0.6** (the level practitioners treat as duplicated risk) with *any* open position is scaled down (default ×0.5). Only positive correlation is penalized: strong negative correlation is a hedge and keeps full size.
2. **Inverse-volatility sizing** (simplified risk parity) — realized daily volatility above the target (default 2%) scales the size by `target/realized`. Chosen over optimization on purpose: it needs no return forecasts (whose estimation errors destabilize Markowitz-style weights) and produces stable sizes.
3. **Gross exposure cap** — total book value is clipped to a % of equity (default 100%). This is the only guard allowed to zero a trade, and it states why.

## Design rules

- **Never size up**: the agents' requested amount is the ceiling; the layer only trims.
- **Missing data never punishes**: no price history → factor 1.0 plus a logged warning.
- **Trades can't silently vanish**: combined penalties are floored (default 0.25); only the explicit exposure clip may zero an order.
- **Only new exposure is sized**: SELL/HOLD/close actions pass through untouched — the layer limits what enters the book, never what leaves it.

## Wiring

Hooked into the WebUI execution path immediately before order placement, config-gated (`portfolio_intelligence_enabled` + 7 tuning keys in `default_config.py`) and failure-isolated: any broker or data failure keeps the original amount. The core (`tradingagents/portfolio/`) is dependency-light and importable without the dataflows stack.

## Tests

15 new tests (correlation hit/pass/negative-hedge, vol scaling up-and-down bounds, headroom clipping and zeroing, missing-data neutrality, penalty floor, pass-through of non-BUY actions, gather-failure survival, config wiring). Full suite: **68 passed (+133 subtests)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
