### PR TITLE
feat: deterministic market-regime detection - context injection + regime-scaled sizing

### DIFF
--- a/tests/test_regime_detection.py
+++ b/tests/test_regime_detection.py
@@ -1,0 +1,145 @@
+"""Tests for deterministic market-regime detection.
+
+Three cheap observable dimensions — realized-volatility percentile (with an
+absolute annualized floor), price-vs-SMA trend, and dollar-volume liquidity
+— combine into a regime label and a risk multiplier that only ever shrinks
+position sizes. A regime filter, not a signal generator: hostile regimes
+reduce size, they never flip decisions. Missing data reads as unknown with
+multiplier 1.0.
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from tradingagents.regime import (
+    RegimeConfig,
+    classify_regime,
+    regime_report_block,
+    regime_risk_multiplier,
+)
+
+
+def _frame(closes, volumes=None, start="2024-01-01"):
+    closes = list(closes)
+    dates = pd.bdate_range(start=start, periods=len(closes))
+    volumes = volumes if volumes is not None else [1_000_000.0] * len(closes)
+    return pd.DataFrame(
+        {
+            "timestamp": dates,
+            "open": closes,
+            "high": [c * 1.005 for c in closes],
+            "low": [c * 0.995 for c in closes],
+            "close": closes,
+            "volume": volumes,
+        }
+    )
+
+
+def _calm_uptrend(n=300, seed=5):
+    rng = np.random.default_rng(seed)
+    return list(100 * np.cumprod(1 + 0.0008 + rng.normal(0, 0.004, n)))
+
+
+def _calm_then_crash(n_calm=260, n_crash=40, seed=9):
+    rng = np.random.default_rng(seed)
+    calm = 0.0005 + rng.normal(0, 0.004, n_calm)
+    crash = -0.02 + rng.normal(0, 0.035, n_crash)
+    return list(100 * np.cumprod(1 + np.concatenate([calm, crash])))
+
+
+class ClassificationTests(unittest.TestCase):
+    def test_calm_uptrend_is_favorable_full_size(self):
+        assessment = classify_regime(_frame(_calm_uptrend()), symbol="SPY")
+        self.assertEqual(assessment.trend_state, "up")
+        self.assertIn(assessment.volatility_state, ("calm", "normal"))
+        self.assertEqual(assessment.label, "favorable")
+        self.assertEqual(assessment.risk_multiplier, 1.0)
+
+    def test_volatile_crash_is_hostile_and_shrinks_size(self):
+        assessment = classify_regime(_frame(_calm_then_crash()), symbol="SPY")
+        self.assertEqual(assessment.volatility_state, "turbulent")
+        self.assertEqual(assessment.trend_state, "down")
+        self.assertEqual(assessment.label, "hostile")
+        # 0.5 (turbulent) * 0.75 (downtrend) = 0.375
+        self.assertAlmostEqual(assessment.risk_multiplier, 0.375)
+
+    def test_persistently_wild_asset_hits_absolute_vol_floor(self):
+        # Constant 4% daily noise: its own percentile history is unremarkable,
+        # but ~63% annualized vol must still read as turbulent.
+        rng = np.random.default_rng(2)
+        closes = list(100 * np.cumprod(1 + rng.normal(0, 0.04, 300)))
+        assessment = classify_regime(_frame(closes), symbol="MEME")
+        self.assertEqual(assessment.volatility_state, "turbulent")
+
+    def test_thinning_liquidity_is_flagged_and_penalized(self):
+        closes = _calm_uptrend()
+        volumes = [1_000_000.0] * 240 + [200_000.0] * 60
+        assessment = classify_regime(_frame(closes, volumes), symbol="SMALL")
+        self.assertEqual(assessment.liquidity_state, "thinning")
+        self.assertLess(assessment.risk_multiplier, 1.0)
+
+    def test_insufficient_history_reads_unknown_full_size(self):
+        assessment = classify_regime(_frame(_calm_uptrend(10)), symbol="IPO")
+        self.assertEqual(assessment.volatility_state, "unknown")
+        self.assertEqual(assessment.risk_multiplier, 1.0)
+
+    def test_multiplier_never_below_floor(self):
+        closes = _calm_then_crash()
+        volumes = [1_000_000.0] * 240 + [100_000.0] * 60
+        config = RegimeConfig(min_risk_multiplier=0.3)
+        assessment = classify_regime(_frame(closes, volumes), config=config)
+        self.assertGreaterEqual(assessment.risk_multiplier, 0.3)
+
+    def test_markdown_block_names_all_three_dimensions(self):
+        assessment = classify_regime(_frame(_calm_uptrend()), symbol="SPY")
+        text = assessment.to_markdown()
+        for needle in ("Regime", "Volatility", "Trend", "Liquidity"):
+            self.assertIn(needle, text)
+
+
+class InjectionHelperTests(unittest.TestCase):
+    def test_report_block_uses_injected_loader(self):
+        block = regime_report_block(
+            "SPY", price_loader=lambda symbol, start, end: _frame(_calm_uptrend())
+        )
+        self.assertIn("Market Regime", block)
+        self.assertIn("favorable", block)
+
+    def test_report_block_swallows_loader_failure(self):
+        def broken(symbol, start, end):
+            raise ConnectionError("data source down")
+
+        self.assertEqual(regime_report_block("SPY", price_loader=broken), "")
+
+    def test_risk_multiplier_helper(self):
+        multiplier = regime_risk_multiplier(
+            "SPY", price_loader=lambda symbol, start, end: _frame(_calm_then_crash())
+        )
+        self.assertAlmostEqual(multiplier, 0.375)
+
+    def test_risk_multiplier_helper_failure_is_neutral(self):
+        def broken(symbol, start, end):
+            raise ConnectionError("data source down")
+
+        self.assertEqual(regime_risk_multiplier("SPY", price_loader=broken), 1.0)
+
+
+class ConfigTests(unittest.TestCase):
+    def test_default_config_exposes_regime_keys(self):
+        from tradingagents.default_config import DEFAULT_CONFIG
+
+        self.assertIn("regime_detection_enabled", DEFAULT_CONFIG)
+        self.assertIn("regime_turbulent_size_factor", DEFAULT_CONFIG)
+
+    def test_from_config_reads_project_keys(self):
+        config = RegimeConfig.from_config(
+            {"regime_turbulent_size_factor": 0.4, "regime_trend_window": 30}
+        )
+        self.assertEqual(config.turbulent_size_factor, 0.4)
+        self.assertEqual(config.trend_window, 30)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -303,9 +303,25 @@ def create_market_analyst(llm, toolkit):
         else:
             result = AIMessage(content=_normalize_market_report_markdown(analysis_content))
 
+        # Deterministic regime context: computed from price/volume history
+        # (no LLM), appended so every downstream agent that reads the market
+        # report sees the same risk-posture facts. Failure-isolated.
+        market_report = result.content
+        try:
+            from tradingagents.dataflows.config import get_config
+            from tradingagents.regime import RegimeConfig, regime_report_block
+
+            regime_block = regime_report_block(
+                ticker, config=RegimeConfig.from_config(get_config() or {})
+            )
+            if regime_block:
+                market_report = f"{market_report}\n\n{regime_block}"
+        except Exception as exc:
+            print(f"[REGIME] Market-report injection skipped for {ticker}: {exc}")
+
         return {
             "messages": [result],
-            "market_report": result.content,
+            "market_report": market_report,
         }
 
     return market_analyst_node

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -51,6 +51,17 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 200,
     # Trading settings
     "allow_shorts": False,  # False = Investment mode (BUY/HOLD/SELL), True = Trading mode (LONG/NEUTRAL/SHORT)
+    # Market regime detection (deterministic, fit-free; filter not signal)
+    "regime_detection_enabled": True,  # Inject regime block into the market report and scale sizing
+    "regime_vol_window": 20,  # Bars for realized-volatility estimate
+    "regime_turbulent_percentile": 75.0,  # Vol percentile above which the regime is turbulent
+    "regime_turbulent_abs_annual_vol_pct": 40.0,  # Absolute annualized-vol floor for turbulence
+    "regime_trend_window": 50,  # SMA window for the trend dimension
+    "regime_thin_liquidity_ratio": 0.7,  # Recent/baseline dollar-volume ratio below this = thinning
+    "regime_turbulent_size_factor": 0.5,  # Size multiplier in turbulent volatility
+    "regime_downtrend_size_factor": 0.75,  # Size multiplier in a downtrend
+    "regime_thin_liquidity_size_factor": 0.85,  # Size multiplier when liquidity is thinning
+    "regime_min_risk_multiplier": 0.25,  # Floor for the combined regime multiplier
     # Execution settings
     "parallel_analysts": True,  # True = Run analysts in parallel for faster execution, False = Sequential execution
     "parallel_risk_first_round": True,  # Run Risky/Safe/Neutral in parallel only for round 1, then revert to linear flow

--- a/tradingagents/regime.py
+++ b/tradingagents/regime.py
@@ -1,0 +1,319 @@
+"""Deterministic market-regime detection.
+
+A cheap, fit-free regime filter over three observable dimensions:
+
+- **Volatility**: realized vol (20-bar) ranked against its own trailing
+  history (252 bars), with an absolute annualized floor so persistently
+  wild assets — whose own percentile history looks unremarkable — still
+  read as turbulent.
+- **Trend**: price vs its SMA plus the SMA's recent slope (up/down/sideways).
+- **Liquidity**: recent average dollar volume vs a longer baseline
+  (thinning/normal/surging).
+
+Threshold rules were chosen over an HMM deliberately: practitioners get
+most of the regime-filter value from the realized-vol percentile plus a
+trend filter, with no fitting, no initialization sensitivity, and no new
+dependency. The output is used as a *filter*, not a signal generator —
+hostile regimes shrink position sizes (multiplicative factors with a
+floor), they never flip the agents' decisions. Missing data reads as
+unknown with multiplier 1.0: absence of evidence never punishes.
+
+Two integration points, both failure-isolated and config-gated:
+- ``regime_report_block`` appends a deterministic markdown section to the
+  market analyst's report, which every downstream agent already reads.
+- ``regime_risk_multiplier`` scales the trade amount at execution time.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Optional
+
+import pandas as pd
+
+_ANNUALIZATION = math.sqrt(252)
+
+
+@dataclass
+class RegimeConfig:
+    enabled: bool = True
+    vol_window: int = 20
+    vol_percentile_window: int = 252
+    calm_percentile: float = 40.0
+    turbulent_percentile: float = 75.0
+    turbulent_abs_annual_vol_pct: float = 40.0
+    trend_window: int = 50
+    trend_slope_bars: int = 5
+    liquidity_window: int = 20
+    liquidity_baseline_window: int = 60
+    thin_liquidity_ratio: float = 0.7
+    surging_liquidity_ratio: float = 1.5
+    turbulent_size_factor: float = 0.5
+    downtrend_size_factor: float = 0.75
+    thin_liquidity_size_factor: float = 0.85
+    min_risk_multiplier: float = 0.25
+
+    @classmethod
+    def from_config(cls, config: Optional[dict]) -> "RegimeConfig":
+        cfg = config or {}
+        mapping = {
+            "enabled": "regime_detection_enabled",
+            "vol_window": "regime_vol_window",
+            "turbulent_percentile": "regime_turbulent_percentile",
+            "turbulent_abs_annual_vol_pct": "regime_turbulent_abs_annual_vol_pct",
+            "trend_window": "regime_trend_window",
+            "thin_liquidity_ratio": "regime_thin_liquidity_ratio",
+            "turbulent_size_factor": "regime_turbulent_size_factor",
+            "downtrend_size_factor": "regime_downtrend_size_factor",
+            "thin_liquidity_size_factor": "regime_thin_liquidity_size_factor",
+            "min_risk_multiplier": "regime_min_risk_multiplier",
+        }
+        kwargs = {}
+        for field_name, key in mapping.items():
+            if cfg.get(key) is not None:
+                kwargs[field_name] = cfg[key]
+        return cls(**kwargs)
+
+
+@dataclass
+class RegimeAssessment:
+    symbol: str
+    volatility_state: str  # calm | normal | turbulent | unknown
+    trend_state: str  # up | down | sideways | unknown
+    liquidity_state: str  # normal | thinning | surging | unknown
+    label: str  # favorable | mixed | hostile | unknown
+    risk_multiplier: float
+    metrics: Dict[str, float] = field(default_factory=dict)
+    notes: list = field(default_factory=list)
+
+    def to_markdown(self) -> str:
+        lines = [
+            "## Market Regime (deterministic indicator)",
+            f"- **Regime**: {self.label}"
+            + (f" — position sizing scaled to {self.risk_multiplier:.0%}" if self.risk_multiplier < 1.0 else ""),
+            f"- **Volatility**: {self.volatility_state}"
+            + (
+                f" (realized {self.metrics['annualized_vol_pct']:.1f}% annualized, "
+                f"p{self.metrics['vol_percentile']:.0f} of its own history)"
+                if "annualized_vol_pct" in self.metrics
+                else ""
+            ),
+            f"- **Trend**: {self.trend_state}"
+            + (
+                f" (price {self.metrics['price_vs_sma_pct']:+.1f}% vs SMA{int(self.metrics.get('trend_window', 0))})"
+                if "price_vs_sma_pct" in self.metrics
+                else ""
+            ),
+            f"- **Liquidity**: {self.liquidity_state}"
+            + (
+                f" (recent dollar volume {self.metrics['liquidity_ratio']:.2f}x its baseline)"
+                if "liquidity_ratio" in self.metrics
+                else ""
+            ),
+        ]
+        if self.notes:
+            lines.extend(f"- {note}" for note in self.notes)
+        lines.append(
+            "- This block is computed deterministically from price/volume history "
+            "— treat it as context for risk posture, not as a trade signal."
+        )
+        return "\n".join(lines)
+
+
+def _normalize(prices: pd.DataFrame) -> pd.DataFrame:
+    frame = prices.copy()
+    frame.columns = [str(c).lower() for c in frame.columns]
+    if "timestamp" in frame.columns:
+        frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+        frame = frame.set_index("timestamp")
+    if "close" not in frame.columns:
+        raise ValueError("Price data needs a 'close' column.")
+    if "volume" not in frame.columns:
+        frame["volume"] = 0.0
+    return frame.sort_index()
+
+
+def classify_regime(
+    prices: pd.DataFrame,
+    config: Optional[RegimeConfig] = None,
+    symbol: str = "",
+) -> RegimeAssessment:
+    """Classify the current regime from an OHLCV history (newest last)."""
+    config = config or RegimeConfig()
+    unknown = RegimeAssessment(
+        symbol=symbol,
+        volatility_state="unknown",
+        trend_state="unknown",
+        liquidity_state="unknown",
+        label="unknown",
+        risk_multiplier=1.0,
+        notes=["Insufficient price history for regime classification."],
+    )
+    try:
+        frame = _normalize(prices)
+    except (ValueError, AttributeError, TypeError):
+        return unknown
+
+    closes = frame["close"].astype(float)
+    returns = closes.pct_change().dropna()
+    if len(returns) < config.vol_window + config.trend_slope_bars:
+        return unknown
+
+    metrics: Dict[str, float] = {}
+    notes = []
+
+    # --- volatility ------------------------------------------------------------
+    rolling_vol = returns.rolling(config.vol_window).std().dropna()
+    current_vol = float(rolling_vol.iloc[-1])
+    annualized_pct = current_vol * _ANNUALIZATION * 100.0
+    history = rolling_vol.tail(config.vol_percentile_window)
+    percentile = float((history <= current_vol).mean() * 100.0)
+    metrics["annualized_vol_pct"] = annualized_pct
+    metrics["vol_percentile"] = percentile
+
+    if (
+        percentile >= config.turbulent_percentile
+        or annualized_pct >= config.turbulent_abs_annual_vol_pct
+    ):
+        vol_state = "turbulent"
+        if annualized_pct >= config.turbulent_abs_annual_vol_pct:
+            notes.append(
+                f"Absolute volatility floor hit: {annualized_pct:.0f}% annualized "
+                f"exceeds {config.turbulent_abs_annual_vol_pct:g}%."
+            )
+    elif percentile <= config.calm_percentile:
+        vol_state = "calm"
+    else:
+        vol_state = "normal"
+
+    # --- trend -------------------------------------------------------------------
+    if len(closes) >= config.trend_window + config.trend_slope_bars:
+        sma = closes.rolling(config.trend_window).mean().dropna()
+        price = float(closes.iloc[-1])
+        sma_now = float(sma.iloc[-1])
+        sma_then = float(sma.iloc[-1 - config.trend_slope_bars])
+        metrics["price_vs_sma_pct"] = (price / sma_now - 1.0) * 100.0
+        metrics["trend_window"] = float(config.trend_window)
+        if price > sma_now and sma_now > sma_then:
+            trend_state = "up"
+        elif price < sma_now and sma_now < sma_then:
+            trend_state = "down"
+        else:
+            trend_state = "sideways"
+    else:
+        trend_state = "unknown"
+
+    # --- liquidity -----------------------------------------------------------------
+    # Share volume, not dollar volume: a price collapse would drag dollar
+    # volume down by itself and double-count what the trend factor already
+    # penalizes. Thinning here means participation drying up.
+    volume = frame["volume"].astype(float).dropna()
+    needed = config.liquidity_window + config.liquidity_baseline_window
+    if float(volume.sum()) > 0 and len(volume) >= needed:
+        recent = float(volume.tail(config.liquidity_window).mean())
+        # Baseline strictly precedes the recent window, otherwise a slow
+        # bleed would drag its own baseline down and hide the thinning.
+        baseline = float(volume.iloc[-needed : -config.liquidity_window].mean())
+        if baseline > 0:
+            ratio = recent / baseline
+            metrics["liquidity_ratio"] = ratio
+            if ratio < config.thin_liquidity_ratio:
+                liquidity_state = "thinning"
+            elif ratio > config.surging_liquidity_ratio:
+                liquidity_state = "surging"
+            else:
+                liquidity_state = "normal"
+        else:
+            liquidity_state = "unknown"
+    else:
+        liquidity_state = "unknown"
+
+    # --- multiplier and label --------------------------------------------------------
+    multiplier = 1.0
+    if vol_state == "turbulent":
+        multiplier *= config.turbulent_size_factor
+    if trend_state == "down":
+        multiplier *= config.downtrend_size_factor
+    if liquidity_state == "thinning":
+        multiplier *= config.thin_liquidity_size_factor
+    multiplier = max(multiplier, config.min_risk_multiplier)
+
+    if vol_state == "turbulent" or (trend_state == "down" and liquidity_state == "thinning"):
+        label = "hostile"
+    elif trend_state == "up" and vol_state in ("calm", "normal") and liquidity_state != "thinning":
+        label = "favorable"
+    else:
+        label = "mixed"
+
+    return RegimeAssessment(
+        symbol=symbol,
+        volatility_state=vol_state,
+        trend_state=trend_state,
+        liquidity_state=liquidity_state,
+        label=label,
+        risk_multiplier=multiplier if label != "favorable" else 1.0,
+        metrics=metrics,
+        notes=notes,
+    )
+
+
+def _default_price_loader():
+    from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+    return AlpacaUtils.get_stock_data
+
+
+def _load_assessment(
+    symbol: str,
+    price_loader: Optional[Callable] = None,
+    config: Optional[RegimeConfig] = None,
+) -> Optional[RegimeAssessment]:
+    from datetime import date, timedelta
+
+    config = config or RegimeConfig()
+    if not config.enabled:
+        return None
+    loader = price_loader or _default_price_loader()
+    start = (date.today() - timedelta(days=550)).isoformat()
+    prices = loader(symbol, start, None)
+    return classify_regime(prices, config=config, symbol=symbol)
+
+
+def regime_report_block(
+    symbol: str,
+    price_loader: Optional[Callable] = None,
+    config: Optional[RegimeConfig] = None,
+) -> str:
+    """Markdown regime block for the market report; '' when unavailable."""
+    try:
+        assessment = _load_assessment(symbol, price_loader, config)
+        if assessment is None or assessment.label == "unknown":
+            return ""
+        return assessment.to_markdown()
+    except Exception as exc:
+        print(f"[REGIME] Report block skipped for {symbol}: {exc}")
+        return ""
+
+
+def regime_risk_multiplier(
+    symbol: str,
+    price_loader: Optional[Callable] = None,
+    config: Optional[RegimeConfig] = None,
+) -> float:
+    """Position-size multiplier in [min_risk_multiplier, 1.0]; 1.0 on failure."""
+    try:
+        assessment = _load_assessment(symbol, price_loader, config)
+        if assessment is None:
+            return 1.0
+        if assessment.risk_multiplier < 1.0:
+            print(
+                f"[REGIME] {symbol}: {assessment.label} regime "
+                f"(vol={assessment.volatility_state}, trend={assessment.trend_state}, "
+                f"liquidity={assessment.liquidity_state}) -> "
+                f"size x{assessment.risk_multiplier:.2f}"
+            )
+        return assessment.risk_multiplier
+    except Exception as exc:
+        print(f"[REGIME] Sizing skipped for {symbol}: {exc}")
+        return 1.0

--- a/webui/components/analysis.py
+++ b/webui/components/analysis.py
@@ -67,6 +67,26 @@ def execute_trade_after_analysis(ticker, allow_shorts, trade_amount):
 
         print(f"[TRADE] Executing trade for {ticker}: {recommended_action} with ${trade_amount}")
 
+        # Regime-aware sizing: hostile regimes shrink NEW exposure, never
+        # flip the decision. Failure-isolated - any problem keeps the
+        # requested amount untouched.
+        if str(recommended_action).upper() in ("BUY", "LONG"):
+            try:
+                from tradingagents.dataflows.config import get_config
+                from tradingagents.regime import RegimeConfig, regime_risk_multiplier
+
+                multiplier = regime_risk_multiplier(
+                    ticker, config=RegimeConfig.from_config(get_config() or {})
+                )
+                if multiplier < 1.0:
+                    trade_amount = trade_amount * multiplier
+                    print(
+                        f"[TRADE] Regime filter scaled {ticker} amount to "
+                        f"${trade_amount:,.0f} (x{multiplier:.2f})"
+                    )
+            except Exception as exc:
+                print(f"[TRADE] Regime sizing unavailable for {ticker}: {exc}")
+
         # Get current position
         current_position = AlpacaUtils.get_current_position_state(ticker)
         print(f"[TRADE] Current position for {ticker}: {current_position}")


### PR DESCRIPTION
## What

The agents analyze fundamentals, news, and sentiment — but nothing tells them *what kind of market they are standing in*. This adds a deterministic, fit-free regime indicator that (1) is injected into the agents' shared context and (2) automatically scales position sizing down in hostile regimes. Based on `origin/main` directly (no stack).

## The indicator (three cheap observable dimensions)

| Dimension | Method | States |
|---|---|---|
| **Volatility** | realized vol (20-bar) percentile vs its own 252-bar history, plus an absolute 40%-annualized floor so persistently wild assets still read turbulent | calm / normal / turbulent |
| **Trend** | price vs SMA(50) + the SMA's recent slope | up / sideways / down |
| **Liquidity** | recent share volume vs a baseline that *strictly precedes* it (a slow bleed can't drag down its own baseline); share volume not dollar volume, so a price collapse isn't double-counted with trend | surging / normal / thinning |

**Why threshold rules and not an HMM:** practitioners get most of the regime-filter value from the realized-vol percentile plus a trend filter — with no fitting, no initialization sensitivity, and no new dependency. Complexity was rejected on purpose.

## Filter, not signal

Hostile regimes shrink NEW exposure multiplicatively — 0.5 (turbulent) × 0.75 (downtrend) × 0.85 (thinning), floored at 0.25 — and **never flip the agents' decisions**. Missing data reads as `unknown` with multiplier 1.0: absence of evidence never punishes.

## Integration (both config-gated, failure-isolated)

1. A deterministic **"Market Regime"** markdown block is appended to the market analyst's report — the one artifact every downstream researcher, trader, and risk agent already reads — labeled explicitly as risk-posture context, not a trade signal.
2. At execution time, BUY/LONG amounts are scaled by the regime multiplier before the order is placed.

`regime_detection_enabled` plus 9 tuning keys in `default_config.py`.

## Tests

13 new tests (favorable full-size, hostile crash at exactly 0.375, absolute-vol floor, liquidity thinning, unknown-data neutrality, multiplier floor, markdown content, injected-loader helpers, failure neutrality, config wiring). Full suite: **66 passed (+133 subtests)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
