### PR TITLE
feat: daily operations report + Telegram/webhook alerts on safety halts

### DIFF
--- a/tests/test_daily_report_alerts.py
+++ b/tests/test_daily_report_alerts.py
@@ -1,0 +1,226 @@
+"""Tests for the daily report generator and the alert dispatcher.
+
+Alerts are stdlib-only (Telegram Bot API + generic webhook), deduplicated
+with a cooldown so a tripped circuit breaker cannot flood the channel, and
+fully failure-isolated: a dead webhook must never affect order flow. The
+daily report is assembled purely from data the system already persists.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tradingagents.alerts import (
+    AlertConfig,
+    notify_safety_block,
+    reset_alert_dedupe,
+    send_alert,
+)
+from tradingagents.daily_report import generate_daily_report, write_daily_report
+from tradingagents.safety.guardrails import SafetyGuard
+
+
+class _FakeTransport:
+    def __init__(self, fail=False):
+        self.calls = []
+        self.fail = fail
+
+    def __call__(self, url, payload):
+        if self.fail:
+            raise ConnectionError("endpoint down")
+        self.calls.append((url, payload))
+
+
+def _alert_config(**overrides):
+    kwargs = {
+        "enabled": True,
+        "telegram_bot_token": "TOKEN",
+        "telegram_chat_id": "42",
+        "webhook_url": "https://hooks.example/x",
+        "cooldown_seconds": 900,
+    }
+    kwargs.update(overrides)
+    return AlertConfig(**kwargs)
+
+
+class AlertDispatchTests(unittest.TestCase):
+    def setUp(self):
+        reset_alert_dedupe()
+
+    def test_sends_to_telegram_and_webhook(self):
+        transport = _FakeTransport()
+        result = send_alert(
+            "Circuit breaker", "details", config=_alert_config(), transport=transport
+        )
+        self.assertTrue(result["sent"])
+        urls = [u for u, _ in transport.calls]
+        self.assertTrue(any("api.telegram.org/botTOKEN/sendMessage" in u for u in urls))
+        self.assertIn("https://hooks.example/x", urls)
+        # Telegram payload carries chat id and both subject and body.
+        telegram_payload = next(p for u, p in transport.calls if "telegram" in u)
+        self.assertEqual(telegram_payload["chat_id"], "42")
+        self.assertIn("Circuit breaker", telegram_payload["text"])
+
+    def test_duplicate_alert_is_suppressed_within_cooldown(self):
+        transport = _FakeTransport()
+        config = _alert_config()
+        first = send_alert("halt", "body", config=config, transport=transport)
+        second = send_alert("halt", "body", config=config, transport=transport)
+        self.assertTrue(first["sent"])
+        self.assertTrue(second["deduped"])
+        self.assertEqual(len(transport.calls), 2)  # telegram + webhook, once
+
+    def test_different_keys_are_not_deduped(self):
+        transport = _FakeTransport()
+        config = _alert_config()
+        send_alert("halt", "body", key="a", config=config, transport=transport)
+        send_alert("halt", "body", key="b", config=config, transport=transport)
+        self.assertEqual(len(transport.calls), 4)
+
+    def test_disabled_or_unconfigured_sends_nothing(self):
+        transport = _FakeTransport()
+        result = send_alert(
+            "halt", "body", config=_alert_config(enabled=False), transport=transport
+        )
+        self.assertFalse(result["sent"])
+        result = send_alert(
+            "halt",
+            "body",
+            config=AlertConfig(enabled=True),  # no channels configured
+            transport=transport,
+        )
+        self.assertFalse(result["sent"])
+        self.assertEqual(transport.calls, [])
+
+    def test_transport_failure_never_raises(self):
+        result = send_alert(
+            "halt",
+            "body",
+            config=_alert_config(),
+            transport=_FakeTransport(fail=True),
+        )
+        self.assertFalse(result["sent"])
+
+    def test_notify_safety_block_dedupes_on_reasons(self):
+        transport = _FakeTransport()
+        config = _alert_config()
+        notify_safety_block("AAPL", ["Kill switch is engaged"], config=config, transport=transport)
+        notify_safety_block("AAPL", ["Kill switch is engaged"], config=config, transport=transport)
+        self.assertEqual(len(transport.calls), 2)  # one alert, two channels
+
+
+def _write_run(root, symbol, trade_date, final_signal, tokens=1000, status="completed"):
+    runs_dir = Path(root) / symbol / "TradingAgentsStrategy_logs" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    started = f"{trade_date}T10:00:00+00:00"
+    payload = {
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "started_at": started,
+        "status": status,
+        "events": [
+            {
+                "type": "llm_call",
+                "payload": {
+                    "model": "fake-deep",
+                    "usage": {"input_tokens": tokens, "output_tokens": tokens // 10},
+                },
+            }
+        ],
+        "summary": {"final_signal": final_signal, "total_llm_tokens": tokens},
+    }
+    (runs_dir / f"{trade_date}_run.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+class DailyReportTests(unittest.TestCase):
+    def _report(self, root, tmp, day="2026-07-11"):
+        guard = SafetyGuard(
+            config={"safety_enabled": True},
+            state_path=Path(tmp) / "state.json",
+            kill_switch_path=Path(tmp) / "KILL_SWITCH",
+        )
+        config = {
+            "results_dir": root,
+            "memory_log_path": str(Path(tmp) / "trading_memory.md"),
+            "llm_pricing_per_million": {"fake-deep": {"input": 10.0, "output": 30.0}},
+        }
+        return generate_daily_report(day=day, config=config, guard=guard)
+
+    def test_report_contains_decisions_safety_cost_and_performance(self):
+        with tempfile.TemporaryDirectory() as root, tempfile.TemporaryDirectory() as tmp:
+            _write_run(root, "AAPL", "2026-07-11", "BUY", tokens=100_000)
+            _write_run(root, "NVDA", "2026-07-11", "HOLD", tokens=50_000)
+            _write_run(root, "EXCL", "2026-07-01", "SELL")  # different day: excluded
+            report = self._report(root, tmp)
+
+        self.assertIn("Daily Trading Report", report)
+        self.assertIn("AAPL", report)
+        self.assertIn("BUY", report)
+        self.assertNotIn("EXCL", report)
+        for section in ("Decisions", "Safety", "LLM cost", "Realized performance"):
+            self.assertIn(section, report)
+        self.assertIn("$", report)  # a priced cost figure appears
+
+    def test_kill_switch_state_is_reported(self):
+        with tempfile.TemporaryDirectory() as root, tempfile.TemporaryDirectory() as tmp:
+            guard = SafetyGuard(
+                config={"safety_enabled": True},
+                state_path=Path(tmp) / "state.json",
+                kill_switch_path=Path(tmp) / "KILL_SWITCH",
+            )
+            guard.engage_kill_switch("drill")
+            report = generate_daily_report(
+                day="2026-07-11", config={"results_dir": root}, guard=guard
+            )
+        self.assertIn("KILL SWITCH", report.upper())
+
+    def test_write_daily_report_creates_md_and_html(self):
+        with tempfile.TemporaryDirectory() as root, tempfile.TemporaryDirectory() as tmp:
+            _write_run(root, "AAPL", "2026-07-11", "BUY")
+            guard = SafetyGuard(
+                config={"safety_enabled": True},
+                state_path=Path(tmp) / "state.json",
+                kill_switch_path=Path(tmp) / "KILL_SWITCH",
+            )
+            md_path, html_path = write_daily_report(
+                day="2026-07-11",
+                output_dir=str(Path(tmp) / "reports"),
+                config={"results_dir": root},
+                guard=guard,
+            )
+            self.assertTrue(Path(md_path).exists())
+            self.assertTrue(Path(html_path).exists())
+            html = Path(html_path).read_text(encoding="utf-8")
+            self.assertIn("AAPL", html)
+
+    def test_empty_day_still_produces_a_report(self):
+        with tempfile.TemporaryDirectory() as root, tempfile.TemporaryDirectory() as tmp:
+            report = self._report(root, tmp, day="2026-01-01")
+        self.assertIn("No completed analyses", report)
+
+
+class ConfigTests(unittest.TestCase):
+    def test_default_config_exposes_alert_keys(self):
+        from tradingagents.default_config import DEFAULT_CONFIG
+
+        self.assertIn("alerts_enabled", DEFAULT_CONFIG)
+        self.assertIn("alert_webhook_url", DEFAULT_CONFIG)
+        self.assertIn("alert_telegram_bot_token", DEFAULT_CONFIG)
+
+    def test_alert_config_from_project_config(self):
+        config = AlertConfig.from_config(
+            {
+                "alerts_enabled": True,
+                "alert_telegram_bot_token": "T",
+                "alert_telegram_chat_id": "C",
+                "alert_webhook_url": "https://x",
+                "alert_cooldown_seconds": 60,
+            }
+        )
+        self.assertEqual(config.telegram_bot_token, "T")
+        self.assertEqual(config.cooldown_seconds, 60)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_cost.py
+++ b/tests/test_llm_cost.py
@@ -1,0 +1,216 @@
+"""Tests for LLM cost accounting: pricing resolution, run-log scanning,
+aggregation per day/symbol/model, realized-return join, and WebUI wiring."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tradingagents.llm_cost import (
+    aggregate_costs,
+    estimate_cost_usd,
+    parse_return_pct,
+    realized_returns_by_symbol,
+    resolve_pricing,
+    scan_run_costs,
+)
+
+
+def _write_run(
+    root,
+    symbol,
+    trade_date,
+    llm_calls=(),
+    summary_tokens=None,
+    status="completed",
+    started_at=None,
+):
+    runs_dir = Path(root) / symbol / "TradingAgentsStrategy_logs" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    started = started_at or f"{trade_date}T10:00:00+00:00"
+    events = [
+        {
+            "type": "llm_call",
+            "timestamp": started,
+            "payload": {"model": model, "usage": usage},
+        }
+        for model, usage in llm_calls
+    ]
+    payload = {
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "started_at": started,
+        "status": status,
+        "events": events,
+        "summary": {"total_llm_tokens": summary_tokens or 0},
+    }
+    name = f"{trade_date}_{started.replace(':', '')}.json"
+    (runs_dir / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+class PricingTests(unittest.TestCase):
+    def test_longest_prefix_wins(self):
+        generic = resolve_pricing("gpt-5-preview")
+        mini = resolve_pricing("gpt-5-mini-2025")
+        self.assertIsNotNone(generic)
+        self.assertIsNotNone(mini)
+        self.assertLess(mini["input"], generic["input"])
+
+    def test_unknown_model_is_unpriced(self):
+        self.assertIsNone(resolve_pricing("totally-unknown-llm-9000"))
+
+    def test_config_override_beats_defaults(self):
+        overrides = {"gpt-5-mini": {"input": 1.0, "output": 2.0}}
+        priced = resolve_pricing("gpt-5-mini", overrides=overrides)
+        self.assertEqual(priced["input"], 1.0)
+
+    def test_estimate_cost_arithmetic(self):
+        overrides = {"fake-model": {"input": 1.0, "output": 10.0}}
+        # 1M input @ $1 + 0.5M output @ $10 = $6.
+        cost = estimate_cost_usd(
+            "fake-model", 1_000_000, 500_000, overrides=overrides
+        )
+        self.assertAlmostEqual(cost, 6.0)
+
+    def test_estimate_cost_unknown_model_returns_none(self):
+        self.assertIsNone(estimate_cost_usd("mystery", 1000, 1000))
+
+
+class ScanRunCostsTests(unittest.TestCase):
+    def test_scans_runs_and_attributes_models(self):
+        overrides = {"fake-deep": {"input": 10.0, "output": 30.0}}
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(
+                root,
+                "AAPL",
+                "2026-07-01",
+                llm_calls=[
+                    ("fake-deep", {"input_tokens": 100_000, "output_tokens": 10_000}),
+                    ("fake-deep", {"input_tokens": 50_000, "output_tokens": 5_000}),
+                    ("mystery-model", {"input_tokens": 1_000, "output_tokens": 100}),
+                ],
+            )
+            records = scan_run_costs(eval_results_dir=root, overrides=overrides)
+
+        self.assertEqual(len(records), 1)
+        record = records[0]
+        self.assertEqual(record["symbol"], "AAPL")
+        self.assertEqual(record["trade_date"], "2026-07-01")
+        self.assertEqual(record["input_tokens"], 151_000)
+        self.assertEqual(record["output_tokens"], 15_100)
+        # fake-deep: 150k in @ $10/M + 15k out @ $30/M = 1.5 + 0.45 = 1.95
+        self.assertAlmostEqual(record["cost_usd"], 1.95)
+        self.assertEqual(record["unpriced_tokens"], 1_100)
+        self.assertIn("fake-deep", record["models"])
+
+    def test_run_without_events_falls_back_to_summary(self):
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(root, "NVDA", "2026-07-02", summary_tokens=42_000)
+            records = scan_run_costs(eval_results_dir=root)
+        self.assertEqual(records[0]["total_tokens"], 42_000)
+        self.assertIsNone(records[0]["cost_usd"])
+        self.assertEqual(records[0]["unpriced_tokens"], 42_000)
+
+    def test_missing_dir_returns_empty(self):
+        self.assertEqual(scan_run_costs(eval_results_dir="does-not-exist-xyz"), [])
+
+
+class AggregationTests(unittest.TestCase):
+    def _records(self):
+        overrides = {"fake-deep": {"input": 10.0, "output": 30.0}}
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(
+                root,
+                "AAPL",
+                "2026-07-01",
+                llm_calls=[("fake-deep", {"input_tokens": 100_000, "output_tokens": 10_000})],
+            )
+            _write_run(
+                root,
+                "AAPL",
+                "2026-07-02",
+                llm_calls=[("fake-deep", {"input_tokens": 200_000, "output_tokens": 20_000})],
+                started_at="2026-07-02T09:00:00+00:00",
+            )
+            _write_run(
+                root,
+                "NVDA",
+                "2026-07-02",
+                llm_calls=[("fake-deep", {"input_tokens": 300_000, "output_tokens": 30_000})],
+                started_at="2026-07-02T11:00:00+00:00",
+            )
+            return scan_run_costs(eval_results_dir=root, overrides=overrides)
+
+    def test_aggregates_by_day_symbol_and_model(self):
+        agg = aggregate_costs(self._records())
+        self.assertEqual(agg["totals"]["runs"], 3)
+        self.assertEqual(set(agg["per_day"]), {"2026-07-01", "2026-07-02"})
+        self.assertEqual(agg["per_day"]["2026-07-02"]["runs"], 2)
+        self.assertEqual(set(agg["per_symbol"]), {"AAPL", "NVDA"})
+        self.assertEqual(agg["per_symbol"]["AAPL"]["runs"], 2)
+        self.assertIn("fake-deep", agg["per_model"])
+        # Total cost: (600k in @ $10/M) + (60k out @ $30/M) = 6.0 + 1.8
+        self.assertAlmostEqual(agg["totals"]["cost_usd"], 7.8)
+
+
+class RealizedReturnJoinTests(unittest.TestCase):
+    def test_parse_return_pct(self):
+        self.assertAlmostEqual(parse_return_pct("+3.2%"), 0.032)
+        self.assertAlmostEqual(parse_return_pct("-1.5%"), -0.015)
+        self.assertIsNone(parse_return_pct("n/a"))
+        self.assertIsNone(parse_return_pct(None))
+
+    def test_returns_joined_from_memory_log(self):
+        from tradingagents.agents.utils.memory import TradingMemoryLog
+
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = str(Path(tmp) / "trading_memory.md")
+            log = TradingMemoryLog({"memory_log_path": log_path})
+            log.store_decision("AAPL", "2026-07-01", "FINAL DECISION: BUY")
+            log.batch_update_with_outcomes(
+                [
+                    {
+                        "ticker": "AAPL",
+                        "trade_date": "2026-07-01",
+                        "raw_return": 0.04,
+                        "alpha_return": None,
+                        "holding_days": 5,
+                        "reflection": "went well",
+                    }
+                ]
+            )
+            returns = realized_returns_by_symbol({"memory_log_path": log_path})
+
+        self.assertIn("AAPL", returns)
+        self.assertEqual(returns["AAPL"]["resolved"], 1)
+        self.assertAlmostEqual(returns["AAPL"]["avg_return"], 0.04, places=3)
+
+
+class CostWebUIWiringTests(unittest.TestCase):
+    def test_panel_component_builds(self):
+        from webui.components.cost_panel import create_cost_panel
+
+        rendered = str(create_cost_panel())
+        for component_id in (
+            "cost-refresh-btn",
+            "cost-summary-cards",
+            "cost-daily-graph",
+            "cost-symbol-table",
+        ):
+            self.assertIn(component_id, rendered)
+
+    def test_callbacks_register_on_fresh_app(self):
+        import dash
+
+        from webui.callbacks.cost_callbacks import register_cost_callbacks
+
+        app = dash.Dash(__name__, suppress_callback_exceptions=True)
+        register_cost_callbacks(app)
+        self.assertTrue(
+            any("cost-summary-cards" in key for key in app.callback_map),
+            f"cost callback missing: {list(app.callback_map)}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_safety_guardrails.py
+++ b/tests/test_safety_guardrails.py
@@ -1,0 +1,281 @@
+"""Tests for the deterministic production safety layer.
+
+The safety layer is intentionally independent of agent logic: every check is
+pure arithmetic over injected account/order state, so nothing here mocks an
+LLM. Each guard is exercised on both sides of its threshold.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tradingagents.safety import (
+    DEFAULT_SAFETY_CONFIG,
+    SafetyGuard,
+    SafetyVerdict,
+    get_safety_guard,
+    reset_safety_guard,
+)
+
+
+def make_guard(tmp, **overrides):
+    config = dict(DEFAULT_SAFETY_CONFIG)
+    config.update(overrides)
+    return SafetyGuard(
+        config=config,
+        state_path=Path(tmp) / "state.json",
+        kill_switch_path=Path(tmp) / "KILL_SWITCH",
+    )
+
+
+ACCOUNT_OK = {"equity": 100_000.0, "last_equity": 100_000.0}
+
+
+class KillSwitchTests(unittest.TestCase):
+    def test_engage_blocks_all_orders_and_release_restores(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp)
+            self.assertTrue(guard.check_order("AAPL", 100.0, account=ACCOUNT_OK).allowed)
+
+            guard.engage_kill_switch("manual test halt")
+            verdict = guard.check_order("AAPL", 100.0, account=ACCOUNT_OK)
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("kill switch" in r.lower() for r in verdict.reasons))
+            self.assertIn("manual test halt", guard.kill_switch_reason())
+
+            guard.release_kill_switch()
+            self.assertFalse(guard.kill_switch_active())
+            self.assertTrue(guard.check_order("AAPL", 100.0, account=ACCOUNT_OK).allowed)
+
+    def test_kill_switch_file_created_externally_is_honored(self):
+        # Ops can halt trading by touching the file - no Python required.
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "KILL_SWITCH").write_text("halted by ops", encoding="utf-8")
+            guard = make_guard(tmp)
+            self.assertTrue(guard.kill_switch_active())
+            self.assertFalse(guard.check_order("AAPL", 100.0).allowed)
+
+
+class PreTradeCheckTests(unittest.TestCase):
+    def test_notional_above_cap_is_blocked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_trade_notional_usd=5_000.0)
+            self.assertTrue(guard.check_order("AAPL", 5_000.0, account=ACCOUNT_OK).allowed)
+            verdict = guard.check_order("AAPL", 5_000.01, account=ACCOUNT_OK)
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("notional" in r.lower() for r in verdict.reasons))
+
+    def test_concentration_limit_counts_existing_position(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_symbol_concentration_pct=25.0)
+            # 20k existing + 10k new = 30% of 100k equity -> blocked
+            verdict = guard.check_order(
+                "AAPL", 10_000.0, account=ACCOUNT_OK, position_value=20_000.0
+            )
+            self.assertFalse(verdict.allowed)
+            # 20k existing + 4k new = 24% -> allowed
+            self.assertTrue(
+                guard.check_order(
+                    "AAPL", 4_000.0, account=ACCOUNT_OK, position_value=20_000.0
+                ).allowed
+            )
+
+    def test_concentration_skipped_without_account_data(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_symbol_concentration_pct=25.0)
+            verdict = guard.check_order("AAPL", 1_000.0, position_value=90_000.0)
+            self.assertTrue(verdict.allowed)
+            self.assertEqual(verdict.checks["concentration"]["status"], "skipped")
+
+
+class CircuitBreakerTests(unittest.TestCase):
+    def test_daily_loss_breaker_trips_beyond_threshold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, daily_loss_halt_pct=10.0)
+            ok = {"equity": 95_000.0, "last_equity": 100_000.0}  # -5%
+            self.assertTrue(guard.check_order("AAPL", 100.0, account=ok).allowed)
+            tripped = {"equity": 89_000.0, "last_equity": 100_000.0}  # -11%
+            verdict = guard.check_order("AAPL", 100.0, account=tripped)
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("daily loss" in r.lower() for r in verdict.reasons))
+
+    def test_drawdown_breaker_uses_persisted_high_water_mark(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_drawdown_halt_pct=15.0)
+            # Establish a 120k high-water mark.
+            guard.check_order("AAPL", 100.0, account={"equity": 120_000.0, "last_equity": 120_000.0})
+
+            # A fresh instance must read the same HWM from disk.
+            guard2 = make_guard(tmp, max_drawdown_halt_pct=15.0)
+            verdict = guard2.check_order(
+                "AAPL", 100.0, account={"equity": 100_000.0, "last_equity": 100_000.0}
+            )  # -16.7% from HWM
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("drawdown" in r.lower() for r in verdict.reasons))
+
+    def test_consecutive_rejections_trip_and_success_resets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_consecutive_rejections=3)
+            for _ in range(3):
+                guard.record_order_result(False)
+            verdict = guard.check_order("AAPL", 100.0, account=ACCOUNT_OK)
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("rejected" in r.lower() for r in verdict.reasons))
+
+            guard.record_order_result(True)
+            self.assertTrue(guard.check_order("AAPL", 100.0, account=ACCOUNT_OK).allowed)
+
+
+class LLMBudgetTests(unittest.TestCase):
+    def test_budget_exhaustion_blocks_new_analysis(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, daily_llm_token_budget=1_000_000)
+            guard.record_llm_tokens(400_000, when="2026-07-11")
+            self.assertTrue(guard.check_llm_budget(when="2026-07-11").allowed)
+            guard.record_llm_tokens(700_000, when="2026-07-11")
+            verdict = guard.check_llm_budget(when="2026-07-11")
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("budget" in r.lower() for r in verdict.reasons))
+
+    def test_budget_resets_each_day(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, daily_llm_token_budget=1_000_000)
+            guard.record_llm_tokens(2_000_000, when="2026-07-10")
+            self.assertTrue(guard.check_llm_budget(when="2026-07-11").allowed)
+
+    def test_zero_budget_means_unlimited(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, daily_llm_token_budget=0)
+            guard.record_llm_tokens(10_000_000, when="2026-07-11")
+            self.assertTrue(guard.check_llm_budget(when="2026-07-11").allowed)
+
+    def test_token_usage_persists_across_instances(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            make_guard(tmp).record_llm_tokens(123, when="2026-07-11")
+            self.assertEqual(
+                make_guard(tmp).llm_tokens_used(when="2026-07-11"), 123
+            )
+
+
+class StatusAndTogglesTests(unittest.TestCase):
+    def test_disabled_safety_allows_everything(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, safety_enabled=False, max_trade_notional_usd=1.0)
+            guard.engage_kill_switch("halt")
+            verdict = guard.check_order("AAPL", 1_000_000.0, account=ACCOUNT_OK)
+            self.assertTrue(verdict.allowed)
+
+    def test_status_reports_every_guard(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp)
+            status = guard.status(account={"equity": 89_000.0, "last_equity": 100_000.0})
+            for name in (
+                "kill_switch",
+                "trade_notional",
+                "concentration",
+                "daily_loss",
+                "drawdown",
+                "rejection_streak",
+                "llm_budget",
+            ):
+                self.assertIn(name, status["guards"], name)
+            self.assertFalse(status["guards"]["daily_loss"]["ok"])  # -11% today
+            self.assertTrue(status["guards"]["kill_switch"]["ok"])
+
+    def test_singleton_helper_returns_guard_and_resets(self):
+        reset_safety_guard()
+        guard = get_safety_guard()
+        self.assertIsInstance(guard, SafetyGuard)
+        self.assertIs(guard, get_safety_guard())
+        reset_safety_guard()
+
+
+class ExecutionIntegrationTests(unittest.TestCase):
+    """execute_trading_action must consult the safety layer before any order."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Importing dataflows first trips a known circular import on main;
+        # importing agents first is the production-safe order.
+        import tradingagents.agents  # noqa: F401
+
+    def _blocked_guard(self):
+        guard = MagicMock(spec=SafetyGuard)
+        guard.enabled = True
+        guard.check_order.return_value = SafetyVerdict(
+            allowed=False, reasons=["max trade notional exceeded"]
+        )
+        return guard
+
+    def test_blocked_verdict_prevents_broker_calls(self):
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        guard = self._blocked_guard()
+        with patch("tradingagents.safety.get_safety_guard", return_value=guard), patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client"
+        ) as client_factory:
+            result = AlpacaUtils.execute_trading_action(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                signal="BUY",
+                dollar_amount=1_000_000.0,
+                allow_shorts=False,
+            )
+
+        self.assertFalse(result["success"])
+        self.assertTrue(result.get("safety_blocked"))
+        self.assertIn("max trade notional exceeded", result["error"])
+        client_factory.assert_not_called()
+
+    def test_order_results_feed_rejection_tracker(self):
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        guard = MagicMock(spec=SafetyGuard)
+        guard.enabled = True
+        guard.check_order.return_value = SafetyVerdict(allowed=True)
+        with patch("tradingagents.safety.get_safety_guard", return_value=guard), patch.object(
+            AlpacaUtils, "place_market_order", return_value={"success": True}
+        ), patch.object(
+            AlpacaUtils, "get_latest_quote", return_value={"bid_price": 100.0}
+        ):
+            AlpacaUtils.execute_trading_action(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                signal="BUY",
+                dollar_amount=1_000.0,
+                allow_shorts=False,
+            )
+
+        guard.record_order_result.assert_called_with(True)
+
+
+class RunLoggerBudgetFeedTests(unittest.TestCase):
+    def test_llm_call_events_feed_token_counter(self):
+        import os
+
+        from tradingagents.run_logger import RunAuditLogger
+
+        guard = MagicMock(spec=SafetyGuard)
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)  # RunAuditLogger writes to ./eval_results
+            try:
+                with patch("tradingagents.safety.get_safety_guard", return_value=guard):
+                    logger = RunAuditLogger()
+                    run_id = logger.start_run(symbol="AAPL", trade_date="2026-07-11")
+                    logger.log_event(
+                        "llm_call",
+                        symbol="AAPL",
+                        run_id=run_id,
+                        payload={"usage": {"total_tokens": 555}},
+                    )
+            finally:
+                os.chdir(cwd)
+
+        guard.record_llm_tokens.assert_called_with(555)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_safety_webui.py
+++ b/tests/test_safety_webui.py
@@ -1,0 +1,94 @@
+"""Wiring tests for the safety guardrails WebUI panel and callbacks."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tradingagents.safety import DEFAULT_SAFETY_CONFIG, SafetyGuard
+
+
+def _guard(tmp, **overrides):
+    config = dict(DEFAULT_SAFETY_CONFIG)
+    config.update(overrides)
+    return SafetyGuard(
+        config=config,
+        state_path=Path(tmp) / "state.json",
+        kill_switch_path=Path(tmp) / "KILL_SWITCH",
+    )
+
+
+class SafetyPanelWiringTests(unittest.TestCase):
+    def test_panel_component_builds(self):
+        from webui.components.safety_panel import create_safety_panel
+
+        rendered = str(create_safety_panel())
+        for component_id in (
+            "safety-status-container",
+            "safety-kill-switch-btn",
+            "safety-release-btn",
+            "safety-refresh-interval",
+            "safety-action-status",
+        ):
+            self.assertIn(component_id, rendered)
+
+    def test_callbacks_register_on_fresh_app(self):
+        import dash
+
+        from webui.callbacks.safety_callbacks import register_safety_callbacks
+
+        app = dash.Dash(__name__, suppress_callback_exceptions=True)
+        register_safety_callbacks(app)
+        self.assertTrue(
+            any("safety-status-container" in key for key in app.callback_map),
+            f"safety callback missing from callback map: {list(app.callback_map)}",
+        )
+
+    def test_status_cards_render_green_and_red(self):
+        from webui.callbacks.safety_callbacks import _status_cards
+
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            healthy = str(
+                _status_cards(
+                    guard.status(account={"equity": 100_000.0, "last_equity": 100_000.0})
+                )
+            )
+            self.assertIn("Kill Switch", healthy)
+            self.assertIn("LLM Budget", healthy)
+            self.assertIn("fa-check-circle", healthy)
+
+            guard.engage_kill_switch("test halt")
+            tripped = str(
+                _status_cards(
+                    guard.status(account={"equity": 100_000.0, "last_equity": 100_000.0})
+                )
+            )
+            self.assertIn("fa-exclamation-triangle", tripped)
+            self.assertIn("test halt", tripped)
+
+    def test_analysis_start_is_gated_by_llm_budget(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, daily_llm_token_budget=100)
+            guard.record_llm_tokens(500)
+            with patch("tradingagents.safety.get_safety_guard", return_value=guard):
+                from webui.components.analysis import start_analysis
+
+                message = start_analysis(
+                    ticker="AAPL",
+                    analysts_market=True,
+                    analysts_social=False,
+                    analysts_news=False,
+                    analysts_fundamentals=False,
+                    analysts_macro=False,
+                    research_depth="Shallow",
+                    allow_shorts=False,
+                    quick_llm="gpt-test",
+                    deep_llm="gpt-test",
+                )
+            self.assertIsInstance(message, str)
+            self.assertIn("budget", message.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/alerts.py
+++ b/tradingagents/alerts.py
@@ -1,0 +1,160 @@
+"""Operational alerts: Telegram and generic webhook, stdlib only.
+
+Design rules learned from production alerting:
+- **Deduplication**: a tripped circuit breaker blocks every subsequent
+  order; without a cooldown that is one identical message per attempt.
+  Alerts are keyed (default: the subject) and suppressed for
+  ``cooldown_seconds`` after a successful send.
+- **Isolation**: alert delivery must never affect trading. Every network
+  failure is swallowed and reported in the return value only.
+- **Secrets**: the Telegram token comes from config/env and is never
+  echoed into logs or reports.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import urllib.request
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+_DEDUPE_LOCK = threading.Lock()
+_LAST_SENT: Dict[str, float] = {}
+
+
+@dataclass
+class AlertConfig:
+    enabled: bool = True
+    telegram_bot_token: str = ""
+    telegram_chat_id: str = ""
+    webhook_url: str = ""
+    cooldown_seconds: float = 900.0
+
+    @classmethod
+    def from_config(cls, config: Optional[dict]) -> "AlertConfig":
+        cfg = config or {}
+        return cls(
+            enabled=bool(cfg.get("alerts_enabled", True)),
+            telegram_bot_token=str(
+                cfg.get("alert_telegram_bot_token")
+                or os.getenv("ALERT_TELEGRAM_BOT_TOKEN", "")
+            ),
+            telegram_chat_id=str(
+                cfg.get("alert_telegram_chat_id")
+                or os.getenv("ALERT_TELEGRAM_CHAT_ID", "")
+            ),
+            webhook_url=str(
+                cfg.get("alert_webhook_url") or os.getenv("ALERT_WEBHOOK_URL", "")
+            ),
+            cooldown_seconds=float(cfg.get("alert_cooldown_seconds", 900.0) or 900.0),
+        )
+
+
+def reset_alert_dedupe() -> None:
+    """Clear the cooldown map (tests and manual ops)."""
+    with _DEDUPE_LOCK:
+        _LAST_SENT.clear()
+
+
+def _post_json(url: str, payload: dict) -> None:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10):
+        pass
+
+
+def send_alert(
+    subject: str,
+    body: str,
+    key: Optional[str] = None,
+    config: Optional[AlertConfig] = None,
+    transport: Optional[Callable[[str, dict], None]] = None,
+) -> dict:
+    """Dispatch an alert to every configured channel.
+
+    Returns {"sent": bool, "deduped": bool, "channels": [...]}; never raises.
+    `transport(url, payload)` is injectable for tests.
+    """
+    config = config or AlertConfig.from_config(None)
+    result = {"sent": False, "deduped": False, "channels": []}
+    if not config.enabled:
+        return result
+
+    dedupe_key = key or subject
+    now = time.monotonic()
+    with _DEDUPE_LOCK:
+        last = _LAST_SENT.get(dedupe_key)
+        if last is not None and now - last < config.cooldown_seconds:
+            result["deduped"] = True
+            return result
+
+    post = transport or _post_json
+    channels: List[str] = []
+
+    if config.telegram_bot_token and config.telegram_chat_id:
+        try:
+            post(
+                f"https://api.telegram.org/bot{config.telegram_bot_token}/sendMessage",
+                {
+                    "chat_id": config.telegram_chat_id,
+                    "text": f"{subject}\n\n{body}",
+                },
+            )
+            channels.append("telegram")
+        except Exception as exc:
+            print(f"[ALERTS] Telegram delivery failed: {exc}")
+
+    if config.webhook_url:
+        try:
+            post(
+                config.webhook_url,
+                {"subject": subject, "body": body, "sent_at": time.time()},
+            )
+            channels.append("webhook")
+        except Exception as exc:
+            print(f"[ALERTS] Webhook delivery failed: {exc}")
+
+    if channels:
+        with _DEDUPE_LOCK:
+            _LAST_SENT[dedupe_key] = now
+        result["sent"] = True
+        result["channels"] = channels
+    return result
+
+
+def notify_safety_block(
+    symbol: str,
+    reasons: List[str],
+    config: Optional[AlertConfig] = None,
+    transport: Optional[Callable[[str, dict], None]] = None,
+) -> dict:
+    """Alert that the safety layer blocked order flow.
+
+    Keyed by the reasons (not the symbol), so one tripped breaker produces
+    one alert per cooldown window no matter how many orders it blocks.
+    """
+    reasons = [str(r) for r in (reasons or [])]
+    return send_alert(
+        subject="🛑 Safety layer blocked order flow",
+        body=f"Symbol: {symbol}\n" + "\n".join(f"- {r}" for r in reasons),
+        key="safety_block|" + "|".join(sorted(reasons)),
+        config=config,
+        transport=transport,
+    )
+
+
+def notify_kill_switch(reason: str, config: Optional[AlertConfig] = None) -> dict:
+    """Alert that the kill switch was engaged."""
+    return send_alert(
+        subject="🔴 Kill switch engaged",
+        body=reason or "manual halt",
+        key="kill_switch_engaged",
+        config=config,
+    )

--- a/tradingagents/daily_report.py
+++ b/tradingagents/daily_report.py
@@ -1,0 +1,194 @@
+"""Daily operations report assembled from data the system already persists.
+
+One function call produces a Markdown (and simple HTML) digest of a
+trading day: the decisions made (run logs), the safety layer's guard
+status, estimated LLM cost for the day (model-attributed), and cumulative
+realized performance per symbol from the decision log. Scheduling is left
+to the operator (cron / Task Scheduler) — the report itself is pure local
+file reading, no network, no LLM calls.
+"""
+
+from __future__ import annotations
+
+import html as html_lib
+import json
+from datetime import date
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+def _day_runs(eval_results_dir: str, day: str) -> List[dict]:
+    root = Path(eval_results_dir)
+    if not root.is_dir():
+        return []
+    runs = []
+    for path in sorted(root.glob("*/TradingAgentsStrategy_logs/runs/*.json")):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        started_day = str(payload.get("started_at") or "")[:10]
+        if started_day != day and str(payload.get("trade_date")) != day:
+            continue
+        summary = payload.get("summary") or {}
+        runs.append(
+            {
+                "symbol": str(payload.get("symbol") or "?"),
+                "status": str(payload.get("status") or "?"),
+                "signal": str(summary.get("final_signal") or "—"),
+                "tokens": int(summary.get("total_llm_tokens", 0) or 0),
+                "errors": int(summary.get("error_events", 0) or 0),
+            }
+        )
+    return runs
+
+
+def _decisions_section(runs: List[dict]) -> List[str]:
+    lines = ["## Decisions"]
+    if not runs:
+        lines.append("No completed analyses recorded for this day.")
+        return lines
+    lines.append("| Symbol | Signal | Status | LLM tokens | Errors |")
+    lines.append("|---|---|---|---:|---:|")
+    for run in runs:
+        lines.append(
+            f"| {run['symbol']} | {run['signal']} | {run['status']} "
+            f"| {run['tokens']:,} | {run['errors']} |"
+        )
+    return lines
+
+
+def _safety_section(guard) -> List[str]:
+    lines = ["## Safety status"]
+    if guard is None:
+        lines.append("Safety guard unavailable.")
+        return lines
+    try:
+        status = guard.status()
+    except Exception as exc:
+        lines.append(f"Safety status unavailable: {exc}")
+        return lines
+    if status.get("kill_switch_active"):
+        lines.append(
+            f"- 🔴 **KILL SWITCH ENGAGED**: {status.get('kill_switch_reason') or 'no reason recorded'}"
+        )
+    for name, view in (status.get("guards") or {}).items():
+        icon = "✅" if view.get("ok") else "🛑"
+        lines.append(f"- {icon} {name}: {view.get('status')}")
+    for reason in status.get("reasons") or []:
+        lines.append(f"- ⚠️ {reason}")
+    return lines
+
+
+def _cost_section(day: str, config: dict) -> List[str]:
+    lines = ["## LLM cost (estimated)"]
+    try:
+        from tradingagents.llm_cost import aggregate_costs, scan_run_costs
+
+        records = scan_run_costs(
+            eval_results_dir=config.get("results_dir", "eval_results"),
+            overrides=config.get("llm_pricing_per_million"),
+        )
+        day_bucket = aggregate_costs(records)["per_day"].get(day)
+    except Exception as exc:
+        lines.append(f"Cost data unavailable: {exc}")
+        return lines
+    if not day_bucket:
+        lines.append("No token usage recorded for this day.")
+        return lines
+    lines.append(
+        f"- {day_bucket['runs']} analysis run(s), {day_bucket['total_tokens']:,} tokens, "
+        f"≈ ${day_bucket['cost_usd']:,.2f}"
+    )
+    if day_bucket.get("unpriced_tokens"):
+        lines.append(
+            f"- {day_bucket['unpriced_tokens']:,} tokens from unpriced models are "
+            "excluded from the dollar figure."
+        )
+    lines.append(
+        "- Estimates are an upper bound (cache discounts are not recorded)."
+    )
+    return lines
+
+
+def _performance_section(config: dict) -> List[str]:
+    lines = ["## Realized performance (cumulative)"]
+    try:
+        from tradingagents.llm_cost import realized_returns_by_symbol
+
+        returns = realized_returns_by_symbol(config)
+    except Exception as exc:
+        lines.append(f"Decision-log data unavailable: {exc}")
+        return lines
+    if not returns:
+        lines.append("No resolved decisions in the log yet.")
+        return lines
+    lines.append("| Symbol | Resolved decisions | Avg realized return |")
+    lines.append("|---|---:|---:|")
+    for symbol in sorted(returns):
+        bucket = returns[symbol]
+        lines.append(
+            f"| {symbol} | {bucket['resolved']} | {bucket['avg_return']:+.2%} |"
+        )
+    return lines
+
+
+def generate_daily_report(
+    day: Optional[str] = None,
+    config: Optional[dict] = None,
+    guard=None,
+) -> str:
+    """Markdown digest for one trading day, from persisted data only."""
+    day = day or date.today().isoformat()
+    config = dict(config or {})
+    if guard is None:
+        try:
+            from tradingagents.safety import get_safety_guard
+
+            guard = get_safety_guard()
+        except Exception:
+            guard = None
+
+    runs = _day_runs(config.get("results_dir", "eval_results"), day)
+    parts: List[str] = [f"# Daily Trading Report — {day}", ""]
+    for section in (
+        _decisions_section(runs),
+        _safety_section(guard),
+        _cost_section(day, config),
+        _performance_section(config),
+    ):
+        parts.extend(section)
+        parts.append("")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def write_daily_report(
+    day: Optional[str] = None,
+    output_dir: str = "reports",
+    config: Optional[dict] = None,
+    guard=None,
+) -> Tuple[str, str]:
+    """Write the day's report as Markdown and a simple HTML page.
+
+    Returns (markdown_path, html_path).
+    """
+    day = day or date.today().isoformat()
+    markdown = generate_daily_report(day=day, config=config, guard=guard)
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    md_path = out / f"{day}.md"
+    md_path.write_text(markdown, encoding="utf-8")
+
+    html_body = html_lib.escape(markdown)
+    html_path = out / f"{day}.html"
+    html_path.write_text(
+        "<!doctype html><html><head><meta charset='utf-8'>"
+        f"<title>Daily Trading Report — {day}</title></head>"
+        "<body style='background:#111;color:#eee;font-family:monospace'>"
+        f"<pre style='white-space:pre-wrap;max-width:960px;margin:2rem auto'>{html_body}</pre>"
+        "</body></html>",
+        encoding="utf-8",
+    )
+    return str(md_path), str(html_path)

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -925,7 +925,36 @@ class AlpacaUtils:
         return result
 
     @staticmethod
-    def execute_trading_action(symbol: str, current_position: str, signal: str, 
+    def _safety_context(symbol: str):
+        """Best-effort account snapshot for the safety layer's breakers.
+
+        Returns (account, position_value); either may be None when the broker
+        is unreachable — the guard reports those checks as skipped instead of
+        guessing.
+        """
+        try:
+            client = get_alpaca_trading_client()
+            acct = client.get_account()
+            account = {
+                "equity": float(acct.equity),
+                "last_equity": float(acct.last_equity),
+            }
+        except Exception:
+            return None, None
+
+        position_value = 0.0
+        try:
+            key = symbol.upper().replace("/", "")
+            for pos in client.get_all_positions():
+                if pos.symbol.upper() == key:
+                    position_value = abs(float(pos.market_value))
+                    break
+        except Exception:
+            position_value = None
+        return account, position_value
+
+    @staticmethod
+    def execute_trading_action(symbol: str, current_position: str, signal: str,
                              dollar_amount: float, allow_shorts: bool = False) -> dict:
         """
         Execute trading action based on current position and signal
@@ -941,8 +970,45 @@ class AlpacaUtils:
             Dictionary with execution results
         """
         try:
+            # Deterministic safety gate — consulted before any broker call and
+            # entirely independent of the agents' reasoning. Cheap local checks
+            # (kill switch, notional cap, rejection streak) run first; account-
+            # based circuit breakers run only if those pass.
+            guard = None
+            try:
+                from tradingagents.safety import get_safety_guard
+
+                guard = get_safety_guard()
+            except Exception:
+                guard = None
+
+            if guard is not None and guard.enabled:
+                verdict = guard.check_order(symbol, dollar_amount)
+                if verdict.allowed:
+                    account_state, position_value = AlpacaUtils._safety_context(symbol)
+                    if account_state:
+                        verdict = guard.check_order(
+                            symbol,
+                            dollar_amount,
+                            account=account_state,
+                            position_value=position_value,
+                        )
+                if not verdict.allowed:
+                    error_msg = "Safety layer blocked order flow: " + " ".join(verdict.reasons)
+                    print(f"[SAFETY] {error_msg}")
+                    return {
+                        "success": False,
+                        "safety_blocked": True,
+                        "symbol": symbol,
+                        "current_position": current_position,
+                        "signal": signal,
+                        "actions": [],
+                        "error": error_msg,
+                        "safety_checks": verdict.checks,
+                    }
+
             results = []
-            
+
             # Helper to calculate integer quantity for any orders (used by both trading modes)
             def _calc_qty(sym: str, amount: float) -> int:
                 """Return integer share qty based on latest quote price."""
@@ -1078,10 +1144,18 @@ class AlpacaUtils:
             # Check if any critical actions failed
             has_failures = False
             for action in results:
-                if "result" in action and not action["result"].get("success", True):
-                    has_failures = True
-                    break
-                    
+                if "result" in action:
+                    order_success = bool(action["result"].get("success", True))
+                    if guard is not None and guard.enabled:
+                        # Feed the consecutive-rejection circuit breaker.
+                        try:
+                            guard.record_order_result(order_success)
+                        except Exception:
+                            pass
+                    if not order_success:
+                        has_failures = True
+
+
             return {
                 "success": not has_failures,
                 "symbol": symbol,

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -996,6 +996,14 @@ class AlpacaUtils:
                 if not verdict.allowed:
                     error_msg = "Safety layer blocked order flow: " + " ".join(verdict.reasons)
                     print(f"[SAFETY] {error_msg}")
+                    # Ops alert (deduped by reason, so a tripped breaker
+                    # alerts once per cooldown window, not once per order).
+                    try:
+                        from tradingagents.alerts import notify_safety_block
+
+                        notify_safety_block(symbol, verdict.reasons)
+                    except Exception:
+                        pass
                     return {
                         "success": False,
                         "safety_blocked": True,

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -59,6 +59,12 @@ DEFAULT_CONFIG = {
     "max_drawdown_halt_pct": 15.0,  # Circuit breaker: halt when equity falls this % below the high-water mark
     "max_consecutive_rejections": 5,  # Circuit breaker: halt after this many broker rejections in a row
     "daily_llm_token_budget": 0,  # Refuse new analyses after this many LLM tokens per day; 0 = unlimited
+    # Operational alerts (Telegram / webhook; stdlib-only, failure-isolated)
+    "alerts_enabled": True,  # Master switch; channels below must also be configured
+    "alert_telegram_bot_token": None,  # Or env ALERT_TELEGRAM_BOT_TOKEN
+    "alert_telegram_chat_id": None,  # Or env ALERT_TELEGRAM_CHAT_ID
+    "alert_webhook_url": None,  # Generic JSON webhook; or env ALERT_WEBHOOK_URL
+    "alert_cooldown_seconds": 900,  # Identical alerts suppressed within this window
     # Execution settings
     "parallel_analysts": True,  # True = Run analysts in parallel for faster execution, False = Sequential execution
     "parallel_risk_first_round": True,  # Run Risky/Safe/Neutral in parallel only for round 1, then revert to linear flow

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -51,6 +51,14 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 200,
     # Trading settings
     "allow_shorts": False,  # False = Investment mode (BUY/HOLD/SELL), True = Trading mode (LONG/NEUTRAL/SHORT)
+    # Production safety layer (deterministic, independent of agent logic)
+    "safety_enabled": True,  # Master switch for pre-trade checks + circuit breakers + kill switch
+    "max_trade_notional_usd": 25000.0,  # Per-order notional cap; 0 = uncapped
+    "max_symbol_concentration_pct": 25.0,  # Max per-symbol exposure as % of equity; 0 = uncapped
+    "daily_loss_halt_pct": 10.0,  # Circuit breaker: halt trading when equity falls this % vs yesterday
+    "max_drawdown_halt_pct": 15.0,  # Circuit breaker: halt when equity falls this % below the high-water mark
+    "max_consecutive_rejections": 5,  # Circuit breaker: halt after this many broker rejections in a row
+    "daily_llm_token_budget": 0,  # Refuse new analyses after this many LLM tokens per day; 0 = unlimited
     # Execution settings
     "parallel_analysts": True,  # True = Run analysts in parallel for faster execution, False = Sequential execution
     "parallel_risk_first_round": True,  # Run Risky/Safe/Neutral in parallel only for round 1, then revert to linear flow

--- a/tradingagents/llm_cost.py
+++ b/tradingagents/llm_cost.py
@@ -1,0 +1,255 @@
+"""LLM cost accounting over the persisted run logs.
+
+Turns the token usage the audit logger already records into attributable
+dollar estimates: per analysis run, per day, per symbol, and per model.
+Attribution — not an aggregate bill — is the point; an unattributed total
+cannot answer "which symbol or model made costs jump".
+
+Honesty rules:
+- Prices drift and differ by account tier, so the built-in table is an
+  estimate and every entry can be overridden via the
+  ``llm_pricing_per_million`` config key.
+- Unknown models are never guessed: their tokens are surfaced separately
+  as ``unpriced_tokens`` instead of silently costing $0.
+- Run logs do not record cache-read discounts, so estimates are an upper
+  bound on the true bill.
+
+Everything here is pure file reading and arithmetic — zero network calls.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# USD per 1M tokens: {"input": ..., "output": ...}. Prefix-matched
+# (longest prefix wins), case-insensitive. Estimates — override via the
+# `llm_pricing_per_million` config key when your bill disagrees.
+DEFAULT_PRICING_PER_MILLION: Dict[str, Dict[str, float]] = {
+    # OpenAI
+    "gpt-5.4-mini": {"input": 0.25, "output": 2.00},
+    "gpt-5.4-nano": {"input": 0.05, "output": 0.40},
+    "gpt-5-mini": {"input": 0.25, "output": 2.00},
+    "gpt-5-nano": {"input": 0.05, "output": 0.40},
+    "gpt-5": {"input": 1.25, "output": 10.00},
+    "gpt-4.1-mini": {"input": 0.40, "output": 1.60},
+    "gpt-4.1-nano": {"input": 0.10, "output": 0.40},
+    "gpt-4.1": {"input": 2.00, "output": 8.00},
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    "gpt-4o": {"input": 2.50, "output": 10.00},
+    "o4-mini": {"input": 1.10, "output": 4.40},
+    "o3": {"input": 2.00, "output": 8.00},
+    # Anthropic
+    "claude-3-5-haiku": {"input": 0.80, "output": 4.00},
+    "claude-haiku": {"input": 0.80, "output": 4.00},
+    "claude-sonnet": {"input": 3.00, "output": 15.00},
+    "claude-opus": {"input": 15.00, "output": 75.00},
+    "claude": {"input": 3.00, "output": 15.00},
+    # DeepSeek
+    "deepseek-chat": {"input": 0.27, "output": 1.10},
+    "deepseek-reasoner": {"input": 0.55, "output": 2.19},
+    # Google
+    "gemini-2.5-flash": {"input": 0.30, "output": 2.50},
+    "gemini-2.5-pro": {"input": 1.25, "output": 10.00},
+    # xAI
+    "grok-4": {"input": 3.00, "output": 15.00},
+    "grok-3-mini": {"input": 0.30, "output": 0.50},
+    "grok": {"input": 3.00, "output": 15.00},
+}
+
+
+def resolve_pricing(
+    model: str, overrides: Optional[Dict[str, Dict[str, float]]] = None
+) -> Optional[Dict[str, float]]:
+    """Longest-prefix price lookup; overrides shadow the defaults."""
+    table = dict(DEFAULT_PRICING_PER_MILLION)
+    for key, value in (overrides or {}).items():
+        if isinstance(value, dict) and "input" in value and "output" in value:
+            table[key.lower()] = {
+                "input": float(value["input"]),
+                "output": float(value["output"]),
+            }
+    name = str(model or "").lower()
+    best_prefix = None
+    for prefix in table:
+        if name.startswith(prefix.lower()):
+            if best_prefix is None or len(prefix) > len(best_prefix):
+                best_prefix = prefix
+    return dict(table[best_prefix]) if best_prefix else None
+
+
+def estimate_cost_usd(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    overrides: Optional[Dict[str, Dict[str, float]]] = None,
+) -> Optional[float]:
+    """Dollar estimate for a token count, or None for unknown models."""
+    pricing = resolve_pricing(model, overrides=overrides)
+    if pricing is None:
+        return None
+    return (
+        int(input_tokens or 0) * pricing["input"]
+        + int(output_tokens or 0) * pricing["output"]
+    ) / 1_000_000.0
+
+
+def scan_run_costs(
+    eval_results_dir: str = "eval_results",
+    overrides: Optional[Dict[str, Dict[str, float]]] = None,
+) -> List[dict]:
+    """One cost record per persisted run, model-attributed where possible.
+
+    Token counts come from each run's llm_call events (which carry the
+    model name and usage); runs without usable events fall back to the
+    summary totals as unpriced tokens.
+    """
+    root = Path(eval_results_dir)
+    if not root.is_dir():
+        return []
+
+    records: List[dict] = []
+    for path in sorted(root.glob("*/TradingAgentsStrategy_logs/runs/*.json")):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        per_model: Dict[str, Dict[str, int]] = {}
+        for event in payload.get("events") or []:
+            if event.get("type") != "llm_call":
+                continue
+            event_payload = event.get("payload") or {}
+            usage = event_payload.get("usage") or {}
+            model = str(event_payload.get("model") or "").strip()
+            input_tokens = int(usage.get("input_tokens", 0) or 0)
+            output_tokens = int(usage.get("output_tokens", 0) or 0)
+            if not model or (input_tokens <= 0 and output_tokens <= 0):
+                continue
+            bucket = per_model.setdefault(model, {"input": 0, "output": 0})
+            bucket["input"] += input_tokens
+            bucket["output"] += output_tokens
+
+        input_total = sum(b["input"] for b in per_model.values())
+        output_total = sum(b["output"] for b in per_model.values())
+        cost: Optional[float] = None
+        unpriced = 0
+        models: Dict[str, dict] = {}
+        for model, bucket in per_model.items():
+            model_cost = estimate_cost_usd(
+                model, bucket["input"], bucket["output"], overrides=overrides
+            )
+            models[model] = {
+                "input_tokens": bucket["input"],
+                "output_tokens": bucket["output"],
+                "cost_usd": model_cost,
+            }
+            if model_cost is None:
+                unpriced += bucket["input"] + bucket["output"]
+            else:
+                cost = (cost or 0.0) + model_cost
+
+        total_tokens = input_total + output_total
+        if not per_model:
+            # No attributable events: report the summary total as unpriced.
+            total_tokens = int(
+                (payload.get("summary") or {}).get("total_llm_tokens", 0) or 0
+            )
+            unpriced = total_tokens
+
+        records.append(
+            {
+                "symbol": str(payload.get("symbol") or path.parts[-4]),
+                "trade_date": str(payload.get("trade_date") or ""),
+                "started_at": str(payload.get("started_at") or ""),
+                "status": str(payload.get("status") or ""),
+                "run_id": str(payload.get("run_id") or path.stem),
+                "input_tokens": input_total,
+                "output_tokens": output_total,
+                "total_tokens": total_tokens,
+                "cost_usd": cost,
+                "unpriced_tokens": unpriced,
+                "models": models,
+            }
+        )
+    return records
+
+
+def _bucket(target: Dict[str, dict], key: str) -> dict:
+    return target.setdefault(
+        key, {"runs": 0, "total_tokens": 0, "cost_usd": 0.0, "unpriced_tokens": 0}
+    )
+
+
+def aggregate_costs(records: List[dict]) -> dict:
+    """Roll run records up into per-day, per-symbol, per-model, and totals."""
+    per_day: Dict[str, dict] = {}
+    per_symbol: Dict[str, dict] = {}
+    per_model: Dict[str, dict] = {}
+    totals = {"runs": 0, "total_tokens": 0, "cost_usd": 0.0, "unpriced_tokens": 0}
+
+    for record in records:
+        day = (record.get("started_at") or "")[:10] or record.get("trade_date") or "?"
+        cost = record.get("cost_usd") or 0.0
+        for bucket in (_bucket(per_day, day), _bucket(per_symbol, record["symbol"]), totals):
+            bucket["runs"] += 1
+            bucket["total_tokens"] += int(record.get("total_tokens", 0) or 0)
+            bucket["cost_usd"] += cost
+            bucket["unpriced_tokens"] += int(record.get("unpriced_tokens", 0) or 0)
+        for model, stats in (record.get("models") or {}).items():
+            model_bucket = per_model.setdefault(
+                model, {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0, "unpriced": False}
+            )
+            model_bucket["input_tokens"] += stats.get("input_tokens", 0)
+            model_bucket["output_tokens"] += stats.get("output_tokens", 0)
+            if stats.get("cost_usd") is None:
+                model_bucket["unpriced"] = True
+            else:
+                model_bucket["cost_usd"] += stats["cost_usd"]
+
+    return {
+        "per_day": per_day,
+        "per_symbol": per_symbol,
+        "per_model": per_model,
+        "totals": totals,
+    }
+
+
+def parse_return_pct(raw) -> Optional[float]:
+    """'+3.2%' -> 0.032; anything unparseable -> None."""
+    if raw is None:
+        return None
+    text = str(raw).strip().rstrip("%")
+    try:
+        return float(text) / 100.0
+    except ValueError:
+        return None
+
+
+def realized_returns_by_symbol(config: Optional[dict] = None) -> Dict[str, dict]:
+    """Average realized return per symbol from the resolved decision log.
+
+    Joins the cost side ("what did analyzing this symbol cost") with the
+    outcome side ("what did its decisions actually return").
+    """
+    from tradingagents.agents.utils.memory import TradingMemoryLog
+
+    log = TradingMemoryLog(config or {})
+    per_symbol: Dict[str, dict] = {}
+    for entry in log.load_entries():
+        if entry.get("pending"):
+            continue
+        realized = parse_return_pct(entry.get("raw"))
+        if realized is None:
+            continue
+        bucket = per_symbol.setdefault(
+            entry["ticker"], {"resolved": 0, "sum_return": 0.0}
+        )
+        bucket["resolved"] += 1
+        bucket["sum_return"] += realized
+
+    for bucket in per_symbol.values():
+        bucket["avg_return"] = bucket["sum_return"] / bucket["resolved"]
+    return per_symbol

--- a/tradingagents/run_logger.py
+++ b/tradingagents/run_logger.py
@@ -233,9 +233,17 @@ class RunAuditLogger:
                 run_data["summary"]["total_llm_output_tokens"] += int(
                     usage.get("output_tokens", 0) or 0
                 )
-                run_data["summary"]["total_llm_tokens"] += int(
-                    usage.get("total_tokens", 0) or 0
-                )
+                total_tokens = int(usage.get("total_tokens", 0) or 0)
+                run_data["summary"]["total_llm_tokens"] += total_tokens
+                if total_tokens:
+                    # Feed the safety layer's daily LLM token budget; logging
+                    # must never fail because the guard is unavailable.
+                    try:
+                        from tradingagents.safety import get_safety_guard
+
+                        get_safety_guard().record_llm_tokens(total_tokens)
+                    except Exception:
+                        pass
             elif event_type == "agent_output":
                 run_data["summary"]["agent_output_events"] += 1
             elif event_type == "node_execution":

--- a/tradingagents/safety/__init__.py
+++ b/tradingagents/safety/__init__.py
@@ -1,0 +1,17 @@
+"""Deterministic production safety layer — independent of all agent logic."""
+
+from .guardrails import (
+    DEFAULT_SAFETY_CONFIG,
+    SafetyGuard,
+    SafetyVerdict,
+    get_safety_guard,
+    reset_safety_guard,
+)
+
+__all__ = [
+    "DEFAULT_SAFETY_CONFIG",
+    "SafetyGuard",
+    "SafetyVerdict",
+    "get_safety_guard",
+    "reset_safety_guard",
+]

--- a/tradingagents/safety/guardrails.py
+++ b/tradingagents/safety/guardrails.py
@@ -113,6 +113,14 @@ class SafetyGuard:
         self.kill_switch_path.parent.mkdir(parents=True, exist_ok=True)
         stamp = datetime.now(timezone.utc).isoformat()
         self.kill_switch_path.write_text(f"{reason} (engaged {stamp})", encoding="utf-8")
+        # Ops alert; imported lazily and failure-isolated so the safety
+        # layer keeps zero hard dependencies.
+        try:
+            from tradingagents.alerts import notify_kill_switch
+
+            notify_kill_switch(reason)
+        except Exception:
+            pass
 
     def release_kill_switch(self) -> None:
         try:

--- a/tradingagents/safety/guardrails.py
+++ b/tradingagents/safety/guardrails.py
@@ -1,0 +1,360 @@
+"""Deterministic production safety layer.
+
+Every guard here is plain arithmetic over injected state — zero LLM calls,
+zero imports from the agent stack — so it cannot be talked out of a halt by
+a model and keeps working when providers misbehave. Three stages:
+
+- pre-trade checks: per-order notional cap, per-symbol concentration cap
+- circuit breakers: daily loss halt, drawdown-from-high-water-mark halt,
+  consecutive-rejection halt (a data/connectivity glitch signal)
+- kill switch: a flag file that stops all order flow no matter what the
+  agents decide (ops can engage it by touching the file, no Python needed)
+
+A daily LLM token budget rides along: run logs already count tokens, the
+guard accumulates them per day and can refuse to start new analyses.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DEFAULT_SAFETY_CONFIG: Dict[str, Any] = {
+    "safety_enabled": True,
+    # Pre-trade checks
+    "max_trade_notional_usd": 25_000.0,  # 0 = uncapped
+    "max_symbol_concentration_pct": 25.0,  # of account equity; 0 = uncapped
+    # Circuit breakers
+    "daily_loss_halt_pct": 10.0,  # halt when equity drops this % vs yesterday
+    "max_drawdown_halt_pct": 15.0,  # halt when equity drops this % vs high-water mark
+    "max_consecutive_rejections": 5,  # halt after this many broker rejections in a row
+    # LLM cost cap
+    "daily_llm_token_budget": 0,  # tokens/day across all runs; 0 = unlimited
+}
+
+_SAFETY_HOME = Path(os.path.expanduser("~")) / ".tradingagents" / "safety"
+
+
+@dataclass
+class SafetyVerdict:
+    allowed: bool
+    reasons: List[str] = field(default_factory=list)
+    checks: Dict[str, dict] = field(default_factory=dict)
+
+
+def _today(when: Optional[str] = None) -> str:
+    return when or date.today().isoformat()
+
+
+class SafetyGuard:
+    """Thread-safe guard with a small JSON state file.
+
+    Persisted state: equity high-water mark, current rejection streak, and
+    per-day LLM token counts. The kill switch is a separate flag file so a
+    human (or cron job) can engage it with `touch`.
+    """
+
+    def __init__(
+        self,
+        config: Optional[Dict[str, Any]] = None,
+        state_path: Optional[Path] = None,
+        kill_switch_path: Optional[Path] = None,
+    ):
+        merged = dict(DEFAULT_SAFETY_CONFIG)
+        for key in merged:
+            if config and config.get(key) is not None:
+                merged[key] = config[key]
+        self.config = merged
+        self.state_path = Path(state_path or (_SAFETY_HOME / "state.json"))
+        self.kill_switch_path = Path(
+            kill_switch_path or (_SAFETY_HOME / "KILL_SWITCH")
+        )
+        self._lock = threading.RLock()
+        self._state = self._load_state()
+
+    # ----- state persistence -------------------------------------------------
+
+    def _load_state(self) -> Dict[str, Any]:
+        try:
+            raw = json.loads(self.state_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                return raw
+        except (OSError, ValueError):
+            pass
+        return {"high_water_mark": None, "consecutive_rejections": 0, "llm_tokens": {}}
+
+    def _save_state(self) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.state_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._state, indent=2), encoding="utf-8")
+        os.replace(tmp, self.state_path)
+
+    # ----- kill switch --------------------------------------------------------
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.config.get("safety_enabled", True))
+
+    def kill_switch_active(self) -> bool:
+        return self.kill_switch_path.exists()
+
+    def kill_switch_reason(self) -> str:
+        try:
+            return self.kill_switch_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return ""
+
+    def engage_kill_switch(self, reason: str = "manual halt") -> None:
+        self.kill_switch_path.parent.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).isoformat()
+        self.kill_switch_path.write_text(f"{reason} (engaged {stamp})", encoding="utf-8")
+
+    def release_kill_switch(self) -> None:
+        try:
+            self.kill_switch_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    # ----- order/rejection tracking -------------------------------------------
+
+    def record_order_result(self, success: bool) -> None:
+        with self._lock:
+            if success:
+                self._state["consecutive_rejections"] = 0
+            else:
+                self._state["consecutive_rejections"] = (
+                    int(self._state.get("consecutive_rejections", 0)) + 1
+                )
+            self._save_state()
+
+    def consecutive_rejections(self) -> int:
+        with self._lock:
+            return int(self._state.get("consecutive_rejections", 0))
+
+    # ----- LLM token budget ----------------------------------------------------
+
+    def record_llm_tokens(self, tokens: int, when: Optional[str] = None) -> None:
+        if not tokens:
+            return
+        day = _today(when)
+        with self._lock:
+            counts = self._state.setdefault("llm_tokens", {})
+            counts[day] = int(counts.get(day, 0)) + int(tokens)
+            # Keep the map from growing unbounded.
+            for old_day in sorted(counts)[:-31]:
+                del counts[old_day]
+            self._save_state()
+
+    def llm_tokens_used(self, when: Optional[str] = None) -> int:
+        day = _today(when)
+        with self._lock:
+            return int(self._state.get("llm_tokens", {}).get(day, 0))
+
+    def check_llm_budget(self, when: Optional[str] = None) -> SafetyVerdict:
+        budget = float(self.config.get("daily_llm_token_budget", 0) or 0)
+        used = self.llm_tokens_used(when)
+        if not self.enabled or budget <= 0 or used < budget:
+            return SafetyVerdict(
+                allowed=True,
+                checks={"llm_budget": {"status": "pass", "used": used, "budget": budget}},
+            )
+        return SafetyVerdict(
+            allowed=False,
+            reasons=[
+                f"Daily LLM token budget exhausted: {used:,.0f} of {budget:,.0f} tokens used."
+            ],
+            checks={"llm_budget": {"status": "fail", "used": used, "budget": budget}},
+        )
+
+    # ----- the main pre-order gate ----------------------------------------------
+
+    def check_order(
+        self,
+        symbol: str,
+        notional: float,
+        account: Optional[Dict[str, float]] = None,
+        position_value: Optional[float] = None,
+    ) -> SafetyVerdict:
+        """Deterministic gate every outbound order must pass.
+
+        `account` carries {"equity", "last_equity"} when available; checks
+        that need missing data are reported as skipped rather than guessed.
+        """
+        if not self.enabled:
+            return SafetyVerdict(
+                allowed=True, checks={"safety": {"status": "skipped", "detail": "disabled"}}
+            )
+
+        reasons: List[str] = []
+        checks: Dict[str, dict] = {}
+        equity = float(account["equity"]) if account and account.get("equity") else None
+        last_equity = (
+            float(account["last_equity"])
+            if account and account.get("last_equity")
+            else None
+        )
+
+        # Kill switch dominates everything.
+        if self.kill_switch_active():
+            reason = self.kill_switch_reason() or "engaged"
+            reasons.append(f"Kill switch is engaged: {reason}")
+            checks["kill_switch"] = {"status": "fail", "detail": reason}
+        else:
+            checks["kill_switch"] = {"status": "pass"}
+
+        # Pre-trade: per-order notional cap.
+        cap = float(self.config.get("max_trade_notional_usd", 0) or 0)
+        if cap > 0 and float(notional) > cap:
+            reasons.append(
+                f"Order notional ${float(notional):,.2f} exceeds max_trade_notional_usd ${cap:,.2f}."
+            )
+            checks["trade_notional"] = {"status": "fail", "notional": float(notional), "cap": cap}
+        else:
+            checks["trade_notional"] = {"status": "pass", "notional": float(notional), "cap": cap}
+
+        # Pre-trade: per-symbol concentration cap.
+        conc_pct = float(self.config.get("max_symbol_concentration_pct", 0) or 0)
+        if conc_pct > 0:
+            if equity:
+                exposure = float(position_value or 0.0) + float(notional)
+                limit = equity * conc_pct / 100.0
+                if exposure > limit:
+                    reasons.append(
+                        f"{symbol} exposure ${exposure:,.2f} would exceed "
+                        f"{conc_pct:g}% of equity (${limit:,.2f})."
+                    )
+                    checks["concentration"] = {
+                        "status": "fail",
+                        "exposure": exposure,
+                        "limit": limit,
+                    }
+                else:
+                    checks["concentration"] = {
+                        "status": "pass",
+                        "exposure": exposure,
+                        "limit": limit,
+                    }
+            else:
+                checks["concentration"] = {
+                    "status": "skipped",
+                    "detail": "account equity unavailable",
+                }
+        else:
+            checks["concentration"] = {"status": "pass", "detail": "uncapped"}
+
+        # Circuit breaker: daily loss.
+        halt_pct = float(self.config.get("daily_loss_halt_pct", 0) or 0)
+        if halt_pct > 0 and equity and last_equity:
+            change_pct = (equity - last_equity) / last_equity * 100.0
+            if change_pct <= -halt_pct:
+                reasons.append(
+                    f"Daily loss circuit breaker: equity is {change_pct:+.2f}% vs "
+                    f"yesterday (halt at -{halt_pct:g}%)."
+                )
+                checks["daily_loss"] = {"status": "fail", "change_pct": change_pct}
+            else:
+                checks["daily_loss"] = {"status": "pass", "change_pct": change_pct}
+        else:
+            checks["daily_loss"] = {
+                "status": "skipped" if halt_pct > 0 else "pass",
+                "detail": "account equity unavailable" if halt_pct > 0 else "uncapped",
+            }
+
+        # Circuit breaker: drawdown from persisted high-water mark.
+        dd_pct = float(self.config.get("max_drawdown_halt_pct", 0) or 0)
+        if equity:
+            with self._lock:
+                hwm = self._state.get("high_water_mark")
+                if hwm is None or equity > float(hwm):
+                    self._state["high_water_mark"] = equity
+                    self._save_state()
+                    hwm = equity
+            hwm = float(hwm)
+            if dd_pct > 0 and hwm > 0:
+                drawdown_pct = (hwm - equity) / hwm * 100.0
+                if drawdown_pct >= dd_pct:
+                    reasons.append(
+                        f"Drawdown circuit breaker: equity is {drawdown_pct:.2f}% below the "
+                        f"${hwm:,.2f} high-water mark (halt at {dd_pct:g}%)."
+                    )
+                    checks["drawdown"] = {"status": "fail", "drawdown_pct": drawdown_pct}
+                else:
+                    checks["drawdown"] = {"status": "pass", "drawdown_pct": drawdown_pct}
+            else:
+                checks["drawdown"] = {"status": "pass", "detail": "uncapped"}
+        else:
+            checks["drawdown"] = {
+                "status": "skipped" if dd_pct > 0 else "pass",
+                "detail": "account equity unavailable" if dd_pct > 0 else "uncapped",
+            }
+
+        # Circuit breaker: consecutive broker rejections (data-glitch signal).
+        max_rejects = int(self.config.get("max_consecutive_rejections", 0) or 0)
+        streak = self.consecutive_rejections()
+        if max_rejects > 0 and streak >= max_rejects:
+            reasons.append(
+                f"{streak} consecutive orders were rejected (halt at {max_rejects}); "
+                "possible data or connectivity problem."
+            )
+            checks["rejection_streak"] = {"status": "fail", "streak": streak}
+        else:
+            checks["rejection_streak"] = {"status": "pass", "streak": streak}
+
+        return SafetyVerdict(allowed=not reasons, reasons=reasons, checks=checks)
+
+    # ----- status for dashboards ---------------------------------------------
+
+    def status(self, account: Optional[Dict[str, float]] = None) -> Dict[str, Any]:
+        """Green/red snapshot of every guard for the WebUI panel."""
+        order_view = self.check_order("_status_", 0.0, account=account)
+        budget_view = self.check_llm_budget()
+        guards: Dict[str, dict] = {}
+        for name, check in {**order_view.checks, **budget_view.checks}.items():
+            guards[name] = {
+                "ok": check.get("status") != "fail",
+                "status": check.get("status"),
+                "detail": {k: v for k, v in check.items() if k != "status"},
+            }
+        return {
+            "enabled": self.enabled,
+            "kill_switch_active": self.kill_switch_active(),
+            "kill_switch_reason": self.kill_switch_reason(),
+            "reasons": list(order_view.reasons) + list(budget_view.reasons),
+            "guards": guards,
+            "config": dict(self.config),
+        }
+
+
+# ----- process-wide singleton ---------------------------------------------------
+
+_GUARD: Optional[SafetyGuard] = None
+_GUARD_LOCK = threading.Lock()
+
+
+def get_safety_guard() -> SafetyGuard:
+    """Process-wide guard configured from the runtime config (lazily)."""
+    global _GUARD
+    with _GUARD_LOCK:
+        if _GUARD is None:
+            config: Dict[str, Any] = {}
+            try:
+                # Imported lazily: the safety layer must stay importable even
+                # if the dataflows stack (and its dependencies) are not.
+                from tradingagents.dataflows.config import get_config
+
+                config = dict(get_config() or {})
+            except Exception:
+                config = {}
+            _GUARD = SafetyGuard(config=config)
+        return _GUARD
+
+
+def reset_safety_guard() -> None:
+    global _GUARD
+    with _GUARD_LOCK:
+        _GUARD = None

--- a/webui/callbacks/__init__.py
+++ b/webui/callbacks/__init__.py
@@ -10,6 +10,7 @@ from .control_callbacks import register_control_callbacks
 from .trading_callbacks import register_trading_callbacks
 from .storage_callbacks import register_storage_callbacks
 from .api_config_callbacks import register_api_config_callbacks
+from .safety_callbacks import register_safety_callbacks
 
 def register_all_callbacks(app):
     """Register all callback functions with the Dash app"""
@@ -19,4 +20,5 @@ def register_all_callbacks(app):
     register_control_callbacks(app)
     register_trading_callbacks(app)
     register_storage_callbacks(app)
-    register_api_config_callbacks(app) 
+    register_api_config_callbacks(app)
+    register_safety_callbacks(app)

--- a/webui/callbacks/__init__.py
+++ b/webui/callbacks/__init__.py
@@ -11,6 +11,7 @@ from .trading_callbacks import register_trading_callbacks
 from .storage_callbacks import register_storage_callbacks
 from .api_config_callbacks import register_api_config_callbacks
 from .safety_callbacks import register_safety_callbacks
+from .cost_callbacks import register_cost_callbacks
 
 def register_all_callbacks(app):
     """Register all callback functions with the Dash app"""
@@ -22,3 +23,4 @@ def register_all_callbacks(app):
     register_storage_callbacks(app)
     register_api_config_callbacks(app)
     register_safety_callbacks(app)
+    register_cost_callbacks(app)

--- a/webui/callbacks/cost_callbacks.py
+++ b/webui/callbacks/cost_callbacks.py
@@ -1,0 +1,230 @@
+"""
+Cost callbacks for TradingAgents WebUI
+Scans the persisted run logs, aggregates LLM spend per day/symbol/model,
+joins each symbol's realized returns, and shows the daily token budget
+state from the safety layer.
+"""
+
+import dash_bootstrap_components as dbc
+import plotly.graph_objects as go
+from dash import Input, Output, html
+
+from webui.config.constants import COLORS
+
+
+def _fmt_usd(value):
+    return "—" if value is None else f"${value:,.2f}"
+
+
+def _fmt_tokens(value):
+    return f"{int(value or 0):,}"
+
+
+def _summary_card(label, text, color=None):
+    return dbc.Col(
+        dbc.Card(
+            dbc.CardBody(
+                [
+                    html.Div(label, className="text-muted small"),
+                    html.Div(
+                        text,
+                        style={
+                            "color": color or COLORS["text"],
+                            "fontSize": "1.3rem",
+                            "fontWeight": 600,
+                        },
+                    ),
+                ],
+                className="p-2 text-center",
+            ),
+            style={"backgroundColor": COLORS["card"], "border": f"1px solid {COLORS['border']}"},
+        ),
+        md=2,
+        xs=6,
+        className="mb-2",
+    )
+
+
+def _budget_text():
+    """Daily token usage vs the safety layer's budget, if configured."""
+    try:
+        from tradingagents.safety import get_safety_guard
+
+        guard = get_safety_guard()
+        used = guard.llm_tokens_used()
+        budget = float(guard.config.get("daily_llm_token_budget", 0) or 0)
+        if budget > 0:
+            return f"{used:,} / {budget:,.0f}", (
+                COLORS["error"] if used >= budget else COLORS["completed"]
+            )
+        return f"{used:,} / ∞", COLORS["text"]
+    except Exception:
+        return "—", COLORS["pending"]
+
+
+def _build_daily_figure(per_day):
+    days = sorted(per_day)
+    figure = go.Figure(
+        go.Bar(
+            x=days,
+            y=[per_day[d]["cost_usd"] for d in days],
+            marker_color=COLORS["primary"],
+        )
+    )
+    figure.update_layout(
+        title="Estimated LLM cost per day",
+        template="plotly_dark",
+        paper_bgcolor=COLORS["card"],
+        plot_bgcolor=COLORS["card"],
+        margin={"l": 40, "r": 20, "t": 40, "b": 30},
+        yaxis={"title": "USD", "tickformat": ",.2f"},
+        showlegend=False,
+    )
+    return figure
+
+
+def _build_symbol_table(per_symbol, returns_by_symbol):
+    if not per_symbol:
+        return None
+    header = html.Thead(
+        html.Tr(
+            [
+                html.Th("Symbol"),
+                html.Th("Runs"),
+                html.Th("Tokens"),
+                html.Th("Est. cost"),
+                html.Th("Resolved decisions"),
+                html.Th("Avg realized return"),
+            ]
+        )
+    )
+    rows = []
+    for symbol in sorted(per_symbol, key=lambda s: -per_symbol[s]["cost_usd"]):
+        stats = per_symbol[symbol]
+        outcome = returns_by_symbol.get(symbol) or {}
+        avg = outcome.get("avg_return")
+        avg_text = "—" if avg is None else f"{avg:+.2%}"
+        avg_color = (
+            COLORS["pending"]
+            if avg is None
+            else (COLORS["completed"] if avg > 0 else COLORS["error"])
+        )
+        rows.append(
+            html.Tr(
+                [
+                    html.Td(symbol),
+                    html.Td(stats["runs"]),
+                    html.Td(_fmt_tokens(stats["total_tokens"])),
+                    html.Td(_fmt_usd(stats["cost_usd"])),
+                    html.Td(outcome.get("resolved", 0)),
+                    html.Td(avg_text, style={"color": avg_color}),
+                ]
+            )
+        )
+    return html.Div(
+        [
+            html.H6("Per symbol — cost vs realized outcome", className="mt-2"),
+            dbc.Table([header, html.Tbody(rows)], bordered=False, hover=True, size="sm", striped=True),
+        ]
+    )
+
+
+def _build_model_table(per_model):
+    if not per_model:
+        return None
+    header = html.Thead(
+        html.Tr(
+            [
+                html.Th("Model"),
+                html.Th("Input tokens"),
+                html.Th("Output tokens"),
+                html.Th("Est. cost"),
+            ]
+        )
+    )
+    rows = []
+    for model in sorted(per_model, key=lambda m: -per_model[m]["cost_usd"]):
+        stats = per_model[model]
+        cost_text = _fmt_usd(stats["cost_usd"]) + (" (partly unpriced)" if stats.get("unpriced") else "")
+        rows.append(
+            html.Tr(
+                [
+                    html.Td(model),
+                    html.Td(_fmt_tokens(stats["input_tokens"])),
+                    html.Td(_fmt_tokens(stats["output_tokens"])),
+                    html.Td(cost_text),
+                ]
+            )
+        )
+    return html.Div(
+        [
+            html.H6("Per model", className="mt-2"),
+            dbc.Table([header, html.Tbody(rows)], bordered=False, hover=True, size="sm", striped=True),
+        ]
+    )
+
+
+def register_cost_callbacks(app):
+    """Register cost-panel callbacks with the Dash app"""
+
+    @app.callback(
+        [
+            Output("cost-summary-cards", "children"),
+            Output("cost-daily-graph", "figure"),
+            Output("cost-graph-container", "style"),
+            Output("cost-symbol-table", "children"),
+            Output("cost-model-table", "children"),
+        ],
+        Input("cost-refresh-btn", "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def refresh_cost_panel(n_clicks):
+        hidden = {"display": "none"}
+        empty = go.Figure()
+        try:
+            from tradingagents.dataflows.config import get_config
+            from tradingagents.llm_cost import (
+                aggregate_costs,
+                realized_returns_by_symbol,
+                scan_run_costs,
+            )
+
+            config = {}
+            try:
+                config = dict(get_config() or {})
+            except Exception:
+                config = {}
+            records = scan_run_costs(
+                eval_results_dir=config.get("results_dir", "eval_results"),
+                overrides=config.get("llm_pricing_per_million"),
+            )
+            aggregates = aggregate_costs(records)
+            returns_by_symbol = realized_returns_by_symbol(config)
+        except Exception as e:
+            alert = dbc.Alert(f"Cost scan failed: {e}", color="danger", className="mb-0")
+            return alert, empty, hidden, None, None
+
+        totals = aggregates["totals"]
+        if not totals["runs"]:
+            alert = dbc.Alert(
+                "No recorded runs found under eval_results/ yet.",
+                color="info",
+                className="mb-0",
+            )
+            return alert, empty, hidden, None, None
+
+        budget_text, budget_color = _budget_text()
+        cards = dbc.Row(
+            [
+                _summary_card("Analyses", f"{totals['runs']:,}"),
+                _summary_card("Total tokens", _fmt_tokens(totals["total_tokens"])),
+                _summary_card("Est. cost", _fmt_usd(totals["cost_usd"]), COLORS["primary"]),
+                _summary_card("Unpriced tokens", _fmt_tokens(totals["unpriced_tokens"])),
+                _summary_card("Today's tokens / budget", budget_text, budget_color),
+            ],
+            className="g-2",
+        )
+        figure = _build_daily_figure(aggregates["per_day"])
+        symbol_table = _build_symbol_table(aggregates["per_symbol"], returns_by_symbol)
+        model_table = _build_model_table(aggregates["per_model"])
+        return cards, figure, {"display": "block"}, symbol_table, model_table

--- a/webui/callbacks/safety_callbacks.py
+++ b/webui/callbacks/safety_callbacks.py
@@ -1,0 +1,155 @@
+"""
+Safety-layer callbacks for TradingAgents WebUI
+Renders live guardrail status and drives the kill switch.
+"""
+
+import dash_bootstrap_components as dbc
+from dash import Input, Output, ctx, html
+
+from webui.config.constants import COLORS
+
+_GUARD_LABELS = {
+    "kill_switch": "Kill Switch",
+    "trade_notional": "Trade Size Cap",
+    "concentration": "Concentration",
+    "daily_loss": "Daily Loss Breaker",
+    "drawdown": "Drawdown Breaker",
+    "rejection_streak": "Rejection Streak",
+    "llm_budget": "LLM Budget",
+}
+
+
+def _guard_detail_text(name, guard):
+    detail = guard.get("detail") or {}
+    if guard.get("status") == "skipped":
+        return str(detail.get("detail", "no account data"))
+    if name == "daily_loss" and "change_pct" in detail:
+        return f"{detail['change_pct']:+.2f}% today"
+    if name == "drawdown" and "drawdown_pct" in detail:
+        return f"-{detail['drawdown_pct']:.2f}% from peak"
+    if name == "rejection_streak":
+        return f"{detail.get('streak', 0)} in a row"
+    if name == "llm_budget":
+        budget = detail.get("budget") or 0
+        if not budget:
+            return "unlimited"
+        return f"{detail.get('used', 0):,.0f} / {budget:,.0f} tokens"
+    if name == "trade_notional":
+        cap = detail.get("cap") or 0
+        return f"cap ${cap:,.0f}" if cap else "uncapped"
+    if name == "concentration":
+        limit = detail.get("limit")
+        return f"limit ${limit:,.0f}" if limit else str(detail.get("detail", ""))
+    return ""
+
+
+def _status_cards(status):
+    cards = []
+    for name, label in _GUARD_LABELS.items():
+        guard = status["guards"].get(name)
+        if guard is None:
+            continue
+        if guard.get("status") == "skipped":
+            color = COLORS.get("pending", "#9ca3af")
+            icon = "fas fa-question-circle"
+        elif guard["ok"]:
+            color = COLORS.get("completed", "#22c55e")
+            icon = "fas fa-check-circle"
+        else:
+            color = COLORS.get("error", "#ef4444")
+            icon = "fas fa-exclamation-triangle"
+        cards.append(
+            dbc.Col(
+                dbc.Card(
+                    dbc.CardBody(
+                        [
+                            html.Div(
+                                [html.I(className=f"{icon} me-2", style={"color": color}), label],
+                                className="small fw-bold",
+                            ),
+                            html.Div(
+                                _guard_detail_text(name, guard),
+                                className="text-muted small",
+                            ),
+                        ],
+                        className="p-2",
+                    ),
+                    style={
+                        "backgroundColor": COLORS.get("card", "#1f2937"),
+                        "border": f"1px solid {color}",
+                    },
+                ),
+                md=3,
+                xs=6,
+                className="mb-2",
+            )
+        )
+    rows = [dbc.Row(cards, className="g-2")]
+    if status.get("reasons"):
+        rows.append(
+            dbc.Alert(
+                [html.Div(reason) for reason in status["reasons"]],
+                color="danger",
+                className="mt-2 mb-0 py-2 small",
+            )
+        )
+    if not status.get("enabled", True):
+        rows.append(
+            dbc.Alert(
+                "Safety layer is DISABLED via configuration (safety_enabled=False).",
+                color="warning",
+                className="mt-2 mb-0 py-2 small",
+            )
+        )
+    return html.Div(rows)
+
+
+def _account_snapshot():
+    try:
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        account, _ = AlpacaUtils._safety_context("_status_")
+        return account
+    except Exception:
+        return None
+
+
+def register_safety_callbacks(app):
+    """Register safety-layer callbacks with the Dash app"""
+
+    @app.callback(
+        [
+            Output("safety-status-container", "children"),
+            Output("safety-action-status", "children"),
+        ],
+        [
+            Input("safety-refresh-interval", "n_intervals"),
+            Input("safety-kill-switch-btn", "n_clicks"),
+            Input("safety-release-btn", "n_clicks"),
+        ],
+        prevent_initial_call=False,
+    )
+    def refresh_safety_panel(_n, _engage_clicks, _release_clicks):
+        from tradingagents.safety import get_safety_guard
+
+        guard = get_safety_guard()
+        action_message = None
+
+        trigger = ctx.triggered_id if ctx.triggered_id else None
+        if trigger == "safety-kill-switch-btn":
+            guard.engage_kill_switch("engaged from WebUI")
+            action_message = dbc.Alert(
+                "Kill switch ENGAGED — all order flow is halted.",
+                color="danger",
+                className="mb-0 py-2 small",
+            )
+        elif trigger == "safety-release-btn":
+            guard.release_kill_switch()
+            action_message = dbc.Alert(
+                "Kill switch released — order flow may resume.",
+                color="success",
+                className="mb-0 py-2 small",
+            )
+
+        status = guard.status(account=_account_snapshot())
+        return _status_cards(status), action_message

--- a/webui/components/analysis.py
+++ b/webui/components/analysis.py
@@ -389,6 +389,19 @@ def start_analysis(
 ):
     """Start real-time analysis function for the UI"""
 
+    # Deterministic LLM budget gate (production safety layer): refuse to burn
+    # tokens on a new analysis once the daily budget is exhausted.
+    try:
+        from tradingagents.safety import get_safety_guard
+
+        budget_verdict = get_safety_guard().check_llm_budget()
+    except Exception:
+        budget_verdict = None
+    if budget_verdict is not None and not budget_verdict.allowed:
+        message = " ".join(budget_verdict.reasons)
+        print(f"[SAFETY] {message}")
+        return message
+
     # Parse selected analysts
     selected_analysts = []
     if analysts_market:

--- a/webui/components/cost_panel.py
+++ b/webui/components/cost_panel.py
@@ -1,0 +1,65 @@
+"""
+webui/components/cost_panel.py - LLM cost monitoring panel
+
+Attributes LLM spend from the persisted run logs to analyses, days,
+symbols, and models, next to each symbol's realized returns — so cost
+without benefit is visible at a glance. Estimates are an upper bound
+(cache-read discounts are not recorded) and unknown models are surfaced
+as unpriced tokens rather than guessed.
+"""
+
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+
+def create_cost_panel():
+    """Create the LLM cost panel card for the web UI."""
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.H4("LLM Cost Monitor", className="mb-1"),
+                html.Div(
+                    "Estimated spend from recorded token usage — attributed per "
+                    "day, symbol, and model, against realized returns. Prices are "
+                    "estimates (override via llm_pricing_per_million); cache "
+                    "discounts are not tracked, so this is an upper bound.",
+                    className="text-muted small mb-3",
+                ),
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            dbc.Button(
+                                [html.I(className="fas fa-sync me-2"), "Refresh"],
+                                id="cost-refresh-btn",
+                                color="primary",
+                                size="sm",
+                            ),
+                            width="auto",
+                        ),
+                    ],
+                    className="g-2 mb-3",
+                ),
+                dcc.Loading(
+                    id="cost-loading",
+                    type="default",
+                    children=html.Div(
+                        [
+                            html.Div(id="cost-summary-cards", className="mb-3"),
+                            html.Div(
+                                dcc.Graph(
+                                    id="cost-daily-graph",
+                                    config={"displayModeBar": False, "responsive": True},
+                                    style={"height": "260px", "width": "100%"},
+                                ),
+                                id="cost-graph-container",
+                                style={"display": "none"},
+                            ),
+                            html.Div(id="cost-symbol-table", className="mb-2"),
+                            html.Div(id="cost-model-table"),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+        className="mb-4",
+    )

--- a/webui/components/safety_panel.py
+++ b/webui/components/safety_panel.py
@@ -1,0 +1,71 @@
+"""
+webui/components/safety_panel.py - Production safety layer status panel
+
+Shows a green/red badge for every deterministic guard (kill switch,
+pre-trade checks, circuit breakers, LLM budget) plus a kill-switch toggle
+that halts all order flow immediately, regardless of agent decisions.
+"""
+
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+
+def create_safety_panel():
+    """Create the safety guardrails card for the web UI."""
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.H4("Safety Guardrails", className="mb-1"),
+                                html.Div(
+                                    "Deterministic pre-trade checks, circuit breakers, and a "
+                                    "kill switch — enforced before any order reaches the broker, "
+                                    "independent of agent decisions.",
+                                    className="text-muted small",
+                                ),
+                            ],
+                            md=8,
+                        ),
+                        dbc.Col(
+                            [
+                                dbc.ButtonGroup(
+                                    [
+                                        dbc.Button(
+                                            [
+                                                html.I(className="fas fa-hand-paper me-2"),
+                                                "Engage Kill Switch",
+                                            ],
+                                            id="safety-kill-switch-btn",
+                                            color="danger",
+                                            size="sm",
+                                        ),
+                                        dbc.Button(
+                                            "Release",
+                                            id="safety-release-btn",
+                                            color="secondary",
+                                            outline=True,
+                                            size="sm",
+                                        ),
+                                    ],
+                                    className="float-end",
+                                ),
+                            ],
+                            md=4,
+                        ),
+                    ],
+                    className="mb-3 align-items-start",
+                ),
+                html.Div(id="safety-action-status", className="mb-2"),
+                html.Div(id="safety-status-container"),
+                dcc.Interval(
+                    id="safety-refresh-interval",
+                    interval=30_000,  # 30s
+                    n_intervals=0,
+                ),
+            ]
+        ),
+        className="mb-4",
+    )

--- a/webui/layout.py
+++ b/webui/layout.py
@@ -14,6 +14,7 @@ from webui.components.decision_panel import create_decision_panel
 from webui.components.reports_panel import create_reports_panel
 from webui.components.alpaca_account import render_alpaca_account_section
 from webui.components.safety_panel import create_safety_panel
+from webui.components.cost_panel import create_cost_panel
 from webui.components.api_config_modal import create_api_config_modal
 from webui.config.constants import COLORS, REFRESH_INTERVALS
 
@@ -178,6 +179,7 @@ def create_main_layout():
                 ], md=6)
             ]),
             reports_card,
+            create_cost_panel(),
             html.Div(className="mt-4"),
             create_footer(),
         ],

--- a/webui/layout.py
+++ b/webui/layout.py
@@ -13,6 +13,7 @@ from webui.components.chart_panel import create_chart_panel
 from webui.components.decision_panel import create_decision_panel
 from webui.components.reports_panel import create_reports_panel
 from webui.components.alpaca_account import render_alpaca_account_section
+from webui.components.safety_panel import create_safety_panel
 from webui.components.api_config_modal import create_api_config_modal
 from webui.config.constants import COLORS, REFRESH_INTERVALS
 
@@ -164,6 +165,7 @@ def create_main_layout():
             
             # Main content
             header,
+            create_safety_panel(),
             alpaca_account_card,
             dbc.Row([
                 dbc.Col(config_card, md=6),


### PR DESCRIPTION
## What

Closes the production loop: the system now **tells the operator what it did each day** and **shouts when a guard fires** — no human tailing logs required.

> **Stacked PR:** built on `feature/llm-cost-dashboard` (#37), which stacks on `feature/production-safety-layer` (#32) — the report reuses #37's cost attribution and #32's guard status. Merging those first reduces this to the report/alerts commit alone.

## Alerts (`tradingagents/alerts.py`, stdlib-only)

- **Channels**: Telegram Bot API + generic JSON webhook, configured via config keys or `ALERT_TELEGRAM_BOT_TOKEN` / `ALERT_TELEGRAM_CHAT_ID` / `ALERT_WEBHOOK_URL` env vars. No new dependency.
- **Deduplicated by reason with a cooldown** (default 15 min): a tripped circuit breaker blocks *every* subsequent order — without dedupe that's one identical Telegram message per attempt. One breaker, one alert per window.
- **Failure-isolated**: a dead webhook or bad token can never affect order flow; failures are logged and swallowed.
- **Wired to fire on**: the safety layer blocking order flow, and kill-switch engagement (both lazy imports — the safety layer keeps zero hard dependencies).

## Daily report (`tradingagents/daily_report.py`, pure local file reading)

`write_daily_report()` renders `reports/YYYY-MM-DD.{md,html}` with:

| Section | Source |
|---|---|
| Decisions (symbol, signal, status, tokens, errors) | run logs |
| Safety status, guard by guard, incl. kill switch | `SafetyGuard.status()` (#32) |
| LLM cost for the day, model-attributed, upper-bound caveat | #37's cost module |
| Cumulative realized returns per symbol | resolved decision log |

No network, no LLM calls; scheduling is left to cron / Task Scheduler by design.

## Tests

12 new tests (both channels dispatch, cooldown dedupe, distinct keys not deduped, unconfigured/disabled silence, transport failure never raises, reason-keyed safety-block dedupe, report content incl. kill-switch banner and day filtering, md+html file writing, empty-day report, config wiring). Full suite: **100 passed (+133 subtests)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
