### PR TITLE
docs: architecture guide + five-minute quickstart

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,128 @@
+# Architecture Guide
+
+A concise map of how AlpacaTradingAgent works internally — for contributors
+and operators who want to know where things happen and why.
+
+## The big picture
+
+```
+                        ┌──────────────────────── WebUI (Dash) / CLI ───────────────────────┐
+                        │  symbols, LLM provider, depth, auto-trade, scheduling             │
+                        └──────────────────────────────┬────────────────────────────────────┘
+                                                       ▼
+┌───────────────────────────── TradingAgentsGraph (LangGraph) ─────────────────────────────┐
+│                                                                                          │
+│  5 parallel analysts                research debate                execution chain       │
+│  ┌────────────────────┐      ┌───────────────────────────┐   ┌───────────────────────┐   │
+│  │ Market             │      │ Bull researcher           │   │ Trader                │   │
+│  │ Social sentiment   │  ──► │ Bear researcher           │──►│ Risky/Safe/Neutral    │   │
+│  │ News               │      │ (N debate rounds)         │   │ risk debate           │   │
+│  │ Fundamentals       │      │ Research manager (judge)  │   │ Risk manager (judge)  │   │
+│  │ Macro (FRED)       │      └───────────────────────────┘   └──────────┬────────────┘   │
+│  └────────────────────┘                                                 │                │
+│        ▲ tools: Alpaca data, Finnhub, Google News, Reddit,              ▼                │
+│          CoinDesk/DeFiLlama (crypto), OpenAI web search       final decision +           │
+│                                                               typed TradeIntent          │
+└──────────────────────────────────────────────────────────────────┬───────────────────────┘
+                                                                   ▼
+                                      Alpaca execution (paper or live) — market/close orders
+```
+
+Final decisions are executable actions (`BUY/HOLD/SELL` in investment mode,
+`LONG/NEUTRAL/SHORT` in trading mode), carried in a typed `TradeIntent`
+schema alongside advisory metadata that never triggers orders by itself.
+
+## Package map
+
+| Path | Responsibility |
+|---|---|
+| `tradingagents/graph/` | LangGraph orchestration. `trading_graph.py` builds the graph and owns the LLM clients, memories, and reflection; `setup.py` wires nodes; `conditional_logic.py` controls debate rounds; `propagation.py` creates initial state; `signal_processing.py` extracts the final signal; `checkpointer.py` optional SQLite resume. |
+| `tradingagents/agents/` | The agents themselves: `analysts/` (market, social, news, fundamentals, macro), `researchers/` (bull/bear), `managers/`, `trader/`, `risk_mgmt/`, plus `utils/` (agent states, memory, trading modes) and `schemas.py` (typed `TradeIntent`). |
+| `tradingagents/dataflows/` | Every external data source behind one interface: `alpaca_utils.py` (bars, quotes, account, orders, execution), Finnhub, Google News, Reddit, FRED macro, crypto sources, with a yfinance fallback for supported failures. `config.py` holds runtime config + API keys. |
+| `tradingagents/llm_clients/` | Provider adapters (OpenAI, Anthropic, Google, xAI, DeepSeek, Qwen, GLM, OpenRouter, Ollama, Azure, local endpoints) behind `create_llm_client`. |
+| `tradingagents/prompts/` | All agent prompts as editable text templates (`TRADINGAGENTS_PROMPT_DIR` overrides). |
+| `tradingagents/run_logger.py` | Append-only audit trail: every prompt, tool call, LLM call (with token usage), state snapshot, and final state per run under `eval_results/<symbol>/TradingAgentsStrategy_logs/runs/`. |
+| `tradingagents/default_config.py` | Single source of defaults; everything is overridable per run. |
+| `webui/` | Dash interface: `layout.py` composes panels from `components/`, `callbacks/` register interaction handlers, `utils/state.py` is the shared app state. Entry: `python run_webui_dash.py`. |
+| `cli/` | Terminal interface: `python -m cli.main`. |
+| `tests/` | Pytest suite; deterministic, no network, no live keys. |
+
+## The analysis lifecycle
+
+1. **Kickoff** — WebUI/CLI builds a config (provider, models, depth, mode)
+   and calls `TradingAgentsGraph.propagate(symbol, date)`. A run log is
+   opened immediately; everything that follows is recorded incrementally.
+2. **Analysts** — five analysts run (parallel by default) with tool access;
+   each produces a markdown report. Context managers keep downstream
+   prompts within budget by chunking and scoring report evidence.
+3. **Research debate** — bull and bear researchers argue over the reports
+   for N rounds; the research manager judges and writes an investment plan.
+4. **Execution chain** — the trader turns the plan into a proposal; the
+   risky/safe/neutral risk debate stress-tests it; the risk manager issues
+   the final decision plus a typed `TradeIntent`.
+5. **Signal + execution** — `SignalProcessor` extracts the executable
+   action. If auto-trading is on, the WebUI executes it via
+   `AlpacaUtils.execute_trade_intent` / `execute_trading_action`.
+6. **Decision log** — the completed decision is appended to a markdown
+   memory log as `pending`, and resolved later with realized returns and a
+   reflection once the outcome is known.
+
+## Memory and learning
+
+Two complementary memories:
+
+- **Decision log** (`TradingMemoryLog`): append-only markdown of every
+  final decision, later updated with realized return / alpha / holding
+  days and a reflection. Recent same-ticker and cross-ticker entries are
+  injected into future prompts as past context.
+- **Per-agent situation memories** (`FinancialSituationMemory`): five
+  ChromaDB collections (bull, bear, trader, invest judge, risk manager)
+  storing (situation embedding → lesson) pairs, queried by similarity at
+  decision time.
+
+## Persistence map
+
+| Location | Contents |
+|---|---|
+| `eval_results/<symbol>/TradingAgentsStrategy_logs/runs/*.json` | Full audit trail per run: config, events (prompts, tool calls, LLM calls with token usage), snapshots, final state, final signal. |
+| `~/.tradingagents/memory/trading_memory.md` | The decision log (path configurable). |
+| `tradingagents/dataflows/data_cache/` | Cached market data. |
+| `eval_results/.../checkpoints` | Optional SQLite LangGraph checkpoints for resume. |
+
+## Configuration
+
+`tradingagents/default_config.py` is the single source of truth; the WebUI
+and CLI pass overrides per run, and API keys come from `.env` /
+environment (see `env.sample`). `ALPACA_USE_PAPER=True` keeps everything
+on the paper API — never develop against live trading.
+
+## Testing conventions
+
+- `python -m pytest tests/` — the suite is deterministic: no network, no
+  live keys; external boundaries are mocked and embeddings are faked.
+- `tests/test_import_no_network.py`-style guards assert that importing the
+  package performs no network calls.
+- On Windows, ChromaDB keeps store files open: use
+  `TemporaryDirectory(ignore_cleanup_errors=True)` in tests.
+
+## In-flight contributions (open PRs)
+
+Currently under review; each PR body documents its design in depth:
+
+| PR | Adds |
+|---|---|
+| [#25](https://github.com/huygiatrng/AlpacaTradingAgent/pull/25) | Deterministic risk sizing: fractional Kelly, ATR stops, exposure caps |
+| [#26](https://github.com/huygiatrng/AlpacaTradingAgent/pull/26) | Walk-forward backtesting engine over recorded decisions + WebUI panel |
+| [#27](https://github.com/huygiatrng/AlpacaTradingAgent/pull/27) | Self-learning memory: persistent agent memories fed by realized outcomes |
+| [#29](https://github.com/huygiatrng/AlpacaTradingAgent/pull/29) | No network calls / circular imports at package import time |
+| [#30](https://github.com/huygiatrng/AlpacaTradingAgent/pull/30) | Real bracket/OTO protective orders |
+| [#31](https://github.com/huygiatrng/AlpacaTradingAgent/pull/31) | Pydantic 3-ready model config |
+| [#32](https://github.com/huygiatrng/AlpacaTradingAgent/pull/32) | Production safety layer: pre-trade checks, circuit breakers, kill switch |
+| [#33](https://github.com/huygiatrng/AlpacaTradingAgent/pull/33) | GitHub Actions CI |
+| [#34](https://github.com/huygiatrng/AlpacaTradingAgent/pull/34) | Intensive teaching: seed agent memories from recorded backtest history |
+| [#35](https://github.com/huygiatrng/AlpacaTradingAgent/pull/35) | FinMem-style memory maintenance: decay, dedup, size caps |
+| [#36](https://github.com/huygiatrng/AlpacaTradingAgent/pull/36) | Chaos test suite + NaN/HTML broker-data hardening |
+| [#37](https://github.com/huygiatrng/AlpacaTradingAgent/pull/37) | LLM cost monitor: attributed spend vs realized returns |
+| [#38](https://github.com/huygiatrng/AlpacaTradingAgent/pull/38) | Portfolio-level intelligence: correlation, vol sizing, exposure cap |
+| [#39](https://github.com/huygiatrng/AlpacaTradingAgent/pull/39) | Deterministic market-regime detection |
+| [#40](https://github.com/huygiatrng/AlpacaTradingAgent/pull/40) | Daily operations report + Telegram/webhook alerts |

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,82 @@
+# Quick Start
+
+From zero to a first multi-agent analysis in about five minutes.
+
+## 1. Install
+
+```bash
+git clone https://github.com/huygiatrng/AlpacaTradingAgent.git
+cd AlpacaTradingAgent
+python -m venv .venv
+# Windows:
+.venv\Scripts\activate
+# macOS/Linux:
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## 2. Configure keys
+
+```bash
+cp env.sample .env   # Windows: copy env.sample .env
+```
+
+Edit `.env` — the minimum to run:
+
+| Key | Where to get it | Required |
+|---|---|---|
+| `ALPACA_API_KEY` / `ALPACA_SECRET_KEY` | free paper account at [alpaca.markets](https://alpaca.markets) | ✅ |
+| `OPENAI_API_KEY` | [platform.openai.com](https://platform.openai.com) (or set `LLM_PROVIDER` to another provider) | ✅ |
+| `FINNHUB_API_KEY` | [finnhub.io](https://finnhub.io) — richer news | optional |
+| `FRED_API_KEY` | [fred.stlouisfed.org](https://fred.stlouisfed.org/docs/api/api_key.html) — macro analyst | optional |
+| `COINDESK_API_KEY` | crypto news | optional |
+
+> **Keep `ALPACA_USE_PAPER=True`.** Everything works against the paper
+> API; switch to live only when you have a tested, reviewed setup and
+> accept the risk.
+
+## 3. Run
+
+```bash
+python run_webui_dash.py
+```
+
+Open the printed URL (usually `http://127.0.0.1:8050`), then:
+
+1. Enter symbols — stocks (`NVDA, AAPL`), crypto (`BTC/USD`), or a mix.
+2. Pick your LLM provider/models and research depth.
+3. Press **Analyze** and watch the five analysts, the bull/bear debate,
+   and the risk team stream their reports live.
+4. Execute the recommendation manually, or enable auto-execution and
+   recurring scheduled analysis.
+
+Prefer a terminal? `python -m cli.main` runs the same pipeline
+interactively.
+
+## 4. Verify your setup
+
+```bash
+python -m pytest tests/
+```
+
+The suite is deterministic (no network, no live keys) — it should pass on
+a fresh clone.
+
+## 5. Where results live
+
+- **Reports & audit trail**: `eval_results/<symbol>/TradingAgentsStrategy_logs/runs/`
+  — every prompt, tool call, LLM call (with token usage), and the final state.
+- **Decision log**: `~/.tradingagents/memory/trading_memory.md` — every
+  final decision, later resolved with realized returns.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `Alpaca API key or secret not found` | `.env` not loaded or keys empty — recheck step 2. |
+| `unauthorized` from Alpaca | Keys expired or live keys used against paper — regenerate paper keys. |
+| Analysis stalls at an analyst | Usually a rate limit; lower research depth or increase the start delays in settings. |
+| Crypto symbol not found | Use the slash format: `BTC/USD`, not `BTCUSD`. |
+
+Next: read [ARCHITECTURE.md](ARCHITECTURE.md) for how the pipeline works
+inside.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 🚀 [Enhanced Features](#enhanced-features) | ⚡ [Installation & Setup](#installation-and-setup) | 📦 [Package Usage](#alpacatradingagent-package) | 🌐 [Web Interface](#web-ui-usage) | 📖 [Complete Guide](#complete-guide) | 🤝 [Contributing](#contributing) | 📄 [Citation](#citation)
 
+⏱️ New here? **[QUICKSTART.md](QUICKSTART.md)** — first analysis in ~5 minutes · 🏗️ **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the pipeline works inside
+
 </div>
 
 ## Enhanced Features


### PR DESCRIPTION
## What

The project has grown well past what the README alone can carry: there was no document explaining how the pipeline actually works inside, and no short path from `git clone` to a first analysis. Two new documents fix that, linked from one nav line in the README. **Docs only — zero code changes.**

## [ARCHITECTURE.md](https://github.com/Solydos/AlpacaTradingAgent/blob/feature/project-docs/ARCHITECTURE.md)

For contributors and operators:

- The big-picture flow diagram: 5 parallel analysts → bull/bear research debate → trader → risky/safe/neutral risk debate → typed `TradeIntent` → Alpaca execution.
- A package-by-package responsibility map (`graph/`, `agents/`, `dataflows/`, `llm_clients/`, `prompts/`, `run_logger`, `webui/`, `cli/`).
- The analysis lifecycle step by step, the two memory systems (decision log + per-agent ChromaDB situation memories), the persistence map, configuration flow, and testing conventions (deterministic suite, no network, Windows/ChromaDB note).
- An index of the in-flight contribution PRs (#25–#40) so reviewers can see how the open work fits together.

## [QUICKSTART.md](https://github.com/Solydos/AlpacaTradingAgent/blob/feature/project-docs/QUICKSTART.md)

For new users: install → minimal `.env` keys (with where to get each one) → first WebUI analysis → `pytest` verification → where results live → a troubleshooting table for the four most common first-run failures. The paper-trading warning is front and center.

## Verification

Full suite unchanged and green: **53 passed (+133 subtests)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
