### PR TITLE
Integrate and harden open contribution PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,9 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Run test suite
+        # No API keys are configured on purpose: the suite must stay runnable
+        # offline (network-dependent paths are mocked or skipped).
+        run: pytest tests/ -v --tb=short

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
           pip install -r requirements.txt pytest
 
       - name: Run test suite
-        # No API keys are configured on purpose: the suite must stay runnable
-        # offline (network-dependent paths are mocked or skipped).
-        run: pytest tests/ -v --tb=short
+        # `python -m pytest` puts the repo root on sys.path (the project is
+        # not pip-installable). No API keys are configured on purpose: the
+        # suite must stay runnable offline.
+        run: python -m pytest tests/ -v --tb=short

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,9 @@ and operators who want to know where things happen and why.
 
 Final decisions are executable actions (`BUY/HOLD/SELL` in investment mode,
 `LONG/NEUTRAL/SHORT` in trading mode), carried in a typed `TradeIntent`
-schema alongside advisory metadata that never triggers orders by itself.
+schema. Numeric stop-loss and take-profit controls can be submitted as
+broker-side bracket/OTO orders when enabled; qualitative controls remain
+advisory.
 
 ## Package map
 
@@ -39,7 +41,7 @@ schema alongside advisory metadata that never triggers orders by itself.
 | `tradingagents/graph/` | LangGraph orchestration. `trading_graph.py` builds the graph and owns the LLM clients, memories, and reflection; `setup.py` wires nodes; `conditional_logic.py` controls debate rounds; `propagation.py` creates initial state; `signal_processing.py` extracts the final signal; `checkpointer.py` optional SQLite resume. |
 | `tradingagents/agents/` | The agents themselves: `analysts/` (market, social, news, fundamentals, macro), `researchers/` (bull/bear), `managers/`, `trader/`, `risk_mgmt/`, plus `utils/` (agent states, memory, trading modes) and `schemas.py` (typed `TradeIntent`). |
 | `tradingagents/dataflows/` | Every external data source behind one interface: `alpaca_utils.py` (bars, quotes, account, orders, execution), Finnhub, Google News, Reddit, FRED macro, crypto sources, with a yfinance fallback for supported failures. `config.py` holds runtime config + API keys. |
-| `tradingagents/llm_clients/` | Provider adapters (OpenAI, Anthropic, Google, xAI, DeepSeek, Qwen, GLM, OpenRouter, Ollama, Azure, local endpoints) behind `create_llm_client`. |
+| `tradingagents/llm_clients/` | Provider adapters (OpenAI, Anthropic, Google, xAI, MiniMax, DeepSeek, Qwen, GLM, OpenRouter, Ollama, Azure, local endpoints) behind `create_llm_client`. |
 | `tradingagents/prompts/` | All agent prompts as editable text templates (`TRADINGAGENTS_PROMPT_DIR` overrides). |
 | `tradingagents/run_logger.py` | Append-only audit trail: every prompt, tool call, LLM call (with token usage), state snapshot, and final state per run under `eval_results/<symbol>/TradingAgentsStrategy_logs/runs/`. |
 | `tradingagents/default_config.py` | Single source of defaults; everything is overridable per run. |
@@ -86,6 +88,9 @@ Two complementary memories:
 |---|---|
 | `eval_results/<symbol>/TradingAgentsStrategy_logs/runs/*.json` | Full audit trail per run: config, events (prompts, tool calls, LLM calls with token usage), snapshots, final state, final signal. |
 | `~/.tradingagents/memory/trading_memory.md` | The decision log (path configurable). |
+| `~/.tradingagents/memory/agent_memory/` | Persistent per-agent ChromaDB reflection memories. |
+| `~/.tradingagents/safety/` | Safety high-water mark, rejection/token counters, and the optional `KILL_SWITCH` flag. |
+| `reports/YYYY-MM-DD.{md,html}` | Optional daily operations reports. |
 | `tradingagents/dataflows/data_cache/` | Cached market data. |
 | `eval_results/.../checkpoints` | Optional SQLite LangGraph checkpoints for resume. |
 
@@ -105,9 +110,10 @@ on the paper API — never develop against live trading.
 - On Windows, ChromaDB keeps store files open: use
   `TemporaryDirectory(ignore_cleanup_errors=True)` in tests.
 
-## In-flight contributions (open PRs)
+## Integrated contribution set
 
-Currently under review; each PR body documents its design in depth:
+These reviewed contributions were integrated together because several are
+stacked and share execution, configuration, and WebUI paths:
 
 | PR | Adds |
 |---|---|

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,128 @@
+# Architecture Guide
+
+A concise map of how AlpacaTradingAgent works internally — for contributors
+and operators who want to know where things happen and why.
+
+## The big picture
+
+```
+                        ┌──────────────────────── WebUI (Dash) / CLI ───────────────────────┐
+                        │  symbols, LLM provider, depth, auto-trade, scheduling             │
+                        └──────────────────────────────┬────────────────────────────────────┘
+                                                       ▼
+┌───────────────────────────── TradingAgentsGraph (LangGraph) ─────────────────────────────┐
+│                                                                                          │
+│  5 parallel analysts                research debate                execution chain       │
+│  ┌────────────────────┐      ┌───────────────────────────┐   ┌───────────────────────┐   │
+│  │ Market             │      │ Bull researcher           │   │ Trader                │   │
+│  │ Social sentiment   │  ──► │ Bear researcher           │──►│ Risky/Safe/Neutral    │   │
+│  │ News               │      │ (N debate rounds)         │   │ risk debate           │   │
+│  │ Fundamentals       │      │ Research manager (judge)  │   │ Risk manager (judge)  │   │
+│  │ Macro (FRED)       │      └───────────────────────────┘   └──────────┬────────────┘   │
+│  └────────────────────┘                                                 │                │
+│        ▲ tools: Alpaca data, Finnhub, Google News, Reddit,              ▼                │
+│          CoinDesk/DeFiLlama (crypto), OpenAI web search       final decision +           │
+│                                                               typed TradeIntent          │
+└──────────────────────────────────────────────────────────────────┬───────────────────────┘
+                                                                   ▼
+                                      Alpaca execution (paper or live) — market/close orders
+```
+
+Final decisions are executable actions (`BUY/HOLD/SELL` in investment mode,
+`LONG/NEUTRAL/SHORT` in trading mode), carried in a typed `TradeIntent`
+schema alongside advisory metadata that never triggers orders by itself.
+
+## Package map
+
+| Path | Responsibility |
+|---|---|
+| `tradingagents/graph/` | LangGraph orchestration. `trading_graph.py` builds the graph and owns the LLM clients, memories, and reflection; `setup.py` wires nodes; `conditional_logic.py` controls debate rounds; `propagation.py` creates initial state; `signal_processing.py` extracts the final signal; `checkpointer.py` optional SQLite resume. |
+| `tradingagents/agents/` | The agents themselves: `analysts/` (market, social, news, fundamentals, macro), `researchers/` (bull/bear), `managers/`, `trader/`, `risk_mgmt/`, plus `utils/` (agent states, memory, trading modes) and `schemas.py` (typed `TradeIntent`). |
+| `tradingagents/dataflows/` | Every external data source behind one interface: `alpaca_utils.py` (bars, quotes, account, orders, execution), Finnhub, Google News, Reddit, FRED macro, crypto sources, with a yfinance fallback for supported failures. `config.py` holds runtime config + API keys. |
+| `tradingagents/llm_clients/` | Provider adapters (OpenAI, Anthropic, Google, xAI, DeepSeek, Qwen, GLM, OpenRouter, Ollama, Azure, local endpoints) behind `create_llm_client`. |
+| `tradingagents/prompts/` | All agent prompts as editable text templates (`TRADINGAGENTS_PROMPT_DIR` overrides). |
+| `tradingagents/run_logger.py` | Append-only audit trail: every prompt, tool call, LLM call (with token usage), state snapshot, and final state per run under `eval_results/<symbol>/TradingAgentsStrategy_logs/runs/`. |
+| `tradingagents/default_config.py` | Single source of defaults; everything is overridable per run. |
+| `webui/` | Dash interface: `layout.py` composes panels from `components/`, `callbacks/` register interaction handlers, `utils/state.py` is the shared app state. Entry: `python run_webui_dash.py`. |
+| `cli/` | Terminal interface: `python -m cli.main`. |
+| `tests/` | Pytest suite; deterministic, no network, no live keys. |
+
+## The analysis lifecycle
+
+1. **Kickoff** — WebUI/CLI builds a config (provider, models, depth, mode)
+   and calls `TradingAgentsGraph.propagate(symbol, date)`. A run log is
+   opened immediately; everything that follows is recorded incrementally.
+2. **Analysts** — five analysts run (parallel by default) with tool access;
+   each produces a markdown report. Context managers keep downstream
+   prompts within budget by chunking and scoring report evidence.
+3. **Research debate** — bull and bear researchers argue over the reports
+   for N rounds; the research manager judges and writes an investment plan.
+4. **Execution chain** — the trader turns the plan into a proposal; the
+   risky/safe/neutral risk debate stress-tests it; the risk manager issues
+   the final decision plus a typed `TradeIntent`.
+5. **Signal + execution** — `SignalProcessor` extracts the executable
+   action. If auto-trading is on, the WebUI executes it via
+   `AlpacaUtils.execute_trade_intent` / `execute_trading_action`.
+6. **Decision log** — the completed decision is appended to a markdown
+   memory log as `pending`, and resolved later with realized returns and a
+   reflection once the outcome is known.
+
+## Memory and learning
+
+Two complementary memories:
+
+- **Decision log** (`TradingMemoryLog`): append-only markdown of every
+  final decision, later updated with realized return / alpha / holding
+  days and a reflection. Recent same-ticker and cross-ticker entries are
+  injected into future prompts as past context.
+- **Per-agent situation memories** (`FinancialSituationMemory`): five
+  ChromaDB collections (bull, bear, trader, invest judge, risk manager)
+  storing (situation embedding → lesson) pairs, queried by similarity at
+  decision time.
+
+## Persistence map
+
+| Location | Contents |
+|---|---|
+| `eval_results/<symbol>/TradingAgentsStrategy_logs/runs/*.json` | Full audit trail per run: config, events (prompts, tool calls, LLM calls with token usage), snapshots, final state, final signal. |
+| `~/.tradingagents/memory/trading_memory.md` | The decision log (path configurable). |
+| `tradingagents/dataflows/data_cache/` | Cached market data. |
+| `eval_results/.../checkpoints` | Optional SQLite LangGraph checkpoints for resume. |
+
+## Configuration
+
+`tradingagents/default_config.py` is the single source of truth; the WebUI
+and CLI pass overrides per run, and API keys come from `.env` /
+environment (see `env.sample`). `ALPACA_USE_PAPER=True` keeps everything
+on the paper API — never develop against live trading.
+
+## Testing conventions
+
+- `python -m pytest tests/` — the suite is deterministic: no network, no
+  live keys; external boundaries are mocked and embeddings are faked.
+- `tests/test_import_no_network.py`-style guards assert that importing the
+  package performs no network calls.
+- On Windows, ChromaDB keeps store files open: use
+  `TemporaryDirectory(ignore_cleanup_errors=True)` in tests.
+
+## In-flight contributions (open PRs)
+
+Currently under review; each PR body documents its design in depth:
+
+| PR | Adds |
+|---|---|
+| [#25](https://github.com/huygiatrng/AlpacaTradingAgent/pull/25) | Deterministic risk sizing: fractional Kelly, ATR stops, exposure caps |
+| [#26](https://github.com/huygiatrng/AlpacaTradingAgent/pull/26) | Walk-forward backtesting engine over recorded decisions + WebUI panel |
+| [#27](https://github.com/huygiatrng/AlpacaTradingAgent/pull/27) | Self-learning memory: persistent agent memories fed by realized outcomes |
+| [#29](https://github.com/huygiatrng/AlpacaTradingAgent/pull/29) | No network calls / circular imports at package import time |
+| [#30](https://github.com/huygiatrng/AlpacaTradingAgent/pull/30) | Real bracket/OTO protective orders |
+| [#31](https://github.com/huygiatrng/AlpacaTradingAgent/pull/31) | Pydantic 3-ready model config |
+| [#32](https://github.com/huygiatrng/AlpacaTradingAgent/pull/32) | Production safety layer: pre-trade checks, circuit breakers, kill switch |
+| [#33](https://github.com/huygiatrng/AlpacaTradingAgent/pull/33) | GitHub Actions CI |
+| [#34](https://github.com/huygiatrng/AlpacaTradingAgent/pull/34) | Intensive teaching: seed agent memories from recorded backtest history |
+| [#35](https://github.com/huygiatrng/AlpacaTradingAgent/pull/35) | FinMem-style memory maintenance: decay, dedup, size caps |
+| [#36](https://github.com/huygiatrng/AlpacaTradingAgent/pull/36) | Chaos test suite + NaN/HTML broker-data hardening |
+| [#37](https://github.com/huygiatrng/AlpacaTradingAgent/pull/37) | LLM cost monitor: attributed spend vs realized returns |
+| [#38](https://github.com/huygiatrng/AlpacaTradingAgent/pull/38) | Portfolio-level intelligence: correlation, vol sizing, exposure cap |
+| [#39](https://github.com/huygiatrng/AlpacaTradingAgent/pull/39) | Deterministic market-regime detection |
+| [#40](https://github.com/huygiatrng/AlpacaTradingAgent/pull/40) | Daily operations report + Telegram/webhook alerts |

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,82 @@
+# Quick Start
+
+From zero to a first multi-agent analysis in about five minutes.
+
+## 1. Install
+
+```bash
+git clone https://github.com/huygiatrng/AlpacaTradingAgent.git
+cd AlpacaTradingAgent
+python -m venv .venv
+# Windows:
+.venv\Scripts\activate
+# macOS/Linux:
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## 2. Configure keys
+
+```bash
+cp env.sample .env   # Windows: copy env.sample .env
+```
+
+Edit `.env` — the minimum to run:
+
+| Key | Where to get it | Required |
+|---|---|---|
+| `ALPACA_API_KEY` / `ALPACA_SECRET_KEY` | free paper account at [alpaca.markets](https://alpaca.markets) | ✅ |
+| `OPENAI_API_KEY` | [platform.openai.com](https://platform.openai.com) (or set `LLM_PROVIDER` to another provider) | ✅ |
+| `FINNHUB_API_KEY` | [finnhub.io](https://finnhub.io) — richer news | optional |
+| `FRED_API_KEY` | [fred.stlouisfed.org](https://fred.stlouisfed.org/docs/api/api_key.html) — macro analyst | optional |
+| `COINDESK_API_KEY` | crypto news | optional |
+
+> **Keep `ALPACA_USE_PAPER=True`.** Everything works against the paper
+> API; switch to live only when you have a tested, reviewed setup and
+> accept the risk.
+
+## 3. Run
+
+```bash
+python run_webui_dash.py
+```
+
+Open the printed URL (usually `http://127.0.0.1:8050`), then:
+
+1. Enter symbols — stocks (`NVDA, AAPL`), crypto (`BTC/USD`), or a mix.
+2. Pick your LLM provider/models and research depth.
+3. Press **Analyze** and watch the five analysts, the bull/bear debate,
+   and the risk team stream their reports live.
+4. Execute the recommendation manually, or enable auto-execution and
+   recurring scheduled analysis.
+
+Prefer a terminal? `python -m cli.main` runs the same pipeline
+interactively.
+
+## 4. Verify your setup
+
+```bash
+python -m pytest tests/
+```
+
+The suite is deterministic (no network, no live keys) — it should pass on
+a fresh clone.
+
+## 5. Where results live
+
+- **Reports & audit trail**: `eval_results/<symbol>/TradingAgentsStrategy_logs/runs/`
+  — every prompt, tool call, LLM call (with token usage), and the final state.
+- **Decision log**: `~/.tradingagents/memory/trading_memory.md` — every
+  final decision, later resolved with realized returns.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `Alpaca API key or secret not found` | `.env` not loaded or keys empty — recheck step 2. |
+| `unauthorized` from Alpaca | Keys expired or live keys used against paper — regenerate paper keys. |
+| Analysis stalls at an analyst | Usually a rate limit; lower research depth or increase the start delays in settings. |
+| Crypto symbol not found | Use the slash format: `BTC/USD`, not `BTCUSD`. |
+
+Next: read [ARCHITECTURE.md](ARCHITECTURE.md) for how the pipeline works
+inside.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 🚀 [Enhanced Features](#enhanced-features) | ⚡ [Installation & Setup](#installation-and-setup) | 📦 [Package Usage](#alpacatradingagent-package) | 🌐 [Web Interface](#web-ui-usage) | 📖 [Complete Guide](#complete-guide) | 🤝 [Contributing](#contributing) | 📄 [Citation](#citation)
 
+⏱️ New here? **[QUICKSTART.md](QUICKSTART.md)** — first analysis in ~5 minutes · 🏗️ **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the pipeline works inside
+
 </div>
 
 ## Enhanced Features

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -241,6 +241,7 @@ class RunBacktestTests(unittest.TestCase):
             initial_cash=10_000,
             commission=0.0,
             position_pct=0.4,
+            slippage_bps=0.0,  # this test isolates lookahead, not costs
         )
         self.assertEqual(result.orders[0]["date"], "2026-01-06")
         self.assertAlmostEqual(result.orders[0]["price"], 200.0)
@@ -316,6 +317,108 @@ class RunBacktestTests(unittest.TestCase):
         result = run_backtest(prices, {"2026-01-05": "BUY"})
         payload = json.dumps(result.to_dict())
         self.assertIn("cumulative_return", payload)
+
+
+class SlippageTests(unittest.TestCase):
+    """Execution-cost realism: fills must be able to model slippage.
+
+    A zero-slippage assumption systematically inflates backtest results, so
+    a fixed basis-point model is on by default and a volatility-scaled model
+    is available for less liquid / more volatile symbols.
+    """
+
+    BUY = {"2026-01-05": "BUY"}
+
+    def test_fixed_bps_slippage_raises_buy_fill_price(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices, self.BUY, initial_cash=10_000, commission=0.0, slippage_bps=50.0
+        )
+        # 50 bps over the 100.0 next-bar open.
+        self.assertAlmostEqual(result.orders[0]["price"], 100.5)
+
+    def test_zero_bps_fills_exactly_at_open(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices, self.BUY, initial_cash=10_000, commission=0.0, slippage_bps=0.0
+        )
+        self.assertAlmostEqual(result.orders[0]["price"], 100.0)
+
+    def test_slippage_is_on_by_default(self):
+        prices = make_prices([100] * 6)
+        default = run_backtest(prices, self.BUY, initial_cash=10_000, commission=0.0)
+        self.assertGreater(default.orders[0]["price"], 100.0)
+
+    def test_sell_fill_price_slips_down(self):
+        prices = make_prices([100] * 8)
+        signals = {"2026-01-05": "BUY", "2026-01-08": "SELL"}
+        result = run_backtest(
+            prices, signals, initial_cash=10_000, commission=0.0, slippage_bps=50.0
+        )
+        sells = [o for o in result.orders if o["side"] == "sell"]
+        self.assertAlmostEqual(sells[0]["price"], 99.5)
+
+    def test_slippage_reduces_round_trip_equity(self):
+        prices = make_prices([100] * 8)
+        signals = {"2026-01-05": "BUY", "2026-01-08": "SELL"}
+        free = run_backtest(
+            prices, signals, initial_cash=10_000, commission=0.0, slippage_bps=0.0
+        )
+        slipped = run_backtest(
+            prices, signals, initial_cash=10_000, commission=0.0, slippage_bps=50.0
+        )
+        self.assertLess(slipped.equity_curve.iloc[-1], free.equity_curve.iloc[-1])
+
+    def test_volatility_model_scales_with_previous_bar_range(self):
+        # make_prices gives every bar high=101/low=99/close=100, so the
+        # previous-bar range fraction is 2%; with vol_fraction=0.1 the buy
+        # slips by 20 bps over the 100.0 open.
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices,
+            self.BUY,
+            initial_cash=10_000,
+            commission=0.0,
+            slippage_model="volatility",
+            slippage_vol_fraction=0.1,
+        )
+        self.assertAlmostEqual(result.orders[0]["price"], 100.2)
+
+    def test_volatility_model_respects_max_cap(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices,
+            self.BUY,
+            initial_cash=10_000,
+            commission=0.0,
+            slippage_model="volatility",
+            slippage_vol_fraction=0.1,
+            slippage_max_bps=5.0,
+        )
+        self.assertAlmostEqual(result.orders[0]["price"], 100.05)
+
+    def test_none_model_disables_slippage(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(
+            prices,
+            self.BUY,
+            initial_cash=10_000,
+            commission=0.0,
+            slippage_model="none",
+            slippage_bps=50.0,
+        )
+        self.assertAlmostEqual(result.orders[0]["price"], 100.0)
+
+    def test_unknown_model_raises(self):
+        prices = make_prices([100] * 6)
+        with self.assertRaises(ValueError):
+            run_backtest(prices, self.BUY, slippage_model="quantum")
+
+    def test_result_reports_slippage_config(self):
+        prices = make_prices([100] * 6)
+        result = run_backtest(prices, self.BUY, slippage_bps=7.5)
+        self.assertEqual(result.to_dict()["slippage"]["model"], "fixed")
+        self.assertAlmostEqual(result.to_dict()["slippage"]["bps"], 7.5)
 
 
 class WalkForwardTests(unittest.TestCase):

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -1,0 +1,409 @@
+"""Tests for the walk-forward backtesting engine and its metrics."""
+
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from tradingagents.backtest import (
+    annualized_return,
+    cumulative_return,
+    load_recorded_signals,
+    max_drawdown,
+    normalize_action,
+    normalize_price_frame,
+    run_backtest,
+    run_recorded_backtest,
+    run_walk_forward,
+    sharpe_ratio,
+    summarize_performance,
+    win_rate,
+)
+
+
+def make_prices(closes, start="2026-01-05", opens=None, freq="B"):
+    """Build an OHLCV frame in AlpacaUtils.get_stock_data's output shape."""
+    closes = [float(c) for c in closes]
+    opens = [float(o) for o in opens] if opens is not None else list(closes)
+    dates = pd.bdate_range(start=start, periods=len(closes)) if freq == "B" else (
+        pd.date_range(start=start, periods=len(closes), freq=freq)
+    )
+    return pd.DataFrame(
+        {
+            "timestamp": dates,
+            "open": opens,
+            "high": [max(o, c) * 1.01 for o, c in zip(opens, closes)],
+            "low": [min(o, c) * 0.99 for o, c in zip(opens, closes)],
+            "close": closes,
+            "volume": [1_000_000] * len(closes),
+        }
+    )
+
+
+class MetricsTests(unittest.TestCase):
+    def test_cumulative_return_hand_computed(self):
+        self.assertAlmostEqual(cumulative_return([100.0, 125.0]), 0.25)
+        self.assertAlmostEqual(cumulative_return([100.0, 80.0]), -0.20)
+
+    def test_cumulative_return_degenerate_inputs(self):
+        self.assertIsNone(cumulative_return([]))
+        self.assertIsNone(cumulative_return([100.0]))
+        self.assertIsNone(cumulative_return([0.0, 50.0]))
+
+    def test_annualized_return_hand_computed(self):
+        # +10% over 126 periods at 252 periods/year => (1.1)^2 - 1 = 21%
+        curve = [100.0] + [100.0] * 125 + [110.0]
+        self.assertAlmostEqual(
+            annualized_return(curve, periods_per_year=252), 1.1**2 - 1.0, places=9
+        )
+
+    def test_sharpe_ratio_hand_computed(self):
+        # Alternating +1%/-1% daily returns: mean 0 => Sharpe ~ 0 (slightly
+        # negative because (1.01 * 0.99) < 1); must not be None.
+        curve = [100.0]
+        for i in range(20):
+            curve.append(curve[-1] * (1.01 if i % 2 == 0 else 0.99))
+        value = sharpe_ratio(curve)
+        self.assertIsNotNone(value)
+        self.assertLess(abs(value), 0.5)
+
+    def test_sharpe_ratio_zero_volatility_is_none(self):
+        self.assertIsNone(sharpe_ratio([100.0, 100.0, 100.0, 100.0]))
+        self.assertIsNone(sharpe_ratio([100.0, 101.0]))  # too short
+
+    def test_max_drawdown_hand_computed(self):
+        # Peak 120 -> trough 90 = 25% drawdown; later recovery must not hide it.
+        self.assertAlmostEqual(
+            max_drawdown([100.0, 120.0, 90.0, 130.0]), 0.25
+        )
+        self.assertAlmostEqual(max_drawdown([100.0, 110.0, 121.0]), 0.0)
+
+    def test_win_rate(self):
+        self.assertAlmostEqual(win_rate([10.0, -5.0, 3.0, -1.0]), 0.5)
+        self.assertIsNone(win_rate([]))
+        self.assertAlmostEqual(win_rate([0.0, 2.0]), 0.5)  # breakeven not a win
+
+    def test_summarize_performance_keys(self):
+        summary = summarize_performance([100.0, 105.0, 103.0], [4.0])
+        for key in (
+            "cumulative_return",
+            "annualized_return",
+            "sharpe_ratio",
+            "max_drawdown",
+            "win_rate",
+            "num_trades",
+            "num_periods",
+            "final_equity",
+        ):
+            self.assertIn(key, summary)
+        self.assertEqual(summary["num_trades"], 1)
+        self.assertEqual(summary["num_periods"], 2)
+        self.assertAlmostEqual(summary["final_equity"], 103.0)
+
+
+class SignalNormalizationTests(unittest.TestCase):
+    def test_all_aliases(self):
+        for raw, expected in {
+            "BUY": "BUY",
+            "long": "BUY",
+            " Short ": "SELL",
+            "sell": "SELL",
+            "HOLD": "HOLD",
+            "Neutral": "HOLD",
+        }.items():
+            with self.subTest(raw=raw):
+                self.assertEqual(normalize_action(raw), expected)
+
+    def test_unknown_inputs_are_none(self):
+        for raw in (None, "", "MAYBE", 42):
+            with self.subTest(raw=raw):
+                self.assertIsNone(normalize_action(raw))
+
+
+def write_run_log(root, symbol, trade_date, final_signal, status="completed", started_at=None):
+    runs_dir = Path(root) / symbol / "TradingAgentsStrategy_logs" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    started = started_at or f"{trade_date}T10:00:00+00:00"
+    payload = {
+        "run_id": f"{trade_date}_{started.replace(':', '')}",
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "started_at": started,
+        "status": status,
+        "summary": {"final_signal": final_signal} if final_signal else {},
+    }
+    path = runs_dir / f"{payload['run_id']}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+class LoadRecordedSignalsTests(unittest.TestCase):
+    def test_reads_completed_runs_and_normalizes(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "BUY")
+            write_run_log(root, "AAPL", "2026-01-06", "long")
+            write_run_log(root, "AAPL", "2026-01-07", "NEUTRAL")
+            signals = load_recorded_signals("AAPL", eval_results_dir=root)
+        self.assertEqual(
+            signals,
+            {"2026-01-05": "BUY", "2026-01-06": "BUY", "2026-01-07": "HOLD"},
+        )
+
+    def test_ignores_aborted_missing_signal_and_bad_dates(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "BUY", status="aborted")
+            write_run_log(root, "AAPL", "2026-01-06", None)
+            write_run_log(root, "AAPL", "not-a-date", "BUY")
+            self.assertEqual(load_recorded_signals("AAPL", eval_results_dir=root), {})
+
+    def test_latest_run_per_date_wins(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(
+                root, "AAPL", "2026-01-05", "BUY",
+                started_at="2026-01-05T09:00:00+00:00",
+            )
+            write_run_log(
+                root, "AAPL", "2026-01-05", "SELL",
+                started_at="2026-01-05T15:00:00+00:00",
+            )
+            signals = load_recorded_signals("AAPL", eval_results_dir=root)
+        self.assertEqual(signals, {"2026-01-05": "SELL"})
+
+    def test_crypto_symbol_path_sanitization(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "BTC_USD", "2026-01-05", "BUY")
+            signals = load_recorded_signals("BTC/USD", eval_results_dir=root)
+        self.assertEqual(signals, {"2026-01-05": "BUY"})
+
+    def test_missing_directory_returns_empty(self):
+        self.assertEqual(
+            load_recorded_signals("ZZZZ", eval_results_dir="definitely_missing_dir"),
+            {},
+        )
+
+
+class NormalizePriceFrameTests(unittest.TestCase):
+    def test_accepts_alpaca_layout(self):
+        frame = normalize_price_frame(make_prices([100, 101, 102]))
+        self.assertIsInstance(frame.index, pd.DatetimeIndex)
+        self.assertEqual(
+            list(frame.columns), ["open", "high", "low", "close", "volume"]
+        )
+
+    def test_strips_timezone_and_sorts(self):
+        prices = make_prices([100, 101, 102])
+        prices["timestamp"] = prices["timestamp"].dt.tz_localize("UTC")
+        prices = prices.iloc[::-1]  # reversed order on purpose
+        frame = normalize_price_frame(prices)
+        self.assertIsNone(frame.index.tz)
+        self.assertTrue(frame.index.is_monotonic_increasing)
+
+    def test_rejects_empty_and_missing_columns(self):
+        with self.assertRaises(ValueError):
+            normalize_price_frame(pd.DataFrame())
+        with self.assertRaises(ValueError):
+            normalize_price_frame(pd.DataFrame({"timestamp": ["2026-01-05"], "close": [1.0]}))
+
+
+class RunBacktestTests(unittest.TestCase):
+    def test_hold_only_keeps_cash_flat(self):
+        prices = make_prices([100, 120, 80, 150])
+        result = run_backtest(prices, {"2026-01-05": "HOLD"}, initial_cash=10_000)
+        self.assertAlmostEqual(result.equity_curve.iloc[-1], 10_000.0)
+        self.assertEqual(result.orders, [])
+        self.assertEqual(result.metrics["num_trades"], 0)
+
+    def test_buy_captures_uptrend(self):
+        closes = [100 + i for i in range(30)]
+        prices = make_prices(closes)
+        result = run_backtest(
+            prices, {"2026-01-05": "BUY"}, initial_cash=100_000, commission=0.0
+        )
+        self.assertGreater(result.equity_curve.iloc[-1], 100_000.0)
+        self.assertEqual(result.orders[0]["side"], "buy")
+
+    def test_no_lookahead_signal_fills_at_next_open(self):
+        # The signal-day close is 100 but the next open gaps to 200. A leaky
+        # engine filling at the signal-day close would buy 40 shares at 100
+        # and end at 14,000; correct next-open execution buys at 200 and the
+        # equity never captures the jump. (position_pct is small enough that
+        # the gapped-up order stays affordable.)
+        prices = make_prices(
+            closes=[100, 200, 200, 200],
+            opens=[100, 200, 200, 200],
+        )
+        result = run_backtest(
+            prices,
+            {"2026-01-05": "BUY"},
+            initial_cash=10_000,
+            commission=0.0,
+            position_pct=0.4,
+        )
+        self.assertEqual(result.orders[0]["date"], "2026-01-06")
+        self.assertAlmostEqual(result.orders[0]["price"], 200.0)
+        self.assertAlmostEqual(result.equity_curve.iloc[-1], 10_000.0, delta=1.0)
+
+    def test_unaffordable_gap_order_is_reported_not_silent(self):
+        # Full-size order computed at close=100 becomes unaffordable at the
+        # 200 open; the engine must record the rejection.
+        prices = make_prices(closes=[100, 200, 200], opens=[100, 200, 200])
+        result = run_backtest(
+            prices, {"2026-01-05": "BUY"}, initial_cash=10_000, commission=0.0
+        )
+        self.assertEqual(result.orders, [])
+        self.assertEqual(len(result.rejected_orders), 1)
+        self.assertEqual(result.rejected_orders[0]["status"], "margin")
+
+    def test_sell_when_flat_without_shorts_does_nothing(self):
+        prices = make_prices([100, 90, 80, 70])
+        result = run_backtest(
+            prices, {"2026-01-05": "SELL"}, initial_cash=10_000, allow_shorts=False
+        )
+        self.assertAlmostEqual(result.equity_curve.iloc[-1], 10_000.0)
+        self.assertEqual(result.orders, [])
+
+    def test_short_profits_in_downtrend_when_allowed(self):
+        closes = [100 - 2 * i for i in range(20)]
+        prices = make_prices(closes)
+        result = run_backtest(
+            prices,
+            {"2026-01-05": "SELL"},
+            initial_cash=100_000,
+            commission=0.0,
+            allow_shorts=True,
+        )
+        self.assertGreater(result.equity_curve.iloc[-1], 100_000.0)
+        self.assertEqual(result.orders[0]["side"], "sell")
+
+    def test_round_trip_produces_closed_trade(self):
+        closes = [100, 100, 110, 120, 120, 120]
+        prices = make_prices(closes)
+        result = run_backtest(
+            prices,
+            {"2026-01-05": "BUY", "2026-01-08": "SELL"},
+            initial_cash=100_000,
+            commission=0.0,
+        )
+        self.assertEqual(len(result.trade_pnls), 1)
+        self.assertGreater(result.trade_pnls[0], 0.0)
+        self.assertEqual(result.metrics["win_rate"], 1.0)
+
+    def test_weekend_signal_applies_on_next_bar(self):
+        # Business days 2026-01-05..09 and 12..13; 2026-01-10 is a Saturday,
+        # so the buy applies on Monday the 12th and fills at Tuesday's open.
+        prices = make_prices([100, 101, 102, 103, 104, 105, 106])
+        result = run_backtest(
+            prices, {"2026-01-10": "BUY"}, initial_cash=10_000, commission=0.0
+        )
+        self.assertEqual(len(result.orders), 1)
+        self.assertEqual(result.orders[0]["date"], "2026-01-13")
+
+    def test_commission_reduces_final_equity(self):
+        closes = [100] * 10
+        prices = make_prices(closes)
+        signals = {"2026-01-05": "BUY", "2026-01-09": "SELL"}
+        free = run_backtest(prices, signals, initial_cash=10_000, commission=0.0)
+        costly = run_backtest(prices, signals, initial_cash=10_000, commission=0.01)
+        self.assertLess(
+            costly.equity_curve.iloc[-1], free.equity_curve.iloc[-1]
+        )
+
+    def test_result_to_dict_is_json_serializable(self):
+        prices = make_prices([100, 101, 102])
+        result = run_backtest(prices, {"2026-01-05": "BUY"})
+        payload = json.dumps(result.to_dict())
+        self.assertIn("cumulative_return", payload)
+
+
+class WalkForwardTests(unittest.TestCase):
+    def test_windows_partition_all_bars(self):
+        prices = make_prices([100 + i for i in range(50)])
+        result = run_walk_forward(
+            prices, {"2026-01-05": "BUY"}, window_bars=20, commission=0.0
+        )
+        self.assertEqual(sum(w["bars"] for w in result.windows), 50)
+        # 20 + 20 + 10 -> the 10-bar remainder stands alone (>= min_window_bars)
+        self.assertEqual([w["bars"] for w in result.windows], [20, 20, 10])
+
+    def test_short_remainder_folds_into_last_window(self):
+        prices = make_prices([100 + i for i in range(43)])
+        result = run_walk_forward(
+            prices, {"2026-01-05": "BUY"}, window_bars=20, min_window_bars=5
+        )
+        self.assertEqual([w["bars"] for w in result.windows], [20, 23])
+
+    def test_each_window_has_metrics_and_full_period_present(self):
+        prices = make_prices([100 + i for i in range(30)])
+        result = run_walk_forward(prices, {"2026-01-05": "BUY"}, window_bars=10)
+        for window in result.windows:
+            self.assertIn("sharpe_ratio", window["metrics"])
+            self.assertIn("max_drawdown", window["metrics"])
+        self.assertIsNotNone(result.full_period)
+        self.assertEqual(result.full_period.metrics["num_periods"], 29)
+
+    def test_rejects_tiny_window(self):
+        prices = make_prices([100, 101, 102])
+        with self.assertRaises(ValueError):
+            run_walk_forward(prices, {}, window_bars=1)
+
+
+class RunRecordedBacktestTests(unittest.TestCase):
+    def test_end_to_end_with_recorded_runs_and_injected_prices(self):
+        closes = [100 + i for i in range(15)]
+        prices = make_prices(closes, start="2026-01-05")
+
+        def fake_loader(symbol, start, end):
+            self.assertEqual(symbol, "AAPL")
+            return prices
+
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "BUY")
+            write_run_log(root, "AAPL", "2026-01-12", "SELL")
+            result = run_recorded_backtest(
+                "AAPL",
+                eval_results_dir=root,
+                price_loader=fake_loader,
+                commission=0.0,
+            )
+        self.assertEqual(result.signals_used, 2)
+        self.assertEqual(len(result.trade_pnls), 1)
+        self.assertGreater(result.metrics["cumulative_return"], 0.0)
+
+    def test_raises_without_recorded_signals(self):
+        with tempfile.TemporaryDirectory() as root:
+            with self.assertRaises(ValueError):
+                run_recorded_backtest("AAPL", eval_results_dir=root)
+
+    def test_signals_before_start_date_are_dropped(self):
+        prices = make_prices([100 + i for i in range(10)], start="2026-02-02")
+
+        def fake_loader(symbol, start, end):
+            self.assertEqual(start, "2026-02-02")
+            return prices
+
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "SELL")
+            write_run_log(root, "AAPL", "2026-02-03", "BUY")
+            result = run_recorded_backtest(
+                "AAPL",
+                start_date="2026-02-02",
+                eval_results_dir=root,
+                price_loader=fake_loader,
+            )
+        self.assertEqual(result.signals_used, 1)
+
+    def test_raises_when_all_signals_predate_start(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_run_log(root, "AAPL", "2026-01-05", "BUY")
+            with self.assertRaises(ValueError):
+                run_recorded_backtest(
+                    "AAPL", start_date="2026-06-01", eval_results_dir=root,
+                    price_loader=lambda s, a, b: make_prices([1, 2]),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_backtest_teach.py
+++ b/tests/test_backtest_teach.py
@@ -1,0 +1,294 @@
+"""Tests for the backtest -> self-learning-memory bridge (intensive teaching).
+
+The bridge replays decisions this deployment already recorded under
+eval_results/ against historical prices, computes each decision's realized
+outcome with the same next-open execution discipline the backtest engine
+uses, and injects one dated lesson per decision into the persistent
+per-agent ChromaDB memories — idempotently, so re-teaching never duplicates.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+import pandas as pd
+
+from tradingagents.agents.utils.memory import FinancialSituationMemory
+from tradingagents.backtest.teach import (
+    compute_decision_outcomes,
+    teach_memories_from_history,
+)
+
+
+def _fake_embedding(text):
+    seed = float(sum(ord(c) for c in text) % 97)
+    return [seed / 97.0 + i * 0.01 for i in range(8)]
+
+
+def _enable_fake_embeddings(memory):
+    memory.embeddings_enabled = True
+    memory.get_embedding = _fake_embedding
+
+
+def _make_memories():
+    # Unique collection names per call: chroma's ephemeral client is shared
+    # process-wide, so a fixed name would leak lessons between tests.
+    import uuid
+
+    suffix = uuid.uuid4().hex[:8]
+    names = ["bull", "bear", "trader", "invest_judge", "risk_manager"]
+    memories = {}
+    for name in names:
+        memory = FinancialSituationMemory(f"teach_test_{name}_{suffix}")
+        _enable_fake_embeddings(memory)
+        memories[name] = memory
+    return memories
+
+
+def _price_frame(start="2025-01-06", days=15, opens=None):
+    dates = pd.bdate_range(start=start, periods=days)
+    if opens is None:
+        opens = [100.0 + i for i in range(days)]
+    return pd.DataFrame(
+        {
+            "timestamp": dates,
+            "open": opens,
+            "high": [o + 1.0 for o in opens],
+            "low": [o - 1.0 for o in opens],
+            "close": [o + 0.5 for o in opens],
+            "volume": [1_000.0] * days,
+        }
+    )
+
+
+def _write_run(root, symbol, trade_date, final_signal, final_state=None, status="completed"):
+    runs_dir = Path(root) / symbol / "TradingAgentsStrategy_logs" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    started = f"{trade_date}T10:00:00+00:00"
+    payload = {
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "started_at": started,
+        "status": status,
+        "summary": {"final_signal": final_signal},
+        "snapshots": {"final_state": final_state} if final_state is not None else {},
+    }
+    name = f"{trade_date}_run.json"
+    (runs_dir / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _final_state(text):
+    return {
+        "market_report": f"market: {text}",
+        "sentiment_report": f"sentiment: {text}",
+        "news_report": f"news: {text}",
+        "fundamentals_report": f"fundamentals: {text}",
+        "final_trade_decision": f"decision text for {text}",
+    }
+
+
+class ComputeDecisionOutcomesTests(unittest.TestCase):
+    def test_buy_enters_next_open_and_exits_horizon_open(self):
+        prices = _price_frame(days=10)  # opens 100..109
+        outcomes = compute_decision_outcomes(
+            prices, {"2025-01-06": "BUY"}, horizon_bars=3
+        )
+        self.assertEqual(len(outcomes), 1)
+        out = outcomes[0]
+        # Decision on the first bar's date -> entry at second bar's open (101),
+        # exit 3 bars later at open 104.
+        self.assertEqual(out["entry_price"], 101.0)
+        self.assertEqual(out["exit_price"], 104.0)
+        self.assertAlmostEqual(out["asset_return"], 104.0 / 101.0 - 1.0)
+        self.assertAlmostEqual(out["decision_return"], out["asset_return"])
+        self.assertFalse(out["partial"])
+
+    def test_sell_decision_return_is_negated(self):
+        prices = _price_frame(days=10)
+        outcomes = compute_decision_outcomes(
+            prices, {"2025-01-06": "SELL"}, horizon_bars=3
+        )
+        out = outcomes[0]
+        self.assertAlmostEqual(out["decision_return"], -(out["asset_return"]))
+
+    def test_hold_decision_return_is_zero_but_asset_move_kept(self):
+        prices = _price_frame(days=10)
+        outcomes = compute_decision_outcomes(
+            prices, {"2025-01-06": "HOLD"}, horizon_bars=3
+        )
+        out = outcomes[0]
+        self.assertEqual(out["decision_return"], 0.0)
+        self.assertGreater(out["asset_return"], 0.0)
+
+    def test_truncated_horizon_is_partial(self):
+        prices = _price_frame(days=5)
+        # Entry at bar 1, horizon 10 runs past the data -> exit at last bar.
+        outcomes = compute_decision_outcomes(
+            prices, {"2025-01-06": "BUY"}, horizon_bars=10
+        )
+        out = outcomes[0]
+        self.assertTrue(out["partial"])
+        self.assertEqual(out["exit_price"], 104.0)
+
+    def test_signal_on_or_after_last_bar_is_skipped(self):
+        prices = _price_frame(days=5)  # last bar 2025-01-10
+        outcomes = compute_decision_outcomes(
+            prices, {"2025-01-10": "BUY", "2025-02-01": "BUY"}, horizon_bars=3
+        )
+        self.assertEqual(outcomes, [])
+
+    def test_weekend_signal_applies_to_next_bar(self):
+        prices = _price_frame(days=10)
+        # Saturday decision -> entry at Monday+1 bar open.
+        outcomes = compute_decision_outcomes(
+            prices, {"2025-01-11": "BUY"}, horizon_bars=2
+        )
+        self.assertEqual(len(outcomes), 1)
+        # First bar strictly after 2025-01-11 is Mon 2025-01-13 (open 105).
+        self.assertEqual(outcomes[0]["entry_price"], 105.0)
+
+
+class TeachMemoriesTests(unittest.TestCase):
+    def _teach(self, root, memories, **kwargs):
+        prices = _price_frame(days=15)
+        return teach_memories_from_history(
+            "AAPL",
+            memories,
+            price_loader=lambda symbol, start, end: prices,
+            eval_results_dir=root,
+            horizon_bars=3,
+            **kwargs,
+        )
+
+    def test_deterministic_lessons_written_to_all_memories(self):
+        memories = _make_memories()
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as root:
+            _write_run(root, "AAPL", "2025-01-06", "BUY", _final_state("day one"))
+            _write_run(root, "AAPL", "2025-01-08", "SELL", _final_state("day three"))
+            summary = self._teach(root, memories)
+
+        self.assertEqual(summary["decisions_taught"], 2)
+        for memory in memories.values():
+            self.assertEqual(memory.situation_collection.count(), 2)
+
+        # The lesson stored against the day-one situation carries the
+        # realized outcome. (The fake embedding is not semantic, so query
+        # with the exact situation text instead of a fragment.)
+        day_one = _final_state("day one")
+        situation = "\n\n".join(
+            day_one[k]
+            for k in (
+                "market_report",
+                "sentiment_report",
+                "news_report",
+                "fundamentals_report",
+            )
+        )
+        matches = memories["trader"].get_memories(situation, n_matches=1)
+        self.assertEqual(len(matches), 1)
+        self.assertIn("%", matches[0]["recommendation"])
+        self.assertIn("BUY", matches[0]["recommendation"])
+
+    def test_teaching_is_idempotent(self):
+        memories = _make_memories()
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as root:
+            _write_run(root, "AAPL", "2025-01-06", "BUY", _final_state("day one"))
+            first = self._teach(root, memories)
+            second = self._teach(root, memories)
+
+        self.assertEqual(first["decisions_taught"], 1)
+        self.assertEqual(second["decisions_taught"], 0)
+        self.assertEqual(second["decisions_skipped_duplicate"], 1)
+        for memory in memories.values():
+            self.assertEqual(memory.situation_collection.count(), 1)
+
+    def test_lessons_are_tagged_for_later_maintenance(self):
+        memories = _make_memories()
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as root:
+            _write_run(root, "AAPL", "2025-01-06", "BUY", _final_state("day one"))
+            self._teach(root, memories)
+
+        stored = memories["bull"].situation_collection.get(include=["metadatas"])
+        meta = stored["metadatas"][0]
+        self.assertEqual(meta["source"], "backtest_teach")
+        self.assertEqual(meta["symbol"], "AAPL")
+        self.assertEqual(meta["trade_date"], "2025-01-06")
+        self.assertEqual(meta["action"], "BUY")
+
+    def test_decision_without_final_state_is_skipped(self):
+        memories = _make_memories()
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as root:
+            _write_run(root, "AAPL", "2025-01-06", "BUY", final_state=None)
+            summary = self._teach(root, memories)
+
+        self.assertEqual(summary["decisions_taught"], 0)
+        self.assertEqual(summary["decisions_skipped_no_state"], 1)
+        for memory in memories.values():
+            self.assertEqual(memory.situation_collection.count(), 0)
+
+    def test_llm_mode_uses_reflector_lesson(self):
+        memories = _make_memories()
+        reflector = Mock()
+        reflector.reflect_on_final_decision.return_value = "LLM lesson about the trade"
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as root:
+            _write_run(root, "AAPL", "2025-01-06", "BUY", _final_state("day one"))
+            summary = self._teach(root, memories, reflector=reflector)
+
+        self.assertEqual(summary["decisions_taught"], 1)
+        reflector.reflect_on_final_decision.assert_called_once()
+        matches = memories["trader"].get_memories("market: day one", n_matches=1)
+        self.assertIn("LLM lesson", matches[0]["recommendation"])
+
+    def test_no_recorded_signals_raises(self):
+        memories = _make_memories()
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as root:
+            with self.assertRaises(ValueError):
+                self._teach(root, memories)
+
+
+class DefaultAgentMemoriesTests(unittest.TestCase):
+    def test_builds_the_five_reflection_memories(self):
+        from tradingagents.backtest.teach import default_agent_memories
+
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            memories = default_agent_memories({"agent_memory_dir": tmp})
+            self.assertEqual(
+                sorted(memories),
+                ["bear", "bull", "invest_judge", "risk_manager", "trader"],
+            )
+            # Collection names must match the ones TradingAgentsGraph uses,
+            # so taught lessons are retrieved by the live agents.
+            self.assertEqual(
+                memories["bull"].situation_collection.name, "bull_memory"
+            )
+
+
+class MemoryMetadataTests(unittest.TestCase):
+    def test_add_situations_accepts_extra_metadata(self):
+        memory = FinancialSituationMemory("teach_test_meta_memory")
+        _enable_fake_embeddings(memory)
+        memory.add_situations(
+            [("situation text", "advice text")],
+            extra_metadata={"source": "backtest_teach", "teach_key": "AAPL|2025-01-06"},
+        )
+        stored = memory.situation_collection.get(include=["metadatas"])
+        meta = stored["metadatas"][0]
+        self.assertEqual(meta["recommendation"], "advice text")
+        self.assertEqual(meta["teach_key"], "AAPL|2025-01-06")
+
+    def test_has_metadata_value(self):
+        memory = FinancialSituationMemory("teach_test_haskey_memory")
+        _enable_fake_embeddings(memory)
+        self.assertFalse(memory.has_metadata_value("teach_key", "AAPL|2025-01-06"))
+        memory.add_situations(
+            [("situation text", "advice text")],
+            extra_metadata={"teach_key": "AAPL|2025-01-06"},
+        )
+        self.assertTrue(memory.has_metadata_value("teach_key", "AAPL|2025-01-06"))
+        self.assertFalse(memory.has_metadata_value("teach_key", "AAPL|2025-01-07"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_backtest_webui.py
+++ b/tests/test_backtest_webui.py
@@ -16,6 +16,7 @@ class BacktestPanelWiringTests(unittest.TestCase):
             "backtest-run-btn",
             "backtest-equity-graph",
             "backtest-windows-table",
+            "backtest-slippage-model",
         ):
             self.assertIn(component_id, rendered)
 

--- a/tests/test_backtest_webui.py
+++ b/tests/test_backtest_webui.py
@@ -1,0 +1,74 @@
+"""Wiring tests for the backtest WebUI panel and callbacks."""
+
+import unittest
+
+import pandas as pd
+
+
+class BacktestPanelWiringTests(unittest.TestCase):
+    def test_panel_component_builds(self):
+        from webui.components.backtest_panel import create_backtest_panel
+
+        panel = create_backtest_panel()
+        rendered = str(panel)
+        for component_id in (
+            "backtest-symbol-input",
+            "backtest-run-btn",
+            "backtest-equity-graph",
+            "backtest-windows-table",
+        ):
+            self.assertIn(component_id, rendered)
+
+    def test_callbacks_register_on_fresh_app(self):
+        import dash
+
+        from webui.callbacks.backtest_callbacks import register_backtest_callbacks
+
+        app = dash.Dash(__name__, suppress_callback_exceptions=True)
+        register_backtest_callbacks(app)
+        # Callback map keys are derived from outputs.
+        self.assertTrue(
+            any("backtest-status" in key for key in app.callback_map),
+            f"backtest callback missing from callback map: {list(app.callback_map)}",
+        )
+
+    def test_metric_formatting_helpers(self):
+        from webui.callbacks.backtest_callbacks import _fmt_pct, _fmt_ratio
+
+        self.assertEqual(_fmt_pct(0.25), "+25.00%")
+        self.assertEqual(_fmt_pct(-0.031), "-3.10%")
+        self.assertEqual(_fmt_pct(None), "—")
+        self.assertEqual(_fmt_ratio(1.234), "1.23")
+        self.assertEqual(_fmt_ratio(None), "—")
+
+    def test_equity_figure_and_windows_table_render(self):
+        from webui.callbacks.backtest_callbacks import (
+            _build_equity_figure,
+            _build_windows_table,
+        )
+
+        curve = pd.Series(
+            [100.0, 101.0, 102.0],
+            index=pd.date_range("2026-01-05", periods=3),
+        )
+        figure = _build_equity_figure(curve, "AAPL")
+        self.assertEqual(len(figure.data), 1)
+
+        window = {
+            "start_date": "2026-01-05",
+            "end_date": "2026-02-05",
+            "bars": 21,
+            "metrics": {
+                "cumulative_return": 0.05,
+                "sharpe_ratio": 1.5,
+                "max_drawdown": 0.02,
+                "win_rate": 0.6,
+            },
+        }
+        # A single window adds nothing beyond the full-period metrics.
+        self.assertIsNone(_build_windows_table([window]))
+        self.assertIsNotNone(_build_windows_table([window, window]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_backtest_webui.py
+++ b/tests/test_backtest_webui.py
@@ -17,6 +17,8 @@ class BacktestPanelWiringTests(unittest.TestCase):
             "backtest-equity-graph",
             "backtest-windows-table",
             "backtest-slippage-model",
+            "backtest-teach-btn",
+            "backtest-teach-status",
         ):
             self.assertIn(component_id, rendered)
 
@@ -31,6 +33,10 @@ class BacktestPanelWiringTests(unittest.TestCase):
         self.assertTrue(
             any("backtest-status" in key for key in app.callback_map),
             f"backtest callback missing from callback map: {list(app.callback_map)}",
+        )
+        self.assertTrue(
+            any("backtest-teach-status" in key for key in app.callback_map),
+            f"teach callback missing from callback map: {list(app.callback_map)}",
         )
 
     def test_metric_formatting_helpers(self):

--- a/tests/test_bracket_protective_orders.py
+++ b/tests/test_bracket_protective_orders.py
@@ -1,0 +1,205 @@
+"""Protective stop-loss / take-profit orders must actually reach the broker.
+
+Before this feature, ``execute_trade_intent`` recorded stops and targets as
+advisory metadata only (``protective_order_status: "advisory_only"``) — no
+protective order was ever submitted to Alpaca.  These tests drive the real
+bracket/OTO submission path with a mocked trading client.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tradingagents.agents.schemas import (
+    ExecutableAction,
+    RiskDecision,
+    build_trade_intent_from_risk_decision,
+    extract_protective_price,
+)
+from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+
+def _intent(symbol="AAPL", stop_loss=None, take_profit=None, action=ExecutableAction.BUY,
+            trading_mode="investment", current_position="NEUTRAL", allow_shorts=False):
+    return build_trade_intent_from_risk_decision(
+        symbol=symbol,
+        trading_mode=trading_mode,
+        current_position=current_position,
+        allow_shorts=allow_shorts,
+        trade_date="2026-01-02",
+        decision=RiskDecision(
+            action=action,
+            confidence="medium",
+            risk_rationale="test",
+            required_controls="test controls",
+            stop_loss=stop_loss,
+            take_profit=take_profit,
+        ),
+    )
+
+
+class ExtractProtectivePriceTests(unittest.TestCase):
+    def test_parses_plain_number(self):
+        self.assertEqual(extract_protective_price("182.50"), 182.50)
+
+    def test_parses_dollar_prefixed_number(self):
+        self.assertEqual(extract_protective_price("Stop at $1,234.56 (ATR-based)"), 1234.56)
+
+    def test_takes_first_price_when_multiple(self):
+        self.assertEqual(extract_protective_price("195 then 202"), 195.0)
+
+    def test_returns_none_for_no_number(self):
+        self.assertIsNone(extract_protective_price("trail below support"))
+        self.assertIsNone(extract_protective_price(None))
+
+    def test_ignores_percentages(self):
+        # "8% below entry" is relative guidance, not an absolute price level.
+        self.assertIsNone(extract_protective_price("8% below entry"))
+
+
+class TradeIntentNumericControlsTests(unittest.TestCase):
+    def test_builder_populates_numeric_protective_prices(self):
+        intent = _intent(stop_loss="182.50", take_profit="$195")
+        self.assertEqual(intent.risk_controls.stop_loss_price, 182.50)
+        self.assertEqual(intent.risk_controls.take_profit_price, 195.0)
+
+    def test_builder_leaves_prices_none_for_qualitative_guidance(self):
+        intent = _intent(stop_loss="below support", take_profit=None)
+        self.assertIsNone(intent.risk_controls.stop_loss_price)
+        self.assertIsNone(intent.risk_controls.take_profit_price)
+
+
+class BracketExecutionTests(unittest.TestCase):
+    def setUp(self):
+        self.client = MagicMock()
+        order = MagicMock()
+        order.id = "order-1"
+        order.symbol = "AAPL"
+        order.side = "buy"
+        order.qty = 5
+        order.notional = None
+        order.status = "accepted"
+        order.order_class = "bracket"
+        self.client.submit_order.return_value = order
+
+        self.patches = [
+            patch(
+                "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
+                return_value=self.client,
+            ),
+            patch.object(
+                AlpacaUtils,
+                "get_latest_quote",
+                return_value={"bid_price": 190.0, "ask_price": 190.1},
+            ),
+        ]
+        for p in self.patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in self.patches])
+
+    def _execute(self, intent, symbol="AAPL", current_position="NEUTRAL", allow_shorts=False):
+        return AlpacaUtils.execute_trade_intent(
+            symbol=symbol,
+            current_position=current_position,
+            trade_intent=intent.model_dump(mode="json"),
+            dollar_amount=1000,
+            allow_shorts=allow_shorts,
+        )
+
+    def test_buy_with_stop_and_target_submits_bracket_order(self):
+        result = self._execute(_intent(stop_loss="182.50", take_profit="195"))
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["protective_order_status"], "submitted_bracket")
+        request = self.client.submit_order.call_args[0][0]
+        self.assertEqual(str(request.order_class.value).lower(), "bracket")
+        self.assertEqual(float(request.stop_loss.stop_price), 182.50)
+        self.assertEqual(float(request.take_profit.limit_price), 195.0)
+        self.assertEqual(str(request.time_in_force.value).lower(), "gtc")
+        self.assertIsNotNone(request.qty)
+
+    def test_buy_with_stop_only_submits_oto_order(self):
+        result = self._execute(_intent(stop_loss="182.50"))
+
+        self.assertEqual(result["protective_order_status"], "submitted_oto")
+        request = self.client.submit_order.call_args[0][0]
+        self.assertEqual(str(request.order_class.value).lower(), "oto")
+        self.assertEqual(float(request.stop_loss.stop_price), 182.50)
+        self.assertIsNone(request.take_profit)
+
+    def test_crypto_buy_stays_advisory(self):
+        result = self._execute(
+            _intent(symbol="BTC/USD", stop_loss="60000", take_profit="70000"),
+            symbol="BTC/USD",
+        )
+
+        self.assertEqual(result["protective_order_status"], "advisory_only")
+        request = self.client.submit_order.call_args[0][0]
+        self.assertIsNone(getattr(request, "stop_loss", None))
+        self.assertTrue(any("crypto" in w.lower() for w in result["intent_warnings"]))
+
+    def test_inverted_long_prices_fall_back_to_advisory(self):
+        # For a long entry the stop must sit below the target.
+        result = self._execute(_intent(stop_loss="200", take_profit="180"))
+
+        self.assertEqual(result["protective_order_status"], "advisory_only")
+        request = self.client.submit_order.call_args[0][0]
+        self.assertIsNone(getattr(request, "stop_loss", None))
+
+    def test_no_numeric_prices_stays_advisory(self):
+        result = self._execute(_intent(stop_loss="below support"))
+
+        self.assertEqual(result["protective_order_status"], "advisory_only")
+
+    def test_config_flag_disables_bracket_submission(self):
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_config",
+            return_value={"protective_bracket_orders_enabled": False},
+        ):
+            result = self._execute(_intent(stop_loss="182.50", take_profit="195"))
+
+        self.assertEqual(result["protective_order_status"], "advisory_only")
+        request = self.client.submit_order.call_args[0][0]
+        self.assertIsNone(getattr(request, "stop_loss", None))
+
+    def test_bracket_rejection_falls_back_to_plain_market_order(self):
+        plain_order = MagicMock()
+        plain_order.id = "order-2"
+        plain_order.symbol = "AAPL"
+        plain_order.side = "buy"
+        plain_order.qty = 5
+        plain_order.notional = None
+        plain_order.status = "accepted"
+        self.client.submit_order.side_effect = [
+            Exception("bracket orders not allowed"),
+            plain_order,
+        ]
+
+        result = self._execute(_intent(stop_loss="182.50", take_profit="195"))
+
+        self.assertTrue(result["success"])
+        self.assertEqual(
+            result["protective_order_status"], "bracket_rejected_fallback_plain"
+        )
+        self.assertEqual(self.client.submit_order.call_count, 2)
+
+    def test_short_entry_bracket_prices_validated_inverted(self):
+        # For a short entry the target sits below the stop.
+        result = self._execute(
+            _intent(
+                stop_loss="210",
+                take_profit="180",
+                action=ExecutableAction.SHORT,
+                trading_mode="trading",
+                allow_shorts=True,
+            ),
+            allow_shorts=True,
+        )
+
+        self.assertEqual(result["protective_order_status"], "submitted_bracket")
+        request = self.client.submit_order.call_args[0][0]
+        self.assertEqual(float(request.stop_loss.stop_price), 210.0)
+        self.assertEqual(float(request.take_profit.limit_price), 180.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bracket_protective_orders.py
+++ b/tests/test_bracket_protective_orders.py
@@ -81,6 +81,9 @@ class BracketExecutionTests(unittest.TestCase):
         order.order_class = "bracket"
         self.client.submit_order.return_value = order
 
+        disabled_guard = MagicMock()
+        disabled_guard.enabled = False
+
         self.patches = [
             patch(
                 "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
@@ -91,6 +94,10 @@ class BracketExecutionTests(unittest.TestCase):
                 "get_latest_quote",
                 return_value={"bid_price": 190.0, "ask_price": 190.1},
             ),
+            # These tests isolate broker protective-order behavior. The safety
+            # gate has its own integration tests and must not persist state in
+            # the developer's real ~/.tradingagents directory during pytest.
+            patch("tradingagents.safety.get_safety_guard", return_value=disabled_guard),
         ]
         for p in self.patches:
             p.start()

--- a/tests/test_chaos_resilience.py
+++ b/tests/test_chaos_resilience.py
@@ -1,0 +1,263 @@
+"""Chaos tests: inject broker/data failures at the system's boundaries and
+verify the safety layer degrades gracefully instead of guessing or dying.
+
+Each test states its hypothesis in the name. No network, no live keys — all
+failures are injected via mocks at the Alpaca boundary, and every SafetyGuard
+gets its own temp state so experiments never leak into each other.
+"""
+
+import math
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+# Importing dataflows first trips a known circular import on main (fixed in
+# the backtesting-engine PR); importing agents first is the production-safe
+# order until that lands.
+import tradingagents.agents  # noqa: F401
+from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+from tradingagents.safety.guardrails import SafetyGuard
+
+
+def _guard(tmp, **config):
+    merged = {"safety_enabled": True}
+    merged.update(config)
+    return SafetyGuard(
+        config=merged,
+        state_path=Path(tmp) / "state.json",
+        kill_switch_path=Path(tmp) / "KILL_SWITCH",
+    )
+
+
+class NanAndGarbageEquityTests(unittest.TestCase):
+    """Anomalous account data must read as 'unavailable', never as a number."""
+
+    def test_nan_equity_does_not_poison_high_water_mark(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            guard.check_order(
+                "AAPL", 1000.0, account={"equity": float("nan"), "last_equity": 100000.0}
+            )
+            hwm = guard._state.get("high_water_mark")
+            self.assertTrue(hwm is None or math.isfinite(float(hwm)))
+
+    def test_drawdown_breaker_survives_a_nan_day(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, max_drawdown_halt_pct=15.0)
+            # Healthy day establishes the mark, then a NaN day, then a crash day.
+            guard.check_order("AAPL", 0.0, account={"equity": 100000.0})
+            guard.check_order("AAPL", 0.0, account={"equity": float("nan")})
+            verdict = guard.check_order("AAPL", 0.0, account={"equity": 80000.0})
+            self.assertFalse(verdict.allowed)
+            self.assertEqual(verdict.checks["drawdown"]["status"], "fail")
+
+    def test_nan_equity_skips_account_breakers_instead_of_passing_them(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, daily_loss_halt_pct=10.0, max_drawdown_halt_pct=15.0)
+            verdict = guard.check_order(
+                "AAPL",
+                1000.0,
+                account={"equity": float("nan"), "last_equity": float("nan")},
+            )
+            self.assertEqual(verdict.checks["daily_loss"]["status"], "skipped")
+            self.assertEqual(verdict.checks["drawdown"]["status"], "skipped")
+
+    def test_nginx_html_in_account_fields_does_not_crash_the_guard(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            verdict = guard.check_order(
+                "AAPL",
+                1000.0,
+                account={
+                    "equity": "<html><body>401 Authorization Required</body></html>",
+                    "last_equity": "<html>",
+                },
+            )
+            # Cheap checks still run; account-based ones are skipped.
+            self.assertTrue(verdict.allowed)
+            self.assertEqual(verdict.checks["daily_loss"]["status"], "skipped")
+            self.assertEqual(verdict.checks["drawdown"]["status"], "skipped")
+
+    def test_infinite_equity_reads_as_unavailable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            verdict = guard.check_order(
+                "AAPL", 1000.0, account={"equity": float("inf"), "last_equity": 1.0}
+            )
+            self.assertEqual(verdict.checks["drawdown"]["status"], "skipped")
+            hwm = guard._state.get("high_water_mark")
+            self.assertTrue(hwm is None or math.isfinite(float(hwm)))
+
+    def test_nan_position_value_does_not_disable_concentration_cap(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, max_symbol_concentration_pct=25.0)
+            verdict = guard.check_order(
+                "AAPL",
+                30000.0,
+                account={"equity": 100000.0},
+                position_value=float("nan"),
+            )
+            # NaN exposure must not silently pass the cap: the $30k order alone
+            # exceeds 25% of $100k equity.
+            self.assertFalse(verdict.allowed)
+            self.assertEqual(verdict.checks["concentration"]["status"], "fail")
+
+    def test_zero_last_equity_skips_daily_loss_without_dividing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, daily_loss_halt_pct=10.0)
+            verdict = guard.check_order(
+                "AAPL", 1000.0, account={"equity": 50000.0, "last_equity": 0.0}
+            )
+            self.assertEqual(verdict.checks["daily_loss"]["status"], "skipped")
+
+
+class MidFlipOutageTests(unittest.TestCase):
+    """API dies between closing one side and opening the other."""
+
+    def _run_flip(self, guard, close_result, open_side_effect):
+        with patch.object(AlpacaUtils, "close_position", return_value=close_result), \
+             patch.object(
+                 AlpacaUtils, "place_market_order", side_effect=open_side_effect
+             ), \
+             patch.object(AlpacaUtils, "_safety_context", return_value=(None, None)), \
+             patch.object(
+                 AlpacaUtils,
+                 "get_latest_quote",
+                 return_value={"bid_price": 100.0, "ask_price": 100.1},
+             ), \
+             patch("tradingagents.safety.get_safety_guard", return_value=guard):
+            return AlpacaUtils.execute_trading_action(
+                symbol="AAPL",
+                current_position="LONG",
+                signal="SHORT",
+                dollar_amount=5000.0,
+                allow_shorts=True,
+            )
+
+    def test_open_leg_failure_reports_failure_and_feeds_the_breaker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, max_consecutive_rejections=5)
+            outcome = self._run_flip(
+                guard,
+                close_result={"success": True, "message": "closed"},
+                open_side_effect=[{"success": False, "error": "connection reset"}],
+            )
+            self.assertFalse(outcome["success"])
+            actions = [a["action"] for a in outcome["actions"]]
+            self.assertEqual(actions, ["close_long", "open_short"])
+            # One success (close) then one rejection (open): streak is 1.
+            self.assertEqual(guard.consecutive_rejections(), 1)
+
+    def test_close_leg_failure_never_attempts_the_open_leg(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            open_order = Mock()
+            outcome = self._run_flip(
+                guard,
+                close_result={"success": False, "error": "504 gateway timeout"},
+                open_side_effect=open_order,
+            )
+            self.assertFalse(outcome["success"])
+            open_order.assert_not_called()
+
+    def test_unexpected_exception_mid_flip_returns_error_dict(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            outcome = self._run_flip(
+                guard,
+                close_result={"success": True},
+                open_side_effect=ConnectionError("socket closed mid-request"),
+            )
+            self.assertFalse(outcome["success"])
+            self.assertIn("error", outcome)
+
+
+class KillSwitchAndBreakerFlowTests(unittest.TestCase):
+    def test_kill_switch_blocks_before_any_broker_call(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            guard.engage_kill_switch("chaos drill")
+            broker_call = Mock()
+            with patch.object(AlpacaUtils, "close_position", broker_call), \
+                 patch.object(AlpacaUtils, "place_market_order", broker_call), \
+                 patch.object(
+                     AlpacaUtils, "_safety_context", return_value=(None, None)
+                 ), \
+                 patch("tradingagents.safety.get_safety_guard", return_value=guard):
+                outcome = AlpacaUtils.execute_trading_action(
+                    symbol="AAPL",
+                    current_position="NEUTRAL",
+                    signal="BUY",
+                    dollar_amount=1000.0,
+                    allow_shorts=False,
+                )
+            self.assertFalse(outcome["success"])
+            self.assertTrue(outcome.get("safety_blocked"))
+            broker_call.assert_not_called()
+
+    def test_rejection_streak_halts_subsequent_order_flow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, max_consecutive_rejections=3)
+            for _ in range(3):
+                guard.record_order_result(False)
+            verdict = guard.check_order("AAPL", 1000.0)
+            self.assertFalse(verdict.allowed)
+            self.assertEqual(verdict.checks["rejection_streak"]["status"], "fail")
+
+    def test_unreachable_account_degrades_to_cheap_checks_only(self):
+        """Broker down: orders are not wrongly blocked by absent breakers."""
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, daily_loss_halt_pct=10.0, max_drawdown_halt_pct=15.0)
+            with patch.object(
+                AlpacaUtils,
+                "place_market_order",
+                return_value={"success": True, "message": "ok"},
+            ), \
+                 patch.object(
+                     AlpacaUtils, "_safety_context", return_value=(None, None)
+                 ), \
+                 patch.object(
+                     AlpacaUtils,
+                     "get_latest_quote",
+                     return_value={"bid_price": 100.0, "ask_price": 100.1},
+                 ), \
+                 patch("tradingagents.safety.get_safety_guard", return_value=guard):
+                outcome = AlpacaUtils.execute_trading_action(
+                    symbol="AAPL",
+                    current_position="NEUTRAL",
+                    signal="BUY",
+                    dollar_amount=1000.0,
+                    allow_shorts=False,
+                )
+            self.assertTrue(outcome["success"])
+
+
+class MalformedBrokerPayloadTests(unittest.TestCase):
+    def test_garbage_position_payload_reads_as_neutral(self):
+        bad_position = Mock()
+        bad_position.symbol = "AAPL"
+        bad_position.qty = "<html>502 Bad Gateway</html>"
+        client = Mock()
+        client.get_all_positions.return_value = [bad_position]
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
+            return_value=client,
+        ):
+            state = AlpacaUtils.get_current_position_state("AAPL")
+        self.assertEqual(state, "NEUTRAL")
+
+    def test_account_fetch_outage_returns_zeroed_info_not_exception(self):
+        client = Mock()
+        client.get_account.side_effect = ConnectionError("nginx: 502")
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
+            return_value=client,
+        ):
+            info = AlpacaUtils.get_account_info()
+        self.assertEqual(info["buying_power"], 0)
+        self.assertEqual(info["cash"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_daily_report_alerts.py
+++ b/tests/test_daily_report_alerts.py
@@ -7,8 +7,11 @@ daily report is assembled purely from data the system already persists.
 """
 
 import json
+import os
+import io
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 
 from tradingagents.alerts import (
@@ -101,6 +104,23 @@ class AlertDispatchTests(unittest.TestCase):
             transport=_FakeTransport(fail=True),
         )
         self.assertFalse(result["sent"])
+
+    def test_transport_failure_log_does_not_echo_credentials_or_urls(self):
+        def leaking_transport(url, payload):
+            raise ConnectionError(f"failed request to {url}")
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            send_alert(
+                "halt",
+                "body",
+                config=_alert_config(),
+                transport=leaking_transport,
+            )
+
+        logged = output.getvalue()
+        self.assertNotIn("TOKEN", logged)
+        self.assertNotIn("hooks.example", logged)
 
     def test_notify_safety_block_dedupes_on_reasons(self):
         transport = _FakeTransport()
@@ -220,6 +240,39 @@ class ConfigTests(unittest.TestCase):
         )
         self.assertEqual(config.telegram_bot_token, "T")
         self.assertEqual(config.cooldown_seconds, 60)
+
+
+class RunLoggerSecretTests(unittest.TestCase):
+    def test_run_config_redacts_provider_and_alert_credentials(self):
+        from tradingagents.run_logger import RunAuditLogger
+
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            try:
+                logger = RunAuditLogger()
+                run_id = logger.start_run(
+                    symbol="AAPL",
+                    trade_date="2026-07-11",
+                    config={
+                        "minimax_api_key": "minimax-secret",
+                        "alert_telegram_bot_token": "telegram-secret",
+                        "alert_telegram_chat_id": "private-chat",
+                        "alert_webhook_url": "https://example.test/private-hook",
+                        "daily_llm_token_budget": 12345,
+                    },
+                )
+                logger.finish_run(run_id=run_id)
+                path = next(Path("eval_results").glob("**/runs/*.json"))
+                stored = json.loads(path.read_text(encoding="utf-8"))["config"]
+            finally:
+                os.chdir(cwd)
+
+        self.assertEqual(stored["minimax_api_key"], "[REDACTED]")
+        self.assertEqual(stored["alert_telegram_bot_token"], "[REDACTED]")
+        self.assertEqual(stored["alert_telegram_chat_id"], "[REDACTED]")
+        self.assertEqual(stored["alert_webhook_url"], "[REDACTED]")
+        self.assertEqual(stored["daily_llm_token_budget"], 12345)
 
 
 if __name__ == "__main__":

--- a/tests/test_daily_report_alerts.py
+++ b/tests/test_daily_report_alerts.py
@@ -1,0 +1,226 @@
+"""Tests for the daily report generator and the alert dispatcher.
+
+Alerts are stdlib-only (Telegram Bot API + generic webhook), deduplicated
+with a cooldown so a tripped circuit breaker cannot flood the channel, and
+fully failure-isolated: a dead webhook must never affect order flow. The
+daily report is assembled purely from data the system already persists.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tradingagents.alerts import (
+    AlertConfig,
+    notify_safety_block,
+    reset_alert_dedupe,
+    send_alert,
+)
+from tradingagents.daily_report import generate_daily_report, write_daily_report
+from tradingagents.safety.guardrails import SafetyGuard
+
+
+class _FakeTransport:
+    def __init__(self, fail=False):
+        self.calls = []
+        self.fail = fail
+
+    def __call__(self, url, payload):
+        if self.fail:
+            raise ConnectionError("endpoint down")
+        self.calls.append((url, payload))
+
+
+def _alert_config(**overrides):
+    kwargs = {
+        "enabled": True,
+        "telegram_bot_token": "TOKEN",
+        "telegram_chat_id": "42",
+        "webhook_url": "https://hooks.example/x",
+        "cooldown_seconds": 900,
+    }
+    kwargs.update(overrides)
+    return AlertConfig(**kwargs)
+
+
+class AlertDispatchTests(unittest.TestCase):
+    def setUp(self):
+        reset_alert_dedupe()
+
+    def test_sends_to_telegram_and_webhook(self):
+        transport = _FakeTransport()
+        result = send_alert(
+            "Circuit breaker", "details", config=_alert_config(), transport=transport
+        )
+        self.assertTrue(result["sent"])
+        urls = [u for u, _ in transport.calls]
+        self.assertTrue(any("api.telegram.org/botTOKEN/sendMessage" in u for u in urls))
+        self.assertIn("https://hooks.example/x", urls)
+        # Telegram payload carries chat id and both subject and body.
+        telegram_payload = next(p for u, p in transport.calls if "telegram" in u)
+        self.assertEqual(telegram_payload["chat_id"], "42")
+        self.assertIn("Circuit breaker", telegram_payload["text"])
+
+    def test_duplicate_alert_is_suppressed_within_cooldown(self):
+        transport = _FakeTransport()
+        config = _alert_config()
+        first = send_alert("halt", "body", config=config, transport=transport)
+        second = send_alert("halt", "body", config=config, transport=transport)
+        self.assertTrue(first["sent"])
+        self.assertTrue(second["deduped"])
+        self.assertEqual(len(transport.calls), 2)  # telegram + webhook, once
+
+    def test_different_keys_are_not_deduped(self):
+        transport = _FakeTransport()
+        config = _alert_config()
+        send_alert("halt", "body", key="a", config=config, transport=transport)
+        send_alert("halt", "body", key="b", config=config, transport=transport)
+        self.assertEqual(len(transport.calls), 4)
+
+    def test_disabled_or_unconfigured_sends_nothing(self):
+        transport = _FakeTransport()
+        result = send_alert(
+            "halt", "body", config=_alert_config(enabled=False), transport=transport
+        )
+        self.assertFalse(result["sent"])
+        result = send_alert(
+            "halt",
+            "body",
+            config=AlertConfig(enabled=True),  # no channels configured
+            transport=transport,
+        )
+        self.assertFalse(result["sent"])
+        self.assertEqual(transport.calls, [])
+
+    def test_transport_failure_never_raises(self):
+        result = send_alert(
+            "halt",
+            "body",
+            config=_alert_config(),
+            transport=_FakeTransport(fail=True),
+        )
+        self.assertFalse(result["sent"])
+
+    def test_notify_safety_block_dedupes_on_reasons(self):
+        transport = _FakeTransport()
+        config = _alert_config()
+        notify_safety_block("AAPL", ["Kill switch is engaged"], config=config, transport=transport)
+        notify_safety_block("AAPL", ["Kill switch is engaged"], config=config, transport=transport)
+        self.assertEqual(len(transport.calls), 2)  # one alert, two channels
+
+
+def _write_run(root, symbol, trade_date, final_signal, tokens=1000, status="completed"):
+    runs_dir = Path(root) / symbol / "TradingAgentsStrategy_logs" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    started = f"{trade_date}T10:00:00+00:00"
+    payload = {
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "started_at": started,
+        "status": status,
+        "events": [
+            {
+                "type": "llm_call",
+                "payload": {
+                    "model": "fake-deep",
+                    "usage": {"input_tokens": tokens, "output_tokens": tokens // 10},
+                },
+            }
+        ],
+        "summary": {"final_signal": final_signal, "total_llm_tokens": tokens},
+    }
+    (runs_dir / f"{trade_date}_run.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+class DailyReportTests(unittest.TestCase):
+    def _report(self, root, tmp, day="2026-07-11"):
+        guard = SafetyGuard(
+            config={"safety_enabled": True},
+            state_path=Path(tmp) / "state.json",
+            kill_switch_path=Path(tmp) / "KILL_SWITCH",
+        )
+        config = {
+            "results_dir": root,
+            "memory_log_path": str(Path(tmp) / "trading_memory.md"),
+            "llm_pricing_per_million": {"fake-deep": {"input": 10.0, "output": 30.0}},
+        }
+        return generate_daily_report(day=day, config=config, guard=guard)
+
+    def test_report_contains_decisions_safety_cost_and_performance(self):
+        with tempfile.TemporaryDirectory() as root, tempfile.TemporaryDirectory() as tmp:
+            _write_run(root, "AAPL", "2026-07-11", "BUY", tokens=100_000)
+            _write_run(root, "NVDA", "2026-07-11", "HOLD", tokens=50_000)
+            _write_run(root, "EXCL", "2026-07-01", "SELL")  # different day: excluded
+            report = self._report(root, tmp)
+
+        self.assertIn("Daily Trading Report", report)
+        self.assertIn("AAPL", report)
+        self.assertIn("BUY", report)
+        self.assertNotIn("EXCL", report)
+        for section in ("Decisions", "Safety", "LLM cost", "Realized performance"):
+            self.assertIn(section, report)
+        self.assertIn("$", report)  # a priced cost figure appears
+
+    def test_kill_switch_state_is_reported(self):
+        with tempfile.TemporaryDirectory() as root, tempfile.TemporaryDirectory() as tmp:
+            guard = SafetyGuard(
+                config={"safety_enabled": True},
+                state_path=Path(tmp) / "state.json",
+                kill_switch_path=Path(tmp) / "KILL_SWITCH",
+            )
+            guard.engage_kill_switch("drill")
+            report = generate_daily_report(
+                day="2026-07-11", config={"results_dir": root}, guard=guard
+            )
+        self.assertIn("KILL SWITCH", report.upper())
+
+    def test_write_daily_report_creates_md_and_html(self):
+        with tempfile.TemporaryDirectory() as root, tempfile.TemporaryDirectory() as tmp:
+            _write_run(root, "AAPL", "2026-07-11", "BUY")
+            guard = SafetyGuard(
+                config={"safety_enabled": True},
+                state_path=Path(tmp) / "state.json",
+                kill_switch_path=Path(tmp) / "KILL_SWITCH",
+            )
+            md_path, html_path = write_daily_report(
+                day="2026-07-11",
+                output_dir=str(Path(tmp) / "reports"),
+                config={"results_dir": root},
+                guard=guard,
+            )
+            self.assertTrue(Path(md_path).exists())
+            self.assertTrue(Path(html_path).exists())
+            html = Path(html_path).read_text(encoding="utf-8")
+            self.assertIn("AAPL", html)
+
+    def test_empty_day_still_produces_a_report(self):
+        with tempfile.TemporaryDirectory() as root, tempfile.TemporaryDirectory() as tmp:
+            report = self._report(root, tmp, day="2026-01-01")
+        self.assertIn("No completed analyses", report)
+
+
+class ConfigTests(unittest.TestCase):
+    def test_default_config_exposes_alert_keys(self):
+        from tradingagents.default_config import DEFAULT_CONFIG
+
+        self.assertIn("alerts_enabled", DEFAULT_CONFIG)
+        self.assertIn("alert_webhook_url", DEFAULT_CONFIG)
+        self.assertIn("alert_telegram_bot_token", DEFAULT_CONFIG)
+
+    def test_alert_config_from_project_config(self):
+        config = AlertConfig.from_config(
+            {
+                "alerts_enabled": True,
+                "alert_telegram_bot_token": "T",
+                "alert_telegram_chat_id": "C",
+                "alert_webhook_url": "https://x",
+                "alert_cooldown_seconds": 60,
+            }
+        )
+        self.assertEqual(config.telegram_bot_token, "T")
+        self.assertEqual(config.cooldown_seconds, 60)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_fallback.py
+++ b/tests/test_data_fallback.py
@@ -25,6 +25,32 @@ class DataFallbackTests(unittest.TestCase):
         self.assertTrue(result.empty)
         yf_download.assert_not_called()
 
+    def test_nginx_401_html_error_triggers_fallback(self):
+        # Alpaca auth failures can surface as a raw nginx HTML page that says
+        # "401 Authorization Required" without the word "unauthorized".
+        fallback = pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2026-01-01", "2026-01-02"]),
+                "Open": [10.0, 11.0],
+                "High": [12.0, 12.5],
+                "Low": [9.5, 10.5],
+                "Close": [11.5, 12.0],
+                "Volume": [1000, 1100],
+            }
+        ).set_index("Date")
+
+        set_config({**self.original_config, "data_fallback_enabled": True})
+        nginx_error = ValueError(
+            "<html>\n<head><title>401 Authorization Required</title></head>\n</html>"
+        )
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_stock_client",
+            side_effect=nginx_error,
+        ), patch("yfinance.download", return_value=fallback):
+            result = AlpacaUtils.get_stock_data("AAPL", "2026-01-01", "2026-01-03")
+
+        self.assertFalse(result.empty)
+
     def test_yfinance_fallback_normalizes_ohlcv_columns(self):
         fallback = pd.DataFrame(
             {

--- a/tests/test_import_no_network.py
+++ b/tests/test_import_no_network.py
@@ -1,0 +1,57 @@
+"""Importing tradingagents packages must never trigger network calls.
+
+Each case runs in a fresh interpreter so previously imported modules in the
+pytest process cannot mask import-time side effects. Inside the subprocess,
+socket primitives are replaced with guards that record any connection
+attempt before the package is imported.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+GUARD_SCRIPT = """
+import socket
+
+attempts = []
+
+def _blocked(*args, **kwargs):
+    attempts.append(args)
+    raise RuntimeError("network access attempted during import")
+
+socket.socket.connect = _blocked
+socket.create_connection = _blocked
+socket.getaddrinfo = _blocked
+
+import {module}
+
+print("ATTEMPTED_CONNECTIONS:", len(attempts))
+print("IMPORT_OK")
+"""
+
+
+@pytest.mark.parametrize(
+    "module",
+    ["tradingagents.dataflows", "tradingagents.agents", "tradingagents"],
+)
+def test_import_does_not_touch_network(module):
+    result = subprocess.run(
+        [sys.executable, "-c", GUARD_SCRIPT.format(module=module)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, f"import {module} failed:\n{output}"
+    assert "IMPORT_OK" in result.stdout, f"import {module} did not complete:\n{output}"
+    assert "ATTEMPTED_CONNECTIONS: 0" in result.stdout, (
+        f"import {module} attempted network connections:\n{output}"
+    )
+    assert "Error fetching" not in output, (
+        f"import {module} triggered Alpaca API calls:\n{output}"
+    )

--- a/tests/test_llm_cost.py
+++ b/tests/test_llm_cost.py
@@ -1,0 +1,216 @@
+"""Tests for LLM cost accounting: pricing resolution, run-log scanning,
+aggregation per day/symbol/model, realized-return join, and WebUI wiring."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tradingagents.llm_cost import (
+    aggregate_costs,
+    estimate_cost_usd,
+    parse_return_pct,
+    realized_returns_by_symbol,
+    resolve_pricing,
+    scan_run_costs,
+)
+
+
+def _write_run(
+    root,
+    symbol,
+    trade_date,
+    llm_calls=(),
+    summary_tokens=None,
+    status="completed",
+    started_at=None,
+):
+    runs_dir = Path(root) / symbol / "TradingAgentsStrategy_logs" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    started = started_at or f"{trade_date}T10:00:00+00:00"
+    events = [
+        {
+            "type": "llm_call",
+            "timestamp": started,
+            "payload": {"model": model, "usage": usage},
+        }
+        for model, usage in llm_calls
+    ]
+    payload = {
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "started_at": started,
+        "status": status,
+        "events": events,
+        "summary": {"total_llm_tokens": summary_tokens or 0},
+    }
+    name = f"{trade_date}_{started.replace(':', '')}.json"
+    (runs_dir / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+class PricingTests(unittest.TestCase):
+    def test_longest_prefix_wins(self):
+        generic = resolve_pricing("gpt-5-preview")
+        mini = resolve_pricing("gpt-5-mini-2025")
+        self.assertIsNotNone(generic)
+        self.assertIsNotNone(mini)
+        self.assertLess(mini["input"], generic["input"])
+
+    def test_unknown_model_is_unpriced(self):
+        self.assertIsNone(resolve_pricing("totally-unknown-llm-9000"))
+
+    def test_config_override_beats_defaults(self):
+        overrides = {"gpt-5-mini": {"input": 1.0, "output": 2.0}}
+        priced = resolve_pricing("gpt-5-mini", overrides=overrides)
+        self.assertEqual(priced["input"], 1.0)
+
+    def test_estimate_cost_arithmetic(self):
+        overrides = {"fake-model": {"input": 1.0, "output": 10.0}}
+        # 1M input @ $1 + 0.5M output @ $10 = $6.
+        cost = estimate_cost_usd(
+            "fake-model", 1_000_000, 500_000, overrides=overrides
+        )
+        self.assertAlmostEqual(cost, 6.0)
+
+    def test_estimate_cost_unknown_model_returns_none(self):
+        self.assertIsNone(estimate_cost_usd("mystery", 1000, 1000))
+
+
+class ScanRunCostsTests(unittest.TestCase):
+    def test_scans_runs_and_attributes_models(self):
+        overrides = {"fake-deep": {"input": 10.0, "output": 30.0}}
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(
+                root,
+                "AAPL",
+                "2026-07-01",
+                llm_calls=[
+                    ("fake-deep", {"input_tokens": 100_000, "output_tokens": 10_000}),
+                    ("fake-deep", {"input_tokens": 50_000, "output_tokens": 5_000}),
+                    ("mystery-model", {"input_tokens": 1_000, "output_tokens": 100}),
+                ],
+            )
+            records = scan_run_costs(eval_results_dir=root, overrides=overrides)
+
+        self.assertEqual(len(records), 1)
+        record = records[0]
+        self.assertEqual(record["symbol"], "AAPL")
+        self.assertEqual(record["trade_date"], "2026-07-01")
+        self.assertEqual(record["input_tokens"], 151_000)
+        self.assertEqual(record["output_tokens"], 15_100)
+        # fake-deep: 150k in @ $10/M + 15k out @ $30/M = 1.5 + 0.45 = 1.95
+        self.assertAlmostEqual(record["cost_usd"], 1.95)
+        self.assertEqual(record["unpriced_tokens"], 1_100)
+        self.assertIn("fake-deep", record["models"])
+
+    def test_run_without_events_falls_back_to_summary(self):
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(root, "NVDA", "2026-07-02", summary_tokens=42_000)
+            records = scan_run_costs(eval_results_dir=root)
+        self.assertEqual(records[0]["total_tokens"], 42_000)
+        self.assertIsNone(records[0]["cost_usd"])
+        self.assertEqual(records[0]["unpriced_tokens"], 42_000)
+
+    def test_missing_dir_returns_empty(self):
+        self.assertEqual(scan_run_costs(eval_results_dir="does-not-exist-xyz"), [])
+
+
+class AggregationTests(unittest.TestCase):
+    def _records(self):
+        overrides = {"fake-deep": {"input": 10.0, "output": 30.0}}
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(
+                root,
+                "AAPL",
+                "2026-07-01",
+                llm_calls=[("fake-deep", {"input_tokens": 100_000, "output_tokens": 10_000})],
+            )
+            _write_run(
+                root,
+                "AAPL",
+                "2026-07-02",
+                llm_calls=[("fake-deep", {"input_tokens": 200_000, "output_tokens": 20_000})],
+                started_at="2026-07-02T09:00:00+00:00",
+            )
+            _write_run(
+                root,
+                "NVDA",
+                "2026-07-02",
+                llm_calls=[("fake-deep", {"input_tokens": 300_000, "output_tokens": 30_000})],
+                started_at="2026-07-02T11:00:00+00:00",
+            )
+            return scan_run_costs(eval_results_dir=root, overrides=overrides)
+
+    def test_aggregates_by_day_symbol_and_model(self):
+        agg = aggregate_costs(self._records())
+        self.assertEqual(agg["totals"]["runs"], 3)
+        self.assertEqual(set(agg["per_day"]), {"2026-07-01", "2026-07-02"})
+        self.assertEqual(agg["per_day"]["2026-07-02"]["runs"], 2)
+        self.assertEqual(set(agg["per_symbol"]), {"AAPL", "NVDA"})
+        self.assertEqual(agg["per_symbol"]["AAPL"]["runs"], 2)
+        self.assertIn("fake-deep", agg["per_model"])
+        # Total cost: (600k in @ $10/M) + (60k out @ $30/M) = 6.0 + 1.8
+        self.assertAlmostEqual(agg["totals"]["cost_usd"], 7.8)
+
+
+class RealizedReturnJoinTests(unittest.TestCase):
+    def test_parse_return_pct(self):
+        self.assertAlmostEqual(parse_return_pct("+3.2%"), 0.032)
+        self.assertAlmostEqual(parse_return_pct("-1.5%"), -0.015)
+        self.assertIsNone(parse_return_pct("n/a"))
+        self.assertIsNone(parse_return_pct(None))
+
+    def test_returns_joined_from_memory_log(self):
+        from tradingagents.agents.utils.memory import TradingMemoryLog
+
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = str(Path(tmp) / "trading_memory.md")
+            log = TradingMemoryLog({"memory_log_path": log_path})
+            log.store_decision("AAPL", "2026-07-01", "FINAL DECISION: BUY")
+            log.batch_update_with_outcomes(
+                [
+                    {
+                        "ticker": "AAPL",
+                        "trade_date": "2026-07-01",
+                        "raw_return": 0.04,
+                        "alpha_return": None,
+                        "holding_days": 5,
+                        "reflection": "went well",
+                    }
+                ]
+            )
+            returns = realized_returns_by_symbol({"memory_log_path": log_path})
+
+        self.assertIn("AAPL", returns)
+        self.assertEqual(returns["AAPL"]["resolved"], 1)
+        self.assertAlmostEqual(returns["AAPL"]["avg_return"], 0.04, places=3)
+
+
+class CostWebUIWiringTests(unittest.TestCase):
+    def test_panel_component_builds(self):
+        from webui.components.cost_panel import create_cost_panel
+
+        rendered = str(create_cost_panel())
+        for component_id in (
+            "cost-refresh-btn",
+            "cost-summary-cards",
+            "cost-daily-graph",
+            "cost-symbol-table",
+        ):
+            self.assertIn(component_id, rendered)
+
+    def test_callbacks_register_on_fresh_app(self):
+        import dash
+
+        from webui.callbacks.cost_callbacks import register_cost_callbacks
+
+        app = dash.Dash(__name__, suppress_callback_exceptions=True)
+        register_cost_callbacks(app)
+        self.assertTrue(
+            any("cost-summary-cards" in key for key in app.callback_map),
+            f"cost callback missing: {list(app.callback_map)}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_maintenance.py
+++ b/tests/test_memory_maintenance.py
@@ -1,0 +1,187 @@
+"""Tests for FinMem-style memory maintenance: time/performance decay,
+duplicate pruning, and per-collection size caps.
+
+Adaptation of FinMem (arXiv:2311.13743) to a single-layer ChromaDB store:
+instead of discrete shallow/intermediate/deep layers, each entry's decay
+stability interpolates continuously with its importance — important lessons
+(large realized moves) decay like FinMem's deep layer (Q=365d), trivial
+ones like the shallow layer (Q=14d). Entries purge when recency < 0.05,
+near-duplicates (cosine similarity above threshold) collapse to the
+highest-scoring copy, and a size cap evicts the lowest-scoring entries.
+"""
+
+import math
+import unittest
+import uuid
+from datetime import date, timedelta
+
+from tradingagents.agents.utils.memory import FinancialSituationMemory
+from tradingagents.agents.utils.memory_maintenance import (
+    MemoryMaintenanceConfig,
+    entry_importance,
+    entry_recency,
+    maintain_memory,
+)
+
+
+def _fresh_memory():
+    memory = FinancialSituationMemory(f"maint_test_{uuid.uuid4().hex[:8]}")
+    memory.embeddings_enabled = True
+    return memory
+
+
+def _add(memory, text, embedding, **metadata):
+    memory.get_embedding = lambda _t: embedding
+    memory.add_situations([(text, f"advice for {text}")], extra_metadata=metadata or None)
+
+
+def _days_ago(days):
+    return (date.today() - timedelta(days=days)).isoformat()
+
+
+class ScoringTests(unittest.TestCase):
+    def test_recency_is_ebbinghaus_decay(self):
+        # importance 0 -> shallow stability (14 days).
+        meta = {"trade_date": _days_ago(14)}
+        self.assertAlmostEqual(
+            entry_recency(meta, importance=0.0), math.exp(-1.0), places=6
+        )
+
+    def test_high_importance_decays_slower(self):
+        meta = {"trade_date": _days_ago(180)}
+        shallow = entry_recency(meta, importance=0.0)
+        deep = entry_recency(meta, importance=1.0)
+        self.assertLess(shallow, 0.05)  # 180d >> Q_shallow=14d: expired
+        self.assertGreater(deep, 0.5)  # 180d < Q_deep=365d: well retained
+
+    def test_undated_entry_gets_neutral_recency(self):
+        self.assertEqual(entry_recency({}, importance=0.0), 0.5)
+
+    def test_importance_scales_with_realized_return(self):
+        base = entry_importance({})
+        small = entry_importance({"decision_return": 0.005})
+        large = entry_importance({"decision_return": -0.25})
+        self.assertGreater(small, base - 1e-9)
+        self.assertGreater(large, small)
+        self.assertLessEqual(large, 1.0)
+
+    def test_created_at_used_when_no_trade_date(self):
+        meta = {"created_at": _days_ago(14)}
+        self.assertAlmostEqual(
+            entry_recency(meta, importance=0.0), math.exp(-1.0), places=6
+        )
+
+
+class CreatedAtStampTests(unittest.TestCase):
+    def test_add_situations_stamps_created_at(self):
+        memory = _fresh_memory()
+        _add(memory, "sit", [0.1] * 8)
+        meta = memory.situation_collection.get(include=["metadatas"])["metadatas"][0]
+        self.assertEqual(meta["created_at"], date.today().isoformat())
+
+    def test_explicit_created_at_not_overwritten(self):
+        memory = _fresh_memory()
+        _add(memory, "sit", [0.1] * 8, created_at="2020-01-01")
+        meta = memory.situation_collection.get(include=["metadatas"])["metadatas"][0]
+        self.assertEqual(meta["created_at"], "2020-01-01")
+
+
+class MaintainMemoryTests(unittest.TestCase):
+    def test_expired_entries_are_purged(self):
+        memory = _fresh_memory()
+        # Low importance + very old: recency far below 0.05.
+        _add(memory, "ancient", [0.1] * 8, trade_date=_days_ago(400))
+        _add(memory, "recent", [0.9] * 8, trade_date=_days_ago(2))
+        summary = maintain_memory(memory)
+        self.assertEqual(summary["purged_expired"], 1)
+        self.assertEqual(memory.situation_collection.count(), 1)
+        kept = memory.situation_collection.get(include=["documents"])["documents"]
+        self.assertEqual(kept, ["recent"])
+
+    def test_important_old_entries_survive(self):
+        memory = _fresh_memory()
+        # Same age, but a large realized move -> deep-layer stability.
+        _add(
+            memory,
+            "big lesson",
+            [0.1] * 8,
+            trade_date=_days_ago(180),
+            decision_return=0.30,
+        )
+        summary = maintain_memory(memory)
+        self.assertEqual(summary["purged_expired"], 0)
+        self.assertEqual(memory.situation_collection.count(), 1)
+
+    def test_near_duplicates_collapse_to_one(self):
+        memory = _fresh_memory()
+        _add(memory, "dup one", [0.5] * 8, trade_date=_days_ago(5))
+        _add(memory, "dup two", [0.5] * 8, trade_date=_days_ago(1))
+        _add(memory, "distinct", [0.9, -0.4, 0.2, 0.7, -0.1, 0.3, -0.8, 0.6])
+        summary = maintain_memory(memory)
+        self.assertEqual(summary["purged_duplicates"], 1)
+        docs = memory.situation_collection.get(include=["documents"])["documents"]
+        self.assertIn("distinct", docs)
+        # The newer duplicate wins on recency.
+        self.assertIn("dup two", docs)
+        self.assertNotIn("dup one", docs)
+
+    def test_size_cap_evicts_lowest_scores(self):
+        memory = _fresh_memory()
+        embeddings = [
+            [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ]
+        _add(memory, "old weak", embeddings[0], trade_date=_days_ago(10))
+        _add(memory, "fresh", embeddings[1], trade_date=_days_ago(1))
+        _add(
+            memory,
+            "important",
+            embeddings[2],
+            trade_date=_days_ago(5),
+            decision_return=0.2,
+        )
+        config = MemoryMaintenanceConfig(max_entries=2)
+        summary = maintain_memory(memory, config)
+        self.assertEqual(summary["purged_over_cap"], 1)
+        docs = memory.situation_collection.get(include=["documents"])["documents"]
+        self.assertEqual(memory.situation_collection.count(), 2)
+        self.assertNotIn("old weak", docs)
+
+    def test_maintenance_is_idempotent_when_healthy(self):
+        memory = _fresh_memory()
+        _add(memory, "a", [0.1] * 8, trade_date=_days_ago(1))
+        _add(memory, "b", [0.9, -0.4, 0.2, 0.7, -0.1, 0.3, -0.8, 0.6])
+        first = maintain_memory(memory)
+        second = maintain_memory(memory)
+        self.assertEqual(second["purged_expired"], 0)
+        self.assertEqual(second["purged_duplicates"], 0)
+        self.assertEqual(second["purged_over_cap"], 0)
+        self.assertEqual(second["kept"], first["kept"])
+
+    def test_empty_memory_is_noop(self):
+        memory = _fresh_memory()
+        summary = maintain_memory(memory)
+        self.assertEqual(summary["kept"], 0)
+
+
+class ConfigWiringTests(unittest.TestCase):
+    def test_default_config_exposes_maintenance_keys(self):
+        from tradingagents.default_config import DEFAULT_CONFIG
+
+        self.assertIn("memory_maintenance_enabled", DEFAULT_CONFIG)
+        self.assertIn("memory_max_entries_per_collection", DEFAULT_CONFIG)
+
+    def test_config_from_dict_reads_project_config(self):
+        config = MemoryMaintenanceConfig.from_config(
+            {
+                "memory_max_entries_per_collection": 42,
+                "memory_duplicate_similarity_threshold": 0.9,
+            }
+        )
+        self.assertEqual(config.max_entries, 42)
+        self.assertEqual(config.duplicate_similarity, 0.9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_no_owned_deprecation_warnings.py
+++ b/tests/test_no_owned_deprecation_warnings.py
@@ -1,0 +1,40 @@
+"""Our own modules must not emit Pydantic deprecation warnings on import.
+
+Third-party warnings are out of scope; this guards the code we own so it
+keeps working when Pydantic 3 removes the deprecated class-based config.
+"""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+class OwnedDeprecationWarningTests(unittest.TestCase):
+    def test_gpt5_llm_import_emits_no_pydantic_deprecation(self):
+        code = (
+            "import warnings\n"
+            "from pydantic import PydanticDeprecatedSince20\n"
+            "with warnings.catch_warnings():\n"
+            "    warnings.simplefilter('error', PydanticDeprecatedSince20)\n"
+            "    import tradingagents.agents.utils.gpt5_llm\n"
+            "print('CLEAN')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            timeout=300,
+        )
+        self.assertIn(
+            "CLEAN",
+            result.stdout,
+            f"importing gpt5_llm raised a Pydantic deprecation:\n{result.stderr[-2000:]}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portfolio_intelligence.py
+++ b/tests/test_portfolio_intelligence.py
@@ -1,0 +1,239 @@
+"""Tests for the deterministic portfolio-intelligence layer.
+
+The layer sits above the per-symbol agent decisions and adjusts NEW
+position sizes only: positive correlation with existing positions above a
+threshold scales the size down, realized volatility above the target
+scales it down (inverse-volatility / simplified risk parity), and a gross
+exposure cap clips what remains. Factors never size a trade UP, missing
+data never punishes, and only an explicit exposure clip may zero a trade.
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from tradingagents.portfolio import (
+    PortfolioLimitsConfig,
+    adjust_new_position_notional,
+    assess_new_position,
+    daily_returns,
+    realized_daily_vol,
+)
+
+
+def _frame(closes, start="2025-01-06"):
+    dates = pd.bdate_range(start=start, periods=len(closes))
+    closes = list(closes)
+    return pd.DataFrame(
+        {
+            "timestamp": dates,
+            "open": closes,
+            "high": [c * 1.01 for c in closes],
+            "low": [c * 0.99 for c in closes],
+            "close": closes,
+            "volume": [1000.0] * len(closes),
+        }
+    )
+
+
+def _trending(n=80, drift=0.01, noise_seed=7, scale=0.001):
+    rng = np.random.default_rng(noise_seed)
+    returns = drift + rng.normal(0, scale, n)
+    return list(100 * np.cumprod(1 + returns))
+
+
+def _config(**overrides):
+    return PortfolioLimitsConfig(**overrides)
+
+
+class ReturnMathTests(unittest.TestCase):
+    def test_daily_returns_shape(self):
+        returns = daily_returns(_frame([100, 110, 99]))
+        self.assertEqual(len(returns), 2)
+        self.assertAlmostEqual(returns.iloc[0], 0.10)
+
+    def test_realized_vol_of_constant_series_is_zero(self):
+        vol = realized_daily_vol(daily_returns(_frame([100] * 30)))
+        self.assertEqual(vol, 0.0)
+
+
+class CorrelationPenaltyTests(unittest.TestCase):
+    def test_highly_correlated_candidate_is_scaled_down(self):
+        closes = _trending()
+        # Same series shifted in level: correlation ~1.
+        verdict = assess_new_position(
+            symbol="MSFT",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={"AAPL": 20_000.0},
+            price_history={"MSFT": _frame(closes), "AAPL": _frame([c * 2 for c in closes])},
+            config=_config(vol_sizing_enabled=False),
+        )
+        self.assertLess(verdict.adjusted_notional, 10_000.0)
+        self.assertAlmostEqual(
+            verdict.adjusted_notional, 10_000.0 * verdict.config.correlated_size_factor
+        )
+        self.assertTrue(any("correlation" in r.lower() for r in verdict.reasons))
+
+    def test_uncorrelated_candidate_keeps_full_size(self):
+        rng = np.random.default_rng(3)
+        a = list(100 * np.cumprod(1 + rng.normal(0, 0.01, 80)))
+        b = list(100 * np.cumprod(1 + rng.normal(0, 0.01, 80)))
+        verdict = assess_new_position(
+            symbol="GLD",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={"AAPL": 20_000.0},
+            price_history={"GLD": _frame(a), "AAPL": _frame(b)},
+            config=_config(vol_sizing_enabled=False),
+        )
+        self.assertEqual(verdict.adjusted_notional, 10_000.0)
+
+    def test_negative_correlation_is_not_punished(self):
+        closes = _trending()
+        inverse = [200 - c + 100 for c in closes]  # strongly negative corr
+        verdict = assess_new_position(
+            symbol="SH",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={"AAPL": 20_000.0},
+            price_history={"SH": _frame(inverse), "AAPL": _frame(closes)},
+            config=_config(vol_sizing_enabled=False),
+        )
+        self.assertEqual(verdict.adjusted_notional, 10_000.0)
+
+
+class VolatilitySizingTests(unittest.TestCase):
+    def test_high_vol_candidate_is_scaled_down(self):
+        rng = np.random.default_rng(11)
+        wild = list(100 * np.cumprod(1 + rng.normal(0, 0.06, 80)))  # ~6% daily vol
+        verdict = assess_new_position(
+            symbol="MEME",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={},
+            price_history={"MEME": _frame(wild)},
+            config=_config(target_daily_vol_pct=2.0),
+        )
+        self.assertLess(verdict.adjusted_notional, 10_000.0)
+        self.assertTrue(any("volatility" in r.lower() for r in verdict.reasons))
+
+    def test_calm_candidate_is_never_sized_up(self):
+        calm = list(np.linspace(100, 101, 80))  # tiny vol
+        verdict = assess_new_position(
+            symbol="BOND",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={},
+            price_history={"BOND": _frame(calm)},
+            config=_config(target_daily_vol_pct=2.0),
+        )
+        self.assertEqual(verdict.adjusted_notional, 10_000.0)
+
+
+class ExposureCapTests(unittest.TestCase):
+    def test_gross_exposure_headroom_clips_notional(self):
+        verdict = assess_new_position(
+            symbol="NVDA",
+            requested_notional=30_000.0,
+            equity=100_000.0,
+            open_positions={"AAPL": 80_000.0},
+            price_history={},
+            config=_config(max_gross_exposure_pct=100.0),
+        )
+        # Headroom is 100k - 80k = 20k.
+        self.assertEqual(verdict.adjusted_notional, 20_000.0)
+        self.assertTrue(any("exposure" in r.lower() for r in verdict.reasons))
+
+    def test_no_headroom_zeroes_the_trade_with_reason(self):
+        verdict = assess_new_position(
+            symbol="NVDA",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={"AAPL": 100_000.0},
+            price_history={},
+            config=_config(max_gross_exposure_pct=100.0),
+        )
+        self.assertEqual(verdict.adjusted_notional, 0.0)
+        self.assertFalse(verdict.allowed)
+
+
+class RobustnessTests(unittest.TestCase):
+    def test_missing_price_data_keeps_full_size_with_warning(self):
+        verdict = assess_new_position(
+            symbol="NEW",
+            requested_notional=10_000.0,
+            equity=100_000.0,
+            open_positions={"AAPL": 10_000.0},
+            price_history={},  # nothing available
+            config=_config(),
+        )
+        self.assertEqual(verdict.adjusted_notional, 10_000.0)
+        self.assertTrue(verdict.allowed)
+        self.assertTrue(any("unavailable" in r.lower() for r in verdict.reasons))
+
+    def test_min_size_factor_floors_combined_penalties(self):
+        closes = _trending()
+        rng = np.random.default_rng(11)
+        wild = list(
+            np.array(closes) * np.cumprod(1 + rng.normal(0, 0.06, len(closes)))
+        )
+        config = _config(min_size_factor=0.25, target_daily_vol_pct=0.5)
+        verdict = assess_new_position(
+            symbol="MEME",
+            requested_notional=10_000.0,
+            equity=1_000_000.0,
+            open_positions={"AAPL": 10_000.0},
+            price_history={"MEME": _frame(wild), "AAPL": _frame(closes)},
+            config=config,
+        )
+        self.assertGreaterEqual(verdict.adjusted_notional, 2_500.0)
+
+    def test_adjust_helper_only_touches_new_long_exposure(self):
+        # SELL/HOLD and closes pass through untouched even with data present.
+        for action in ("SELL", "HOLD", "NEUTRAL"):
+            amount = adjust_new_position_notional(
+                symbol="AAPL",
+                action=action,
+                requested_notional=5_000.0,
+                gather_state=lambda: (100_000.0, {"MSFT": 50_000.0}, {}),
+                config=_config(),
+            )
+            self.assertEqual(amount, 5_000.0)
+
+    def test_adjust_helper_survives_gather_failure(self):
+        def broken_gather():
+            raise ConnectionError("broker down")
+
+        amount = adjust_new_position_notional(
+            symbol="AAPL",
+            action="BUY",
+            requested_notional=5_000.0,
+            gather_state=broken_gather,
+            config=_config(),
+        )
+        self.assertEqual(amount, 5_000.0)
+
+
+class ConfigTests(unittest.TestCase):
+    def test_default_config_exposes_portfolio_keys(self):
+        from tradingagents.default_config import DEFAULT_CONFIG
+
+        self.assertIn("portfolio_intelligence_enabled", DEFAULT_CONFIG)
+        self.assertIn("portfolio_high_correlation", DEFAULT_CONFIG)
+        self.assertIn("portfolio_max_gross_exposure_pct", DEFAULT_CONFIG)
+
+    def test_from_config_reads_project_keys(self):
+        config = PortfolioLimitsConfig.from_config(
+            {
+                "portfolio_high_correlation": 0.5,
+                "portfolio_max_gross_exposure_pct": 80.0,
+            }
+        )
+        self.assertEqual(config.high_correlation, 0.5)
+        self.assertEqual(config.max_gross_exposure_pct, 80.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_regime_detection.py
+++ b/tests/test_regime_detection.py
@@ -1,0 +1,145 @@
+"""Tests for deterministic market-regime detection.
+
+Three cheap observable dimensions — realized-volatility percentile (with an
+absolute annualized floor), price-vs-SMA trend, and dollar-volume liquidity
+— combine into a regime label and a risk multiplier that only ever shrinks
+position sizes. A regime filter, not a signal generator: hostile regimes
+reduce size, they never flip decisions. Missing data reads as unknown with
+multiplier 1.0.
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from tradingagents.regime import (
+    RegimeConfig,
+    classify_regime,
+    regime_report_block,
+    regime_risk_multiplier,
+)
+
+
+def _frame(closes, volumes=None, start="2024-01-01"):
+    closes = list(closes)
+    dates = pd.bdate_range(start=start, periods=len(closes))
+    volumes = volumes if volumes is not None else [1_000_000.0] * len(closes)
+    return pd.DataFrame(
+        {
+            "timestamp": dates,
+            "open": closes,
+            "high": [c * 1.005 for c in closes],
+            "low": [c * 0.995 for c in closes],
+            "close": closes,
+            "volume": volumes,
+        }
+    )
+
+
+def _calm_uptrend(n=300, seed=5):
+    rng = np.random.default_rng(seed)
+    return list(100 * np.cumprod(1 + 0.0008 + rng.normal(0, 0.004, n)))
+
+
+def _calm_then_crash(n_calm=260, n_crash=40, seed=9):
+    rng = np.random.default_rng(seed)
+    calm = 0.0005 + rng.normal(0, 0.004, n_calm)
+    crash = -0.02 + rng.normal(0, 0.035, n_crash)
+    return list(100 * np.cumprod(1 + np.concatenate([calm, crash])))
+
+
+class ClassificationTests(unittest.TestCase):
+    def test_calm_uptrend_is_favorable_full_size(self):
+        assessment = classify_regime(_frame(_calm_uptrend()), symbol="SPY")
+        self.assertEqual(assessment.trend_state, "up")
+        self.assertIn(assessment.volatility_state, ("calm", "normal"))
+        self.assertEqual(assessment.label, "favorable")
+        self.assertEqual(assessment.risk_multiplier, 1.0)
+
+    def test_volatile_crash_is_hostile_and_shrinks_size(self):
+        assessment = classify_regime(_frame(_calm_then_crash()), symbol="SPY")
+        self.assertEqual(assessment.volatility_state, "turbulent")
+        self.assertEqual(assessment.trend_state, "down")
+        self.assertEqual(assessment.label, "hostile")
+        # 0.5 (turbulent) * 0.75 (downtrend) = 0.375
+        self.assertAlmostEqual(assessment.risk_multiplier, 0.375)
+
+    def test_persistently_wild_asset_hits_absolute_vol_floor(self):
+        # Constant 4% daily noise: its own percentile history is unremarkable,
+        # but ~63% annualized vol must still read as turbulent.
+        rng = np.random.default_rng(2)
+        closes = list(100 * np.cumprod(1 + rng.normal(0, 0.04, 300)))
+        assessment = classify_regime(_frame(closes), symbol="MEME")
+        self.assertEqual(assessment.volatility_state, "turbulent")
+
+    def test_thinning_liquidity_is_flagged_and_penalized(self):
+        closes = _calm_uptrend()
+        volumes = [1_000_000.0] * 240 + [200_000.0] * 60
+        assessment = classify_regime(_frame(closes, volumes), symbol="SMALL")
+        self.assertEqual(assessment.liquidity_state, "thinning")
+        self.assertLess(assessment.risk_multiplier, 1.0)
+
+    def test_insufficient_history_reads_unknown_full_size(self):
+        assessment = classify_regime(_frame(_calm_uptrend(10)), symbol="IPO")
+        self.assertEqual(assessment.volatility_state, "unknown")
+        self.assertEqual(assessment.risk_multiplier, 1.0)
+
+    def test_multiplier_never_below_floor(self):
+        closes = _calm_then_crash()
+        volumes = [1_000_000.0] * 240 + [100_000.0] * 60
+        config = RegimeConfig(min_risk_multiplier=0.3)
+        assessment = classify_regime(_frame(closes, volumes), config=config)
+        self.assertGreaterEqual(assessment.risk_multiplier, 0.3)
+
+    def test_markdown_block_names_all_three_dimensions(self):
+        assessment = classify_regime(_frame(_calm_uptrend()), symbol="SPY")
+        text = assessment.to_markdown()
+        for needle in ("Regime", "Volatility", "Trend", "Liquidity"):
+            self.assertIn(needle, text)
+
+
+class InjectionHelperTests(unittest.TestCase):
+    def test_report_block_uses_injected_loader(self):
+        block = regime_report_block(
+            "SPY", price_loader=lambda symbol, start, end: _frame(_calm_uptrend())
+        )
+        self.assertIn("Market Regime", block)
+        self.assertIn("favorable", block)
+
+    def test_report_block_swallows_loader_failure(self):
+        def broken(symbol, start, end):
+            raise ConnectionError("data source down")
+
+        self.assertEqual(regime_report_block("SPY", price_loader=broken), "")
+
+    def test_risk_multiplier_helper(self):
+        multiplier = regime_risk_multiplier(
+            "SPY", price_loader=lambda symbol, start, end: _frame(_calm_then_crash())
+        )
+        self.assertAlmostEqual(multiplier, 0.375)
+
+    def test_risk_multiplier_helper_failure_is_neutral(self):
+        def broken(symbol, start, end):
+            raise ConnectionError("data source down")
+
+        self.assertEqual(regime_risk_multiplier("SPY", price_loader=broken), 1.0)
+
+
+class ConfigTests(unittest.TestCase):
+    def test_default_config_exposes_regime_keys(self):
+        from tradingagents.default_config import DEFAULT_CONFIG
+
+        self.assertIn("regime_detection_enabled", DEFAULT_CONFIG)
+        self.assertIn("regime_turbulent_size_factor", DEFAULT_CONFIG)
+
+    def test_from_config_reads_project_keys(self):
+        config = RegimeConfig.from_config(
+            {"regime_turbulent_size_factor": 0.4, "regime_trend_window": 30}
+        )
+        self.assertEqual(config.turbulent_size_factor, 0.4)
+        self.assertEqual(config.trend_window, 30)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_risk_position_sizing.py
+++ b/tests/test_risk_position_sizing.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
@@ -12,6 +12,7 @@ from tradingagents.dataflows.alpaca_utils import AlpacaUtils
 from tradingagents.risk.position_sizing import (
     PositionSizer,
     RiskParameters,
+    SizingDecision,
     compute_atr,
     kelly_position_fraction,
 )
@@ -302,6 +303,37 @@ class ExecuteTradeIntentRiskSizingTests(unittest.TestCase):
         self.assertIn("risk", result["error"].lower())
         execute.assert_not_called()
 
+    def test_risk_sizing_stop_is_forwarded_to_protective_order_execution(self):
+        sizing = SizingDecision(
+            approved=True,
+            notional=1_000.0,
+            stop_loss_price=95.0,
+            risk_amount=50.0,
+            caps_applied=["requested_notional"],
+            reason="test",
+        )
+        with patch.object(
+            AlpacaUtils, "compute_risk_sized_amount", return_value=sizing
+        ), patch.object(
+            AlpacaUtils,
+            "execute_trading_action",
+            return_value={"success": True, "symbol": "AAPL", "actions": []},
+        ) as execute:
+            result = AlpacaUtils.execute_trade_intent(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                trade_intent=_buy_intent(),
+                dollar_amount=1_000.0,
+                allow_shorts=False,
+                risk_params={},
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(
+            execute.call_args.kwargs["protective_prices"]["stop_loss_price"],
+            95.0,
+        )
+
     def test_risk_engine_data_failure_fails_open_with_warning(self):
         with patch.object(
             AlpacaUtils,
@@ -363,6 +395,28 @@ class ExecuteTradeIntentRiskSizingTests(unittest.TestCase):
         snapshot.assert_not_called()
         self.assertEqual(execute.call_args.kwargs["dollar_amount"], 10_000)
 
+    def test_risk_sizing_skipped_when_target_position_is_already_held(self):
+        with patch.object(
+            AlpacaUtils, "get_account_risk_snapshot"
+        ) as snapshot, patch.object(
+            AlpacaUtils,
+            "execute_trading_action",
+            return_value={"success": True, "symbol": "AAPL", "actions": []},
+        ) as execute:
+            result = AlpacaUtils.execute_trade_intent(
+                symbol="AAPL",
+                current_position="LONG",
+                trade_intent=_buy_intent(),
+                dollar_amount=10_000,
+                allow_shorts=False,
+                risk_params={},
+            )
+
+        self.assertTrue(result["success"])
+        snapshot.assert_not_called()
+        self.assertNotIn("risk_sizing", result)
+        self.assertEqual(execute.call_args.kwargs["dollar_amount"], 10_000)
+
     def test_default_call_without_risk_params_preserves_legacy_behavior(self):
         with patch.object(
             AlpacaUtils,
@@ -400,6 +454,27 @@ class CalcQtyPriceFailureTests(unittest.TestCase):
         buy_action = result["actions"][0]
         self.assertFalse(buy_action["result"]["success"])
         self.assertIn("price", buy_action["result"]["error"].lower())
+
+    def test_budget_below_one_share_does_not_exceed_the_notional_cap(self):
+        disabled_guard = MagicMock()
+        disabled_guard.enabled = False
+        with patch(
+            "tradingagents.safety.get_safety_guard", return_value=disabled_guard
+        ), patch.object(
+            AlpacaUtils,
+            "get_latest_quote",
+            return_value={"bid_price": 500.0, "ask_price": 501.0},
+        ), patch.object(AlpacaUtils, "place_market_order") as place_order:
+            result = AlpacaUtils.execute_trading_action(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                signal="BUY",
+                dollar_amount=100.0,
+                allow_shorts=False,
+            )
+
+        self.assertFalse(result["success"])
+        place_order.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_risk_position_sizing.py
+++ b/tests/test_risk_position_sizing.py
@@ -1,0 +1,406 @@
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+from tradingagents.agents.schemas import (
+    ExecutableAction,
+    RiskDecision,
+    build_trade_intent_from_risk_decision,
+)
+from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+from tradingagents.risk.position_sizing import (
+    PositionSizer,
+    RiskParameters,
+    compute_atr,
+    kelly_position_fraction,
+)
+
+
+def _bars(highs, lows, closes):
+    return pd.DataFrame({"high": highs, "low": lows, "close": closes})
+
+
+def _constant_bars(rows=20, high=101.0, low=99.0, close=100.0):
+    return _bars([high] * rows, [low] * rows, [close] * rows)
+
+
+class ComputeAtrTests(unittest.TestCase):
+    def test_matches_wilder_smoothing_reference_values(self):
+        bars = _bars(
+            highs=[101, 103, 102, 104, 103.5, 105],
+            lows=[99, 101, 100, 102, 101.5, 103],
+            closes=[100, 102, 101, 103, 102.5, 104],
+        )
+        # TRs from the 2nd row: 3, 2, 3, 2, 2.5
+        # ATR(3) seed = mean(3, 2, 3) = 8/3
+        # then (8/3*2 + 2)/3 = 22/9, then (22/9*2 + 2.5)/3 = 66.5/27
+        atr = compute_atr(bars, period=3)
+        self.assertAlmostEqual(atr, 66.5 / 27, places=6)
+
+    def test_constant_range_bars_give_constant_atr(self):
+        atr = compute_atr(_constant_bars(), period=14)
+        self.assertAlmostEqual(atr, 2.0, places=9)
+
+    def test_insufficient_rows_returns_none(self):
+        self.assertIsNone(compute_atr(_constant_bars(rows=3), period=14))
+
+    def test_empty_or_malformed_data_returns_none(self):
+        self.assertIsNone(compute_atr(pd.DataFrame(), period=14))
+        self.assertIsNone(compute_atr(None, period=14))
+        missing_cols = pd.DataFrame({"close": [1.0] * 30})
+        self.assertIsNone(compute_atr(missing_cols, period=14))
+
+    def test_non_positive_result_returns_none(self):
+        flat = _bars([100.0] * 20, [100.0] * 20, [100.0] * 20)
+        self.assertIsNone(compute_atr(flat, period=14))
+
+
+class KellyFractionTests(unittest.TestCase):
+    def test_positive_edge_scaled_by_fraction(self):
+        # full Kelly = 0.55 - 0.45/1.5 = 0.25 ; half Kelly = 0.125
+        self.assertAlmostEqual(
+            kelly_position_fraction(0.55, 1.5, kelly_fraction=0.5), 0.125, places=9
+        )
+
+    def test_negative_edge_clamps_to_zero(self):
+        self.assertEqual(kelly_position_fraction(0.40, 1.0, kelly_fraction=0.5), 0.0)
+
+    def test_invalid_inputs_clamp_to_zero(self):
+        self.assertEqual(kelly_position_fraction(0.55, 0.0, kelly_fraction=0.5), 0.0)
+        self.assertEqual(kelly_position_fraction(0.55, -2.0, kelly_fraction=0.5), 0.0)
+        self.assertEqual(kelly_position_fraction(0.0, 1.5, kelly_fraction=0.5), 0.0)
+        self.assertEqual(kelly_position_fraction(1.2, 1.5, kelly_fraction=0.5), 0.0)
+
+
+class PositionSizerTests(unittest.TestCase):
+    def setUp(self):
+        self.sizer = PositionSizer(RiskParameters())
+
+    def test_kelly_cap_binds_when_smallest(self):
+        # equity=100k, price=100, atr=2, stop=4 -> risk notional 25k
+        # kelly(high)=0.125 -> 12.5k ; max position 20% -> 20k ; requested 50k
+        decision = self.sizer.size_position(
+            equity=100_000.0,
+            price=100.0,
+            atr=2.0,
+            confidence="high",
+            requested_notional=50_000.0,
+        )
+        self.assertTrue(decision.approved)
+        self.assertAlmostEqual(decision.notional, 12_500.0, places=2)
+        self.assertIn("kelly", decision.caps_applied)
+        self.assertAlmostEqual(decision.stop_loss_price, 96.0, places=6)
+        self.assertAlmostEqual(decision.risk_amount, 500.0, places=2)
+
+    def test_requested_notional_is_a_hard_ceiling(self):
+        decision = self.sizer.size_position(
+            equity=100_000.0,
+            price=100.0,
+            atr=2.0,
+            confidence="high",
+            requested_notional=1_000.0,
+        )
+        self.assertTrue(decision.approved)
+        self.assertLessEqual(decision.notional, 1_000.0)
+        self.assertIn("requested_notional", decision.caps_applied)
+
+    def test_total_exposure_limit_blocks_new_position(self):
+        decision = self.sizer.size_position(
+            equity=100_000.0,
+            price=100.0,
+            atr=2.0,
+            confidence="high",
+            requested_notional=10_000.0,
+            current_gross_exposure=79_995.0,
+        )
+        self.assertFalse(decision.approved)
+        self.assertEqual(decision.notional, 0.0)
+        self.assertIn("exposure", decision.reason.lower())
+
+    def test_missing_atr_uses_conservative_default_stop(self):
+        decision = self.sizer.size_position(
+            equity=100_000.0,
+            price=100.0,
+            atr=None,
+            confidence="high",
+            requested_notional=50_000.0,
+        )
+        self.assertTrue(decision.approved)
+        self.assertIn("atr_unavailable_default_stop", decision.caps_applied)
+        # default stop distance = 5% of price
+        self.assertAlmostEqual(decision.stop_loss_price, 95.0, places=6)
+
+    def test_sell_side_places_stop_above_price(self):
+        decision = self.sizer.size_position(
+            equity=100_000.0,
+            price=100.0,
+            atr=2.0,
+            confidence="high",
+            requested_notional=10_000.0,
+            side="sell",
+        )
+        self.assertTrue(decision.approved)
+        self.assertAlmostEqual(decision.stop_loss_price, 104.0, places=6)
+
+    def test_unknown_confidence_falls_back_to_most_conservative_edge(self):
+        low = self.sizer.size_position(
+            equity=100_000.0,
+            price=100.0,
+            atr=2.0,
+            confidence="low",
+            requested_notional=50_000.0,
+        )
+        unknown = self.sizer.size_position(
+            equity=100_000.0,
+            price=100.0,
+            atr=2.0,
+            confidence="galactic",
+            requested_notional=50_000.0,
+        )
+        self.assertAlmostEqual(unknown.notional, low.notional, places=6)
+
+    def test_invalid_inputs_are_rejected(self):
+        for kwargs in (
+            {"equity": 0.0, "price": 100.0},
+            {"equity": -5.0, "price": 100.0},
+            {"equity": 100_000.0, "price": 0.0},
+            {"equity": 100_000.0, "price": -1.0},
+        ):
+            with self.subTest(kwargs=kwargs):
+                decision = self.sizer.size_position(
+                    atr=2.0,
+                    confidence="high",
+                    requested_notional=1_000.0,
+                    **kwargs,
+                )
+                self.assertFalse(decision.approved)
+                self.assertEqual(decision.notional, 0.0)
+
+    def test_result_below_minimum_notional_is_rejected(self):
+        decision = self.sizer.size_position(
+            equity=50.0,
+            price=100.0,
+            atr=2.0,
+            confidence="high",
+            requested_notional=1_000.0,
+        )
+        self.assertFalse(decision.approved)
+        self.assertIn("minimum", decision.reason.lower())
+
+
+class AccountRiskSnapshotTests(unittest.TestCase):
+    def test_snapshot_aggregates_equity_and_gross_exposure(self):
+        class FakePosition:
+            def __init__(self, market_value):
+                self.market_value = market_value
+
+        class FakeAccount:
+            equity = "100000"
+
+        class FakeClient:
+            def get_account(self):
+                return FakeAccount()
+
+            def get_all_positions(self):
+                return [FakePosition("2500.5"), FakePosition("-1500.25")]
+
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
+            return_value=FakeClient(),
+        ):
+            snapshot = AlpacaUtils.get_account_risk_snapshot()
+
+        self.assertAlmostEqual(snapshot["equity"], 100_000.0, places=2)
+        self.assertAlmostEqual(snapshot["gross_exposure"], 4_000.75, places=2)
+
+    def test_snapshot_failure_raises(self):
+        class BrokenClient:
+            def get_account(self):
+                raise RuntimeError("alpaca down")
+
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
+            return_value=BrokenClient(),
+        ):
+            with self.assertRaises(Exception):
+                AlpacaUtils.get_account_risk_snapshot()
+
+
+def _buy_intent(confidence="high"):
+    return build_trade_intent_from_risk_decision(
+        symbol="AAPL",
+        trading_mode="investment",
+        current_position="NEUTRAL",
+        allow_shorts=False,
+        trade_date="2026-01-02",
+        decision=RiskDecision(
+            action=ExecutableAction.BUY,
+            confidence=confidence,
+            risk_rationale="Buy setup.",
+            required_controls="Stop below support.",
+        ),
+    ).model_dump(mode="json")
+
+
+class ExecuteTradeIntentRiskSizingTests(unittest.TestCase):
+    def test_risk_sizing_shrinks_dollar_amount_before_execution(self):
+        with patch.object(
+            AlpacaUtils,
+            "get_account_risk_snapshot",
+            return_value={"equity": 100_000.0, "gross_exposure": 0.0},
+        ), patch.object(
+            AlpacaUtils, "get_stock_data_window", return_value=_constant_bars()
+        ), patch.object(
+            AlpacaUtils,
+            "get_latest_quote",
+            return_value={"bid_price": 100.0, "ask_price": 100.0},
+        ), patch.object(
+            AlpacaUtils,
+            "execute_trading_action",
+            return_value={"success": True, "symbol": "AAPL", "actions": []},
+        ) as execute:
+            result = AlpacaUtils.execute_trade_intent(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                trade_intent=_buy_intent(),
+                dollar_amount=50_000,
+                allow_shorts=False,
+                risk_params={},
+            )
+
+        self.assertTrue(result["success"])
+        sizing = result["risk_sizing"]
+        self.assertTrue(sizing["applied"])
+        self.assertAlmostEqual(sizing["notional"], 12_500.0, places=2)
+        self.assertAlmostEqual(
+            execute.call_args.kwargs["dollar_amount"], 12_500.0, places=2
+        )
+
+    def test_risk_sizing_rejection_blocks_order_submission(self):
+        with patch.object(
+            AlpacaUtils,
+            "get_account_risk_snapshot",
+            return_value={"equity": 100_000.0, "gross_exposure": 79_995.0},
+        ), patch.object(
+            AlpacaUtils, "get_stock_data_window", return_value=_constant_bars()
+        ), patch.object(
+            AlpacaUtils,
+            "get_latest_quote",
+            return_value={"bid_price": 100.0, "ask_price": 100.0},
+        ), patch.object(AlpacaUtils, "execute_trading_action") as execute:
+            result = AlpacaUtils.execute_trade_intent(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                trade_intent=_buy_intent(),
+                dollar_amount=10_000,
+                allow_shorts=False,
+                risk_params={},
+            )
+
+        self.assertFalse(result["success"])
+        self.assertIn("risk", result["error"].lower())
+        execute.assert_not_called()
+
+    def test_risk_engine_data_failure_fails_open_with_warning(self):
+        with patch.object(
+            AlpacaUtils,
+            "get_account_risk_snapshot",
+            side_effect=RuntimeError("alpaca down"),
+        ), patch.object(
+            AlpacaUtils,
+            "execute_trading_action",
+            return_value={"success": True, "symbol": "AAPL", "actions": []},
+        ) as execute:
+            result = AlpacaUtils.execute_trade_intent(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                trade_intent=_buy_intent(),
+                dollar_amount=50_000,
+                allow_shorts=False,
+                risk_params={},
+            )
+
+        self.assertTrue(result["success"])
+        self.assertFalse(result["risk_sizing"]["applied"])
+        self.assertEqual(execute.call_args.kwargs["dollar_amount"], 50_000)
+        self.assertTrue(
+            any("risk sizing" in w.lower() for w in result["intent_warnings"])
+        )
+
+    def test_risk_sizing_skipped_for_closing_actions(self):
+        intent = build_trade_intent_from_risk_decision(
+            symbol="AAPL",
+            trading_mode="investment",
+            current_position="LONG",
+            allow_shorts=False,
+            trade_date="2026-01-02",
+            decision=RiskDecision(
+                action=ExecutableAction.SELL,
+                confidence="high",
+                risk_rationale="Exit.",
+                required_controls="None.",
+            ),
+        ).model_dump(mode="json")
+
+        with patch.object(
+            AlpacaUtils, "get_account_risk_snapshot"
+        ) as snapshot, patch.object(
+            AlpacaUtils,
+            "execute_trading_action",
+            return_value={"success": True, "symbol": "AAPL", "actions": []},
+        ) as execute:
+            result = AlpacaUtils.execute_trade_intent(
+                symbol="AAPL",
+                current_position="LONG",
+                trade_intent=intent,
+                dollar_amount=10_000,
+                allow_shorts=False,
+                risk_params={},
+            )
+
+        self.assertTrue(result["success"])
+        snapshot.assert_not_called()
+        self.assertEqual(execute.call_args.kwargs["dollar_amount"], 10_000)
+
+    def test_default_call_without_risk_params_preserves_legacy_behavior(self):
+        with patch.object(
+            AlpacaUtils,
+            "execute_trading_action",
+            return_value={"success": True, "symbol": "AAPL", "actions": []},
+        ) as execute:
+            result = AlpacaUtils.execute_trade_intent(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                trade_intent=_buy_intent(),
+                dollar_amount=1_000,
+                allow_shorts=False,
+            )
+
+        self.assertTrue(result["success"])
+        self.assertNotIn("risk_sizing", result)
+        self.assertEqual(execute.call_args.kwargs["dollar_amount"], 1_000)
+
+
+class CalcQtyPriceFailureTests(unittest.TestCase):
+    def test_buy_without_price_data_fails_instead_of_guessing_quantity(self):
+        with patch.object(
+            AlpacaUtils, "get_latest_quote", return_value={}
+        ), patch.object(AlpacaUtils, "place_market_order") as place_order:
+            result = AlpacaUtils.execute_trading_action(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                signal="BUY",
+                dollar_amount=1_000,
+                allow_shorts=False,
+            )
+
+        place_order.assert_not_called()
+        self.assertFalse(result["success"])
+        buy_action = result["actions"][0]
+        self.assertFalse(buy_action["result"]["success"])
+        self.assertIn("price", buy_action["result"]["error"].lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_safety_guardrails.py
+++ b/tests/test_safety_guardrails.py
@@ -127,6 +127,29 @@ class CircuitBreakerTests(unittest.TestCase):
             guard.record_order_result(True)
             self.assertTrue(guard.check_order("AAPL", 100.0, account=ACCOUNT_OK).allowed)
 
+    def test_risk_reducing_exit_bypasses_breakers_but_not_kill_switch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_consecutive_rejections=1)
+            guard.record_order_result(False)
+
+            exit_verdict = guard.check_order(
+                "AAPL",
+                0.0,
+                account={"equity": 80_000.0, "last_equity": 100_000.0},
+                risk_reducing=True,
+            )
+            self.assertTrue(exit_verdict.allowed)
+            self.assertEqual(
+                exit_verdict.checks["daily_loss"]["status"], "skipped"
+            )
+
+            guard.engage_kill_switch("operator halt")
+            self.assertFalse(
+                guard.check_order(
+                    "AAPL", 0.0, risk_reducing=True
+                ).allowed
+            )
+
 
 class LLMBudgetTests(unittest.TestCase):
     def test_budget_exhaustion_blocks_new_analysis(self):
@@ -249,6 +272,57 @@ class ExecutionIntegrationTests(unittest.TestCase):
             )
 
         guard.record_order_result.assert_called_with(True)
+
+    def test_loss_breaker_does_not_trap_an_existing_position(self):
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_consecutive_rejections=1)
+            guard.record_order_result(False)
+            with patch(
+                "tradingagents.safety.get_safety_guard", return_value=guard
+            ), patch.object(
+                AlpacaUtils,
+                "close_position",
+                return_value={"success": True},
+            ) as close_position:
+                result = AlpacaUtils.execute_trading_action(
+                    symbol="AAPL",
+                    current_position="LONG",
+                    signal="SELL",
+                    dollar_amount=10_000.0,
+                    allow_shorts=False,
+                )
+
+        self.assertTrue(result["success"])
+        close_position.assert_called_once_with("AAPL")
+
+    def test_position_flip_closes_first_then_blocks_new_exposure(self):
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_trade_notional_usd=100.0)
+            with patch(
+                "tradingagents.safety.get_safety_guard", return_value=guard
+            ), patch.object(
+                AlpacaUtils,
+                "close_position",
+                return_value={"success": True},
+            ) as close_position, patch.object(
+                AlpacaUtils, "place_market_order"
+            ) as place_order:
+                result = AlpacaUtils.execute_trading_action(
+                    symbol="AAPL",
+                    current_position="LONG",
+                    signal="SHORT",
+                    dollar_amount=1_000.0,
+                    allow_shorts=True,
+                )
+
+        self.assertFalse(result["success"])
+        self.assertTrue(result["safety_blocked"])
+        close_position.assert_called_once_with("AAPL")
+        place_order.assert_not_called()
 
 
 class RunLoggerBudgetFeedTests(unittest.TestCase):

--- a/tests/test_safety_guardrails.py
+++ b/tests/test_safety_guardrails.py
@@ -1,0 +1,281 @@
+"""Tests for the deterministic production safety layer.
+
+The safety layer is intentionally independent of agent logic: every check is
+pure arithmetic over injected account/order state, so nothing here mocks an
+LLM. Each guard is exercised on both sides of its threshold.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tradingagents.safety import (
+    DEFAULT_SAFETY_CONFIG,
+    SafetyGuard,
+    SafetyVerdict,
+    get_safety_guard,
+    reset_safety_guard,
+)
+
+
+def make_guard(tmp, **overrides):
+    config = dict(DEFAULT_SAFETY_CONFIG)
+    config.update(overrides)
+    return SafetyGuard(
+        config=config,
+        state_path=Path(tmp) / "state.json",
+        kill_switch_path=Path(tmp) / "KILL_SWITCH",
+    )
+
+
+ACCOUNT_OK = {"equity": 100_000.0, "last_equity": 100_000.0}
+
+
+class KillSwitchTests(unittest.TestCase):
+    def test_engage_blocks_all_orders_and_release_restores(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp)
+            self.assertTrue(guard.check_order("AAPL", 100.0, account=ACCOUNT_OK).allowed)
+
+            guard.engage_kill_switch("manual test halt")
+            verdict = guard.check_order("AAPL", 100.0, account=ACCOUNT_OK)
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("kill switch" in r.lower() for r in verdict.reasons))
+            self.assertIn("manual test halt", guard.kill_switch_reason())
+
+            guard.release_kill_switch()
+            self.assertFalse(guard.kill_switch_active())
+            self.assertTrue(guard.check_order("AAPL", 100.0, account=ACCOUNT_OK).allowed)
+
+    def test_kill_switch_file_created_externally_is_honored(self):
+        # Ops can halt trading by touching the file - no Python required.
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "KILL_SWITCH").write_text("halted by ops", encoding="utf-8")
+            guard = make_guard(tmp)
+            self.assertTrue(guard.kill_switch_active())
+            self.assertFalse(guard.check_order("AAPL", 100.0).allowed)
+
+
+class PreTradeCheckTests(unittest.TestCase):
+    def test_notional_above_cap_is_blocked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_trade_notional_usd=5_000.0)
+            self.assertTrue(guard.check_order("AAPL", 5_000.0, account=ACCOUNT_OK).allowed)
+            verdict = guard.check_order("AAPL", 5_000.01, account=ACCOUNT_OK)
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("notional" in r.lower() for r in verdict.reasons))
+
+    def test_concentration_limit_counts_existing_position(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_symbol_concentration_pct=25.0)
+            # 20k existing + 10k new = 30% of 100k equity -> blocked
+            verdict = guard.check_order(
+                "AAPL", 10_000.0, account=ACCOUNT_OK, position_value=20_000.0
+            )
+            self.assertFalse(verdict.allowed)
+            # 20k existing + 4k new = 24% -> allowed
+            self.assertTrue(
+                guard.check_order(
+                    "AAPL", 4_000.0, account=ACCOUNT_OK, position_value=20_000.0
+                ).allowed
+            )
+
+    def test_concentration_skipped_without_account_data(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_symbol_concentration_pct=25.0)
+            verdict = guard.check_order("AAPL", 1_000.0, position_value=90_000.0)
+            self.assertTrue(verdict.allowed)
+            self.assertEqual(verdict.checks["concentration"]["status"], "skipped")
+
+
+class CircuitBreakerTests(unittest.TestCase):
+    def test_daily_loss_breaker_trips_beyond_threshold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, daily_loss_halt_pct=10.0)
+            ok = {"equity": 95_000.0, "last_equity": 100_000.0}  # -5%
+            self.assertTrue(guard.check_order("AAPL", 100.0, account=ok).allowed)
+            tripped = {"equity": 89_000.0, "last_equity": 100_000.0}  # -11%
+            verdict = guard.check_order("AAPL", 100.0, account=tripped)
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("daily loss" in r.lower() for r in verdict.reasons))
+
+    def test_drawdown_breaker_uses_persisted_high_water_mark(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_drawdown_halt_pct=15.0)
+            # Establish a 120k high-water mark.
+            guard.check_order("AAPL", 100.0, account={"equity": 120_000.0, "last_equity": 120_000.0})
+
+            # A fresh instance must read the same HWM from disk.
+            guard2 = make_guard(tmp, max_drawdown_halt_pct=15.0)
+            verdict = guard2.check_order(
+                "AAPL", 100.0, account={"equity": 100_000.0, "last_equity": 100_000.0}
+            )  # -16.7% from HWM
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("drawdown" in r.lower() for r in verdict.reasons))
+
+    def test_consecutive_rejections_trip_and_success_resets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, max_consecutive_rejections=3)
+            for _ in range(3):
+                guard.record_order_result(False)
+            verdict = guard.check_order("AAPL", 100.0, account=ACCOUNT_OK)
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("rejected" in r.lower() for r in verdict.reasons))
+
+            guard.record_order_result(True)
+            self.assertTrue(guard.check_order("AAPL", 100.0, account=ACCOUNT_OK).allowed)
+
+
+class LLMBudgetTests(unittest.TestCase):
+    def test_budget_exhaustion_blocks_new_analysis(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, daily_llm_token_budget=1_000_000)
+            guard.record_llm_tokens(400_000, when="2026-07-11")
+            self.assertTrue(guard.check_llm_budget(when="2026-07-11").allowed)
+            guard.record_llm_tokens(700_000, when="2026-07-11")
+            verdict = guard.check_llm_budget(when="2026-07-11")
+            self.assertFalse(verdict.allowed)
+            self.assertTrue(any("budget" in r.lower() for r in verdict.reasons))
+
+    def test_budget_resets_each_day(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, daily_llm_token_budget=1_000_000)
+            guard.record_llm_tokens(2_000_000, when="2026-07-10")
+            self.assertTrue(guard.check_llm_budget(when="2026-07-11").allowed)
+
+    def test_zero_budget_means_unlimited(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, daily_llm_token_budget=0)
+            guard.record_llm_tokens(10_000_000, when="2026-07-11")
+            self.assertTrue(guard.check_llm_budget(when="2026-07-11").allowed)
+
+    def test_token_usage_persists_across_instances(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            make_guard(tmp).record_llm_tokens(123, when="2026-07-11")
+            self.assertEqual(
+                make_guard(tmp).llm_tokens_used(when="2026-07-11"), 123
+            )
+
+
+class StatusAndTogglesTests(unittest.TestCase):
+    def test_disabled_safety_allows_everything(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp, safety_enabled=False, max_trade_notional_usd=1.0)
+            guard.engage_kill_switch("halt")
+            verdict = guard.check_order("AAPL", 1_000_000.0, account=ACCOUNT_OK)
+            self.assertTrue(verdict.allowed)
+
+    def test_status_reports_every_guard(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = make_guard(tmp)
+            status = guard.status(account={"equity": 89_000.0, "last_equity": 100_000.0})
+            for name in (
+                "kill_switch",
+                "trade_notional",
+                "concentration",
+                "daily_loss",
+                "drawdown",
+                "rejection_streak",
+                "llm_budget",
+            ):
+                self.assertIn(name, status["guards"], name)
+            self.assertFalse(status["guards"]["daily_loss"]["ok"])  # -11% today
+            self.assertTrue(status["guards"]["kill_switch"]["ok"])
+
+    def test_singleton_helper_returns_guard_and_resets(self):
+        reset_safety_guard()
+        guard = get_safety_guard()
+        self.assertIsInstance(guard, SafetyGuard)
+        self.assertIs(guard, get_safety_guard())
+        reset_safety_guard()
+
+
+class ExecutionIntegrationTests(unittest.TestCase):
+    """execute_trading_action must consult the safety layer before any order."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Importing dataflows first trips a known circular import on main;
+        # importing agents first is the production-safe order.
+        import tradingagents.agents  # noqa: F401
+
+    def _blocked_guard(self):
+        guard = MagicMock(spec=SafetyGuard)
+        guard.enabled = True
+        guard.check_order.return_value = SafetyVerdict(
+            allowed=False, reasons=["max trade notional exceeded"]
+        )
+        return guard
+
+    def test_blocked_verdict_prevents_broker_calls(self):
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        guard = self._blocked_guard()
+        with patch("tradingagents.safety.get_safety_guard", return_value=guard), patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client"
+        ) as client_factory:
+            result = AlpacaUtils.execute_trading_action(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                signal="BUY",
+                dollar_amount=1_000_000.0,
+                allow_shorts=False,
+            )
+
+        self.assertFalse(result["success"])
+        self.assertTrue(result.get("safety_blocked"))
+        self.assertIn("max trade notional exceeded", result["error"])
+        client_factory.assert_not_called()
+
+    def test_order_results_feed_rejection_tracker(self):
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        guard = MagicMock(spec=SafetyGuard)
+        guard.enabled = True
+        guard.check_order.return_value = SafetyVerdict(allowed=True)
+        with patch("tradingagents.safety.get_safety_guard", return_value=guard), patch.object(
+            AlpacaUtils, "place_market_order", return_value={"success": True}
+        ), patch.object(
+            AlpacaUtils, "get_latest_quote", return_value={"bid_price": 100.0}
+        ):
+            AlpacaUtils.execute_trading_action(
+                symbol="AAPL",
+                current_position="NEUTRAL",
+                signal="BUY",
+                dollar_amount=1_000.0,
+                allow_shorts=False,
+            )
+
+        guard.record_order_result.assert_called_with(True)
+
+
+class RunLoggerBudgetFeedTests(unittest.TestCase):
+    def test_llm_call_events_feed_token_counter(self):
+        import os
+
+        from tradingagents.run_logger import RunAuditLogger
+
+        guard = MagicMock(spec=SafetyGuard)
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)  # RunAuditLogger writes to ./eval_results
+            try:
+                with patch("tradingagents.safety.get_safety_guard", return_value=guard):
+                    logger = RunAuditLogger()
+                    run_id = logger.start_run(symbol="AAPL", trade_date="2026-07-11")
+                    logger.log_event(
+                        "llm_call",
+                        symbol="AAPL",
+                        run_id=run_id,
+                        payload={"usage": {"total_tokens": 555}},
+                    )
+            finally:
+                os.chdir(cwd)
+
+        guard.record_llm_tokens.assert_called_with(555)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_safety_webui.py
+++ b/tests/test_safety_webui.py
@@ -1,0 +1,94 @@
+"""Wiring tests for the safety guardrails WebUI panel and callbacks."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tradingagents.safety import DEFAULT_SAFETY_CONFIG, SafetyGuard
+
+
+def _guard(tmp, **overrides):
+    config = dict(DEFAULT_SAFETY_CONFIG)
+    config.update(overrides)
+    return SafetyGuard(
+        config=config,
+        state_path=Path(tmp) / "state.json",
+        kill_switch_path=Path(tmp) / "KILL_SWITCH",
+    )
+
+
+class SafetyPanelWiringTests(unittest.TestCase):
+    def test_panel_component_builds(self):
+        from webui.components.safety_panel import create_safety_panel
+
+        rendered = str(create_safety_panel())
+        for component_id in (
+            "safety-status-container",
+            "safety-kill-switch-btn",
+            "safety-release-btn",
+            "safety-refresh-interval",
+            "safety-action-status",
+        ):
+            self.assertIn(component_id, rendered)
+
+    def test_callbacks_register_on_fresh_app(self):
+        import dash
+
+        from webui.callbacks.safety_callbacks import register_safety_callbacks
+
+        app = dash.Dash(__name__, suppress_callback_exceptions=True)
+        register_safety_callbacks(app)
+        self.assertTrue(
+            any("safety-status-container" in key for key in app.callback_map),
+            f"safety callback missing from callback map: {list(app.callback_map)}",
+        )
+
+    def test_status_cards_render_green_and_red(self):
+        from webui.callbacks.safety_callbacks import _status_cards
+
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            healthy = str(
+                _status_cards(
+                    guard.status(account={"equity": 100_000.0, "last_equity": 100_000.0})
+                )
+            )
+            self.assertIn("Kill Switch", healthy)
+            self.assertIn("LLM Budget", healthy)
+            self.assertIn("fa-check-circle", healthy)
+
+            guard.engage_kill_switch("test halt")
+            tripped = str(
+                _status_cards(
+                    guard.status(account={"equity": 100_000.0, "last_equity": 100_000.0})
+                )
+            )
+            self.assertIn("fa-exclamation-triangle", tripped)
+            self.assertIn("test halt", tripped)
+
+    def test_analysis_start_is_gated_by_llm_budget(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp, daily_llm_token_budget=100)
+            guard.record_llm_tokens(500)
+            with patch("tradingagents.safety.get_safety_guard", return_value=guard):
+                from webui.components.analysis import start_analysis
+
+                message = start_analysis(
+                    ticker="AAPL",
+                    analysts_market=True,
+                    analysts_social=False,
+                    analysts_news=False,
+                    analysts_fundamentals=False,
+                    analysts_macro=False,
+                    research_depth="Shallow",
+                    allow_shorts=False,
+                    quick_llm="gpt-test",
+                    deep_llm="gpt-test",
+                )
+            self.assertIsInstance(message, str)
+            self.assertIn("budget", message.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_self_learning_memory.py
+++ b/tests/test_self_learning_memory.py
@@ -1,0 +1,249 @@
+"""Tests for the self-learning memory loop: persistence, snapshot recovery,
+and outcome-driven reflection into the per-agent ChromaDB memories."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from tradingagents.agents.utils.memory import FinancialSituationMemory
+from tradingagents.graph.reflection import Reflector
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.run_logger import load_final_state_snapshot
+
+
+def _fake_embedding(text):
+    # Deterministic 8-dim embedding so similar texts produce similar vectors.
+    seed = float(sum(ord(c) for c in text) % 97)
+    return [seed / 97.0 + i * 0.01 for i in range(8)]
+
+
+def _enable_fake_embeddings(memory):
+    memory.embeddings_enabled = True
+    memory.get_embedding = _fake_embedding
+
+
+class MemoryPersistenceTests(unittest.TestCase):
+    def test_default_memory_stays_in_process(self):
+        memory = FinancialSituationMemory("ephemeral_test_memory")
+        self.assertEqual(type(memory.chroma_client).__name__, "Client")
+
+    def test_persistent_memory_survives_reopen(self):
+        # ignore_cleanup_errors: chromadb keeps its store files open on
+        # Windows, so temp-dir removal can race the process handle.
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            config = {"agent_memory_dir": tmp}
+
+            first = FinancialSituationMemory("persist_test_memory", config)
+            _enable_fake_embeddings(first)
+            first.add_situations(
+                [("High inflation with rising rates", "Prefer defensive sectors")]
+            )
+            self.assertEqual(first.situation_collection.count(), 1)
+
+            second = FinancialSituationMemory("persist_test_memory", config)
+            _enable_fake_embeddings(second)
+            self.assertEqual(second.situation_collection.count(), 1)
+
+            matches = second.get_memories("High inflation with rising rates", n_matches=1)
+            self.assertEqual(len(matches), 1)
+            self.assertEqual(matches[0]["recommendation"], "Prefer defensive sectors")
+
+    def test_ids_do_not_collide_across_instances(self):
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            config = {"agent_memory_dir": tmp}
+            for i in range(3):
+                memory = FinancialSituationMemory("collision_test_memory", config)
+                _enable_fake_embeddings(memory)
+                memory.add_situations([(f"situation {i}", f"advice {i}")])
+            final = FinancialSituationMemory("collision_test_memory", config)
+            self.assertEqual(final.situation_collection.count(), 3)
+
+    def test_empty_agent_memory_dir_means_ephemeral(self):
+        memory = FinancialSituationMemory("cfg_test_memory", {"agent_memory_dir": ""})
+        self.assertEqual(type(memory.chroma_client).__name__, "Client")
+
+
+def _write_run(root, symbol, trade_date, status="completed", final_state=None, started_at=None):
+    runs_dir = Path(root) / symbol / "TradingAgentsStrategy_logs" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    started = started_at or f"{trade_date}T10:00:00+00:00"
+    payload = {
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "started_at": started,
+        "status": status,
+        "snapshots": {"final_state": final_state} if final_state is not None else {},
+    }
+    name = f"{trade_date}_{started.replace(':', '').replace('+', '')}.json"
+    (runs_dir / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+class LoadFinalStateSnapshotTests(unittest.TestCase):
+    def test_returns_latest_completed_snapshot_for_date(self):
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(
+                root, "AAPL", "2026-01-05",
+                final_state={"market_report": "old"},
+                started_at="2026-01-05T09:00:00+00:00",
+            )
+            _write_run(
+                root, "AAPL", "2026-01-05",
+                final_state={"market_report": "new"},
+                started_at="2026-01-05T15:00:00+00:00",
+            )
+            snapshot = load_final_state_snapshot("AAPL", "2026-01-05", eval_results_dir=root)
+        self.assertEqual(snapshot, {"market_report": "new"})
+
+    def test_ignores_failed_runs_other_dates_and_missing_snapshots(self):
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(root, "AAPL", "2026-01-05", status="failed",
+                       final_state={"market_report": "failed"})
+            _write_run(root, "AAPL", "2026-01-06", final_state={"market_report": "other day"})
+            _write_run(root, "AAPL", "2026-01-05", final_state=None)
+            self.assertIsNone(
+                load_final_state_snapshot("AAPL", "2026-01-05", eval_results_dir=root)
+            )
+
+    def test_missing_directory_returns_none(self):
+        self.assertIsNone(
+            load_final_state_snapshot("ZZZZ", "2026-01-05", eval_results_dir="no_such_dir")
+        )
+
+    def test_crypto_symbol_is_sanitized(self):
+        with tempfile.TemporaryDirectory() as root:
+            _write_run(root, "BTC_USD", "2026-01-05", final_state={"market_report": "btc"})
+            snapshot = load_final_state_snapshot("BTC/USD", "2026-01-05", eval_results_dir=root)
+        self.assertEqual(snapshot, {"market_report": "btc"})
+
+
+def _full_state():
+    return {
+        "market_report": "market",
+        "sentiment_report": "sentiment",
+        "news_report": "news",
+        "fundamentals_report": "fundamentals",
+        "investment_debate_state": {
+            "bull_history": "bull said",
+            "bear_history": "bear said",
+            "judge_decision": "judge decided",
+        },
+        "trader_investment_plan": "trader plan",
+        "risk_debate_state": {"judge_decision": "risk decision"},
+    }
+
+
+class ReflectOnOutcomeTests(unittest.TestCase):
+    def _reflector(self):
+        llm = Mock()
+        llm.invoke.return_value = Mock(content="lesson learned")
+        return Reflector(llm)
+
+    def test_all_components_reflect_and_store(self):
+        reflector = self._reflector()
+        memories = {
+            name: Mock()
+            for name in ("bull", "bear", "trader", "invest_judge", "risk_manager")
+        }
+        results = reflector.reflect_on_outcome(_full_state(), "+5.0% realized", memories)
+
+        self.assertEqual(set(results), set(memories))
+        self.assertTrue(all(results.values()))
+        for memory in memories.values():
+            memory.add_situations.assert_called_once()
+            (pairs,), _ = memory.add_situations.call_args
+            situation, lesson = pairs[0]
+            self.assertIn("market", situation)
+            self.assertEqual(lesson, "lesson learned")
+
+    def test_one_failure_does_not_block_other_components(self):
+        reflector = self._reflector()
+        memories = {
+            "bull": Mock(add_situations=Mock(side_effect=RuntimeError("chroma down"))),
+            "trader": Mock(),
+        }
+        results = reflector.reflect_on_outcome(_full_state(), "-2.0% realized", memories)
+        self.assertFalse(results["bull"])
+        self.assertTrue(results["trader"])
+        memories["trader"].add_situations.assert_called_once()
+
+    def test_missing_memories_are_skipped(self):
+        reflector = self._reflector()
+        results = reflector.reflect_on_outcome(_full_state(), "+1.0%", {"bull": Mock()})
+        self.assertEqual(set(results), {"bull"})
+
+
+class OutcomeReflectionWiringTests(unittest.TestCase):
+    """Exercise TradingAgentsGraph._reflect_agents_on_outcome via a stub self."""
+
+    def _fake_graph(self, enabled=True):
+        fake = Mock(spec=TradingAgentsGraph)
+        fake.config = {"reflection_on_outcome_enabled": enabled}
+        fake.reflector = Mock()
+        for name in (
+            "bull_memory",
+            "bear_memory",
+            "trader_memory",
+            "invest_judge_memory",
+            "risk_manager_memory",
+        ):
+            setattr(fake, name, Mock())
+        return fake
+
+    def test_resolved_outcome_triggers_reflection_with_recovered_state(self):
+        fake = self._fake_graph()
+        state = _full_state()
+        with patch(
+            "tradingagents.run_logger.load_final_state_snapshot", return_value=state
+        ):
+            TradingAgentsGraph._reflect_agents_on_outcome(
+                fake, "AAPL", "2026-01-05", 0.05, 0.02, 5
+            )
+        fake.reflector.reflect_on_outcome.assert_called_once()
+        args, _ = fake.reflector.reflect_on_outcome.call_args
+        passed_state, returns_losses, memories = args
+        self.assertIs(passed_state, state)
+        self.assertIn("+5.0%", returns_losses)
+        self.assertIn("+2.0%", returns_losses)
+        self.assertEqual(
+            set(memories),
+            {"bull", "bear", "trader", "invest_judge", "risk_manager"},
+        )
+
+    def test_disabled_flag_skips_reflection(self):
+        fake = self._fake_graph(enabled=False)
+        with patch(
+            "tradingagents.run_logger.load_final_state_snapshot"
+        ) as loader:
+            TradingAgentsGraph._reflect_agents_on_outcome(
+                fake, "AAPL", "2026-01-05", 0.05, None, 5
+            )
+        loader.assert_not_called()
+        fake.reflector.reflect_on_outcome.assert_not_called()
+
+    def test_missing_snapshot_skips_reflection(self):
+        fake = self._fake_graph()
+        with patch(
+            "tradingagents.run_logger.load_final_state_snapshot", return_value=None
+        ):
+            TradingAgentsGraph._reflect_agents_on_outcome(
+                fake, "AAPL", "2026-01-05", 0.05, None, 5
+            )
+        fake.reflector.reflect_on_outcome.assert_not_called()
+
+    def test_reflection_errors_never_propagate(self):
+        fake = self._fake_graph()
+        fake.reflector.reflect_on_outcome.side_effect = RuntimeError("llm down")
+        with patch(
+            "tradingagents.run_logger.load_final_state_snapshot",
+            return_value=_full_state(),
+        ):
+            # Must not raise: outcome reflection is strictly best-effort.
+            TradingAgentsGraph._reflect_agents_on_outcome(
+                fake, "AAPL", "2026-01-05", 0.05, None, 5
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_structured_decisions.py
+++ b/tests/test_structured_decisions.py
@@ -90,7 +90,11 @@ class StructuredDecisionTests(unittest.TestCase):
         self.assertEqual(intent.position_transition, PositionTransition.OPEN_LONG)
         self.assertEqual(intent.order_intent.side, "buy")
         self.assertEqual(intent.risk_controls.mode, "advisory_only")
-        self.assertIn("protective-order", " ".join(intent.execution_constraints.warnings))
+        # Numeric protective levels are extracted so execution can submit
+        # real bracket orders instead of leaving controls advisory.
+        self.assertEqual(intent.risk_controls.stop_loss_price, 182.50)
+        self.assertEqual(intent.risk_controls.take_profit_price, 195.0)
+        self.assertTrue(intent.execution_constraints.broker_protective_orders_enabled)
         self.assertEqual(trade_intent_action(intent.model_dump(mode="json")), "BUY")
 
     def test_alpaca_execution_prefers_validated_trade_intent(self):

--- a/tests/test_trading_graph_mocked.py
+++ b/tests/test_trading_graph_mocked.py
@@ -67,7 +67,9 @@ def _final_state(ticker, trade_date):
 
 class MockedTradingGraphTests(unittest.TestCase):
     def test_propagate_preserves_macro_and_safe_paths_with_checkpoint(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        # ignore_cleanup_errors: chromadb holds its store files open on
+        # Windows, so temp-dir removal can race the process handle.
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             tmp_path = Path(tmp)
             for ticker, safe_ticker in (("AAPL", "AAPL"), ("BTC/USD", "BTC_USD")):
                 with self.subTest(ticker=ticker):
@@ -81,6 +83,7 @@ class MockedTradingGraphTests(unittest.TestCase):
                             "data_cache_dir": str(tmp_path / f"cache-{safe_ticker}"),
                             "results_dir": str(tmp_path / "results"),
                             "memory_log_path": str(tmp_path / f"memory-{safe_ticker}.md"),
+                            "agent_memory_dir": str(tmp_path / f"agent-memory-{safe_ticker}"),
                             "checkpoint_enabled": True,
                         }
                     )
@@ -113,7 +116,9 @@ class MockedTradingGraphTests(unittest.TestCase):
         ]
 
         for provider, provider_config, expected_key, expected_value in cases:
-            with self.subTest(provider=provider), tempfile.TemporaryDirectory() as tmp:
+            with self.subTest(provider=provider), tempfile.TemporaryDirectory(
+                ignore_cleanup_errors=True
+            ) as tmp:
                 calls = []
 
                 def fake_create_llm_client(**kwargs):
@@ -129,6 +134,7 @@ class MockedTradingGraphTests(unittest.TestCase):
                         "data_cache_dir": str(Path(tmp) / "cache"),
                         "results_dir": str(Path(tmp) / "results"),
                         "memory_log_path": str(Path(tmp) / "memory.md"),
+                        "agent_memory_dir": str(Path(tmp) / "agent-memory"),
                         **provider_config,
                     }
                 )

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -303,9 +303,25 @@ def create_market_analyst(llm, toolkit):
         else:
             result = AIMessage(content=_normalize_market_report_markdown(analysis_content))
 
+        # Deterministic regime context: computed from price/volume history
+        # (no LLM), appended so every downstream agent that reads the market
+        # report sees the same risk-posture facts. Failure-isolated.
+        market_report = result.content
+        try:
+            from tradingagents.dataflows.config import get_config
+            from tradingagents.regime import RegimeConfig, regime_report_block
+
+            regime_block = regime_report_block(
+                ticker, config=RegimeConfig.from_config(get_config() or {})
+            )
+            if regime_block:
+                market_report = f"{market_report}\n\n{regime_block}"
+        except Exception as exc:
+            print(f"[REGIME] Market-report injection skipped for {ticker}: {exc}")
+
         return {
             "messages": [result],
-            "market_report": result.content,
+            "market_report": market_report,
         }
 
     return market_analyst_node

--- a/tradingagents/agents/schemas.py
+++ b/tradingagents/agents/schemas.py
@@ -6,11 +6,39 @@ The upstream 5-tier rating is advisory metadata only.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, Field
+
+_PRICE_PATTERN = re.compile(r"\$?\s*(\d{1,3}(?:,\d{3})+|\d+)(?:\.(\d+))?")
+
+
+def extract_protective_price(guidance: Optional[str]) -> Optional[float]:
+    """Extract the first absolute price level from free-text risk guidance.
+
+    Returns None for qualitative guidance ("below support"), relative values
+    ("8% below entry"), or empty input — a protective order must never be
+    submitted from a level we are not sure about.
+    """
+    if not guidance:
+        return None
+    match = _PRICE_PATTERN.search(guidance)
+    if not match:
+        return None
+    # Percentages are relative to an unknown entry price, not price levels.
+    tail = guidance[match.end():].lstrip()
+    if tail.startswith("%") or tail.lower().startswith("percent"):
+        return None
+    whole = match.group(1).replace(",", "")
+    fraction = match.group(2) or "0"
+    try:
+        price = float(f"{whole}.{fraction}")
+    except ValueError:
+        return None
+    return price if price > 0 else None
 
 
 class AdvisoryRating(str, Enum):
@@ -64,6 +92,14 @@ class RiskControls(BaseModel):
     required_controls: Optional[str] = Field(default=None, description="Full risk-control guidance from the risk manager.")
     stop_loss: Optional[str] = Field(default=None, description="Stop-loss or invalidation guidance.")
     take_profit: Optional[str] = Field(default=None, description="Take-profit or target guidance.")
+    stop_loss_price: Optional[float] = Field(
+        default=None,
+        description="Absolute stop-loss price level for broker protective orders, when known.",
+    )
+    take_profit_price: Optional[float] = Field(
+        default=None,
+        description="Absolute take-profit price level for broker protective orders, when known.",
+    )
     invalidation: Optional[str] = Field(default=None, description="Setup invalidation guidance.")
     max_position_size: Optional[str] = Field(default=None, description="Position-size or max exposure guidance.")
 
@@ -386,9 +422,12 @@ def build_trade_intent_from_risk_decision(
     if target == TargetPosition.SHORT and not allow_shorts:
         warnings.append("Short exposure is disabled for this session.")
 
-    if decision.required_controls or decision.stop_loss or decision.take_profit:
+    stop_loss_price = extract_protective_price(decision.stop_loss)
+    take_profit_price = extract_protective_price(decision.take_profit)
+    has_numeric_controls = bool(stop_loss_price or take_profit_price)
+    if (decision.required_controls or decision.stop_loss or decision.take_profit) and not has_numeric_controls:
         warnings.append(
-            "Risk controls are captured as advisory metadata; broker protective-order submission is not enabled in this execution path."
+            "Risk controls carry no absolute protective-order price levels; they remain advisory metadata."
         )
 
     risk_controls = RiskControls(
@@ -396,6 +435,8 @@ def build_trade_intent_from_risk_decision(
         required_controls=decision.required_controls,
         stop_loss=decision.stop_loss,
         take_profit=decision.take_profit,
+        stop_loss_price=stop_loss_price,
+        take_profit_price=take_profit_price,
         invalidation=decision.invalidation,
         max_position_size=decision.max_position_size,
     )
@@ -403,7 +444,7 @@ def build_trade_intent_from_risk_decision(
         allow_shorts=allow_shorts,
         asset_class=asset_class,
         requires_open_market=asset_class != "crypto",
-        broker_protective_orders_enabled=False,
+        broker_protective_orders_enabled=has_numeric_controls and asset_class != "crypto",
         warnings=warnings,
     )
 

--- a/tradingagents/agents/utils/gpt5_llm.py
+++ b/tradingagents/agents/utils/gpt5_llm.py
@@ -1,6 +1,7 @@
 """Custom LangChain wrapper for OpenAI reasoning models using Responses API."""
 
 from typing import Any, Dict, List, Optional
+from pydantic import ConfigDict
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.outputs import ChatResult, ChatGeneration
@@ -55,10 +56,9 @@ class GPT5ChatModel(BaseChatModel):
     
     # Internal client - not a pydantic field
     _client: Optional[OpenAI] = None
-    
-    class Config:
-        arbitrary_types_allowed = True
-    
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # Initialize the OpenAI client

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -2,6 +2,7 @@ import chromadb
 from chromadb.config import Settings
 from openai import OpenAI
 import numpy as np
+from datetime import date
 from pathlib import Path
 import re
 import uuid
@@ -89,11 +90,14 @@ class FinancialSituationMemory:
         if not embeddings:
             return
 
+        # created_at powers time-decay maintenance; an explicit value in
+        # extra_metadata (e.g. a backdated batch-taught lesson) wins.
+        base_metadata = {"created_at": date.today().isoformat()}
+        base_metadata.update(extra_metadata or {})
+
         self.situation_collection.add(
             documents=situations,
-            metadatas=[
-                {**(extra_metadata or {}), "recommendation": rec} for rec in advice
-            ],
+            metadatas=[{**base_metadata, "recommendation": rec} for rec in advice],
             embeddings=embeddings,
             ids=ids,
         )

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -59,8 +59,14 @@ class FinancialSituationMemory:
                 self._warned_embedding_failure = True
             return None
 
-    def add_situations(self, situations_and_advice):
-        """Add financial situations and their corresponding advice. Parameter is a list of tuples (situation, rec)"""
+    def add_situations(self, situations_and_advice, extra_metadata=None):
+        """Add financial situations and their corresponding advice.
+
+        `situations_and_advice` is a list of (situation, recommendation)
+        tuples. `extra_metadata`, when given, is merged into every entry's
+        metadata — used e.g. by batch teaching to tag lessons with their
+        source and an idempotency key.
+        """
         if not self.embeddings_enabled:
             return
 
@@ -85,10 +91,20 @@ class FinancialSituationMemory:
 
         self.situation_collection.add(
             documents=situations,
-            metadatas=[{"recommendation": rec} for rec in advice],
+            metadatas=[
+                {**(extra_metadata or {}), "recommendation": rec} for rec in advice
+            ],
             embeddings=embeddings,
             ids=ids,
         )
+
+    def has_metadata_value(self, key, value) -> bool:
+        """True when any stored entry carries `key == value` in its metadata."""
+        try:
+            found = self.situation_collection.get(where={key: value}, limit=1)
+        except Exception:
+            return False
+        return bool(found and found.get("ids"))
 
     def get_memories(self, current_situation, n_matches=1):
         """Find matching recommendations using OpenAI embeddings"""

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -4,18 +4,29 @@ from openai import OpenAI
 import numpy as np
 from pathlib import Path
 import re
+import uuid
 from tradingagents.dataflows.config import get_openai_client_config, get_openai_embedding_model
 from tradingagents.agents.utils.agent_trading_modes import extract_recommendation
 
 
 class FinancialSituationMemory:
-    def __init__(self, name):
+    def __init__(self, name, config: dict = None):
         client_config = get_openai_client_config()
         self.client = OpenAI(**client_config) if client_config else None
         self.embedding_model = get_openai_embedding_model()
         self.embeddings_enabled = self.client is not None
         self._warned_embedding_failure = False
-        self.chroma_client = chromadb.Client(Settings(allow_reset=True))
+        persist_dir = (config or {}).get("agent_memory_dir") or ""
+        if persist_dir:
+            # Persistent store: lessons written after outcome resolution
+            # survive process restarts, which is what makes the reflection
+            # loop cumulative instead of session-scoped.
+            Path(persist_dir).mkdir(parents=True, exist_ok=True)
+            self.chroma_client = chromadb.PersistentClient(
+                path=str(persist_dir), settings=Settings(allow_reset=True)
+            )
+        else:
+            self.chroma_client = chromadb.Client(Settings(allow_reset=True))
         self.situation_collection = self.chroma_client.get_or_create_collection(name=name)
 
     def get_embedding(self, text):
@@ -58,15 +69,15 @@ class FinancialSituationMemory:
         ids = []
         embeddings = []
 
-        offset = self.situation_collection.count()
-
-        for i, (situation, recommendation) in enumerate(situations_and_advice):
+        for situation, recommendation in situations_and_advice:
             embedding = self.get_embedding(situation)
             if embedding is None:
                 continue
             situations.append(situation)
             advice.append(recommendation)
-            ids.append(str(offset + i))
+            # Random ids: count-based ids collide across processes once the
+            # collection is persistent (two sessions can see the same count).
+            ids.append(uuid.uuid4().hex)
             embeddings.append(embedding)
 
         if not embeddings:

--- a/tradingagents/agents/utils/memory_maintenance.py
+++ b/tradingagents/agents/utils/memory_maintenance.py
@@ -1,0 +1,204 @@
+"""FinMem-style maintenance for the per-agent ChromaDB reflection memories.
+
+Adapts the layered memory of FinMem (arXiv:2311.13743) to this project's
+single-collection stores. FinMem retains events with an Ebbinghaus recency
+score e^(-age/Q) whose stability constant Q depends on the layer (shallow
+14d, intermediate 90d, deep 365d) and purges anything whose recency falls
+below 0.05. With no discrete layers here, Q interpolates continuously with
+an entry's importance — a lesson backed by a large realized move decays
+like FinMem's deep layer, a trivial one like its shallow layer:
+
+    importance = base + weight * min(|decision_return| / scale, 1)
+    Q_eff      = Q_shallow + importance * (Q_deep - Q_shallow)
+    recency    = exp(-age_days / Q_eff)
+
+Age comes from the lesson's trade_date (batch-taught lessons enter with
+their historical dates, exactly like FinMem's warm-up) or, failing that,
+the created_at stamp add_situations now writes. Entries with neither are
+given a neutral recency so pre-existing memories are never unfairly purged.
+
+On top of decay, maintenance collapses near-duplicates (cosine similarity
+above a threshold keeps only the highest-scoring copy) and enforces a
+per-collection size cap by evicting the lowest-scoring entries first.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import date
+from typing import Dict, Optional
+
+import numpy as np
+
+
+@dataclass
+class MemoryMaintenanceConfig:
+    max_entries: int = 500
+    duplicate_similarity: float = 0.97
+    recency_purge_threshold: float = 0.05
+    q_shallow_days: float = 14.0  # FinMem shallow-layer stability
+    q_deep_days: float = 365.0  # FinMem deep-layer stability
+    importance_base: float = 0.3
+    importance_weight: float = 0.7
+    return_scale: float = 0.10  # |realized return| that maxes importance
+    neutral_recency: float = 0.5  # for entries with no usable date
+
+    @classmethod
+    def from_config(cls, config: Optional[dict]) -> "MemoryMaintenanceConfig":
+        cfg = config or {}
+        kwargs = {}
+        mapping = {
+            "max_entries": "memory_max_entries_per_collection",
+            "duplicate_similarity": "memory_duplicate_similarity_threshold",
+            "recency_purge_threshold": "memory_recency_purge_threshold",
+        }
+        for field_name, key in mapping.items():
+            if cfg.get(key) is not None:
+                kwargs[field_name] = cfg[key]
+        return cls(**kwargs)
+
+
+def entry_importance(
+    metadata: Optional[dict], config: Optional[MemoryMaintenanceConfig] = None
+) -> float:
+    """Importance in [0,1]; lessons with larger realized moves matter more."""
+    config = config or MemoryMaintenanceConfig()
+    meta = metadata or {}
+    try:
+        realized = abs(float(meta["decision_return"]))
+    except (KeyError, TypeError, ValueError):
+        return config.importance_base
+    scaled = min(realized / config.return_scale, 1.0) if config.return_scale else 1.0
+    return min(config.importance_base + config.importance_weight * scaled, 1.0)
+
+
+def _entry_age_days(metadata: Optional[dict]) -> Optional[float]:
+    meta = metadata or {}
+    for key in ("trade_date", "created_at"):
+        raw = str(meta.get(key) or "")[:10]
+        try:
+            stamped = date.fromisoformat(raw)
+        except ValueError:
+            continue
+        return max((date.today() - stamped).days, 0)
+    return None
+
+
+def entry_recency(
+    metadata: Optional[dict],
+    importance: float,
+    config: Optional[MemoryMaintenanceConfig] = None,
+) -> float:
+    """Ebbinghaus decay e^(-age/Q) with Q interpolated by importance."""
+    config = config or MemoryMaintenanceConfig()
+    age = _entry_age_days(metadata)
+    if age is None:
+        return config.neutral_recency
+    q_eff = config.q_shallow_days + importance * (
+        config.q_deep_days - config.q_shallow_days
+    )
+    return math.exp(-age / q_eff) if q_eff > 0 else 0.0
+
+
+def maintain_memory(
+    memory, config: Optional[MemoryMaintenanceConfig] = None
+) -> Dict[str, int]:
+    """Purge expired entries, collapse near-duplicates, enforce the size cap.
+
+    `memory` is a FinancialSituationMemory. Returns a summary of what was
+    removed. Safe on empty collections.
+    """
+    config = config or MemoryMaintenanceConfig()
+    collection = memory.situation_collection
+    stored = collection.get(include=["metadatas", "embeddings"])
+    ids = stored.get("ids") or []
+    summary = {
+        "kept": 0,
+        "purged_expired": 0,
+        "purged_duplicates": 0,
+        "purged_over_cap": 0,
+    }
+    if not ids:
+        return summary
+
+    metadatas = stored.get("metadatas") or [{}] * len(ids)
+    embeddings = stored.get("embeddings")
+
+    entries = []
+    for i, entry_id in enumerate(ids):
+        meta = metadatas[i] or {}
+        importance = entry_importance(meta, config)
+        recency = entry_recency(meta, importance, config)
+        embedding = None
+        if embeddings is not None and len(embeddings) > i:
+            embedding = np.asarray(embeddings[i], dtype=float)
+        entries.append(
+            {
+                "id": entry_id,
+                "score": recency + importance,
+                "recency": recency,
+                "embedding": embedding,
+            }
+        )
+
+    to_delete = []
+
+    # 1. FinMem forgetting rule: recency below the purge threshold.
+    survivors = []
+    for entry in entries:
+        if entry["recency"] < config.recency_purge_threshold:
+            to_delete.append(entry["id"])
+            summary["purged_expired"] += 1
+        else:
+            survivors.append(entry)
+
+    # 2. Near-duplicates: greedy keep-best by score, drop anything whose
+    #    cosine similarity to an already-kept entry exceeds the threshold.
+    survivors.sort(key=lambda e: e["score"], reverse=True)
+    kept = []
+    for entry in survivors:
+        duplicate = False
+        vec = entry["embedding"]
+        if vec is not None and np.linalg.norm(vec) > 0:
+            for other in kept:
+                ovec = other["embedding"]
+                if ovec is None:
+                    continue
+                denom = np.linalg.norm(vec) * np.linalg.norm(ovec)
+                if denom <= 0:
+                    continue
+                if float(np.dot(vec, ovec)) / denom > config.duplicate_similarity:
+                    duplicate = True
+                    break
+        if duplicate:
+            to_delete.append(entry["id"])
+            summary["purged_duplicates"] += 1
+        else:
+            kept.append(entry)
+
+    # 3. Size cap: evict lowest-scoring entries (kept is sorted best-first).
+    if config.max_entries and len(kept) > config.max_entries:
+        for entry in kept[config.max_entries :]:
+            to_delete.append(entry["id"])
+            summary["purged_over_cap"] += 1
+        kept = kept[: config.max_entries]
+
+    if to_delete:
+        collection.delete(ids=to_delete)
+    summary["kept"] = len(kept)
+    return summary
+
+
+def maintain_all_memories(memories: Dict[str, object], config: Optional[dict] = None) -> Dict[str, dict]:
+    """Run maintenance over a component->memory map, isolating failures."""
+    maintenance_config = MemoryMaintenanceConfig.from_config(config)
+    results: Dict[str, dict] = {}
+    for name, memory in memories.items():
+        if memory is None:
+            continue
+        try:
+            results[name] = maintain_memory(memory, maintenance_config)
+        except Exception as exc:
+            print(f"[MEMORY] Maintenance skipped for {name}: {exc}")
+    return results

--- a/tradingagents/alerts.py
+++ b/tradingagents/alerts.py
@@ -109,7 +109,10 @@ def send_alert(
             )
             channels.append("telegram")
         except Exception as exc:
-            print(f"[ALERTS] Telegram delivery failed: {exc}")
+            print(
+                f"[ALERTS] Telegram delivery failed "
+                f"({type(exc).__name__}); credential-bearing URL suppressed"
+            )
 
     if config.webhook_url:
         try:
@@ -119,7 +122,10 @@ def send_alert(
             )
             channels.append("webhook")
         except Exception as exc:
-            print(f"[ALERTS] Webhook delivery failed: {exc}")
+            print(
+                f"[ALERTS] Webhook delivery failed "
+                f"({type(exc).__name__}); URL suppressed"
+            )
 
     if channels:
         with _DEDUPE_LOCK:

--- a/tradingagents/alerts.py
+++ b/tradingagents/alerts.py
@@ -1,0 +1,160 @@
+"""Operational alerts: Telegram and generic webhook, stdlib only.
+
+Design rules learned from production alerting:
+- **Deduplication**: a tripped circuit breaker blocks every subsequent
+  order; without a cooldown that is one identical message per attempt.
+  Alerts are keyed (default: the subject) and suppressed for
+  ``cooldown_seconds`` after a successful send.
+- **Isolation**: alert delivery must never affect trading. Every network
+  failure is swallowed and reported in the return value only.
+- **Secrets**: the Telegram token comes from config/env and is never
+  echoed into logs or reports.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import urllib.request
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+_DEDUPE_LOCK = threading.Lock()
+_LAST_SENT: Dict[str, float] = {}
+
+
+@dataclass
+class AlertConfig:
+    enabled: bool = True
+    telegram_bot_token: str = ""
+    telegram_chat_id: str = ""
+    webhook_url: str = ""
+    cooldown_seconds: float = 900.0
+
+    @classmethod
+    def from_config(cls, config: Optional[dict]) -> "AlertConfig":
+        cfg = config or {}
+        return cls(
+            enabled=bool(cfg.get("alerts_enabled", True)),
+            telegram_bot_token=str(
+                cfg.get("alert_telegram_bot_token")
+                or os.getenv("ALERT_TELEGRAM_BOT_TOKEN", "")
+            ),
+            telegram_chat_id=str(
+                cfg.get("alert_telegram_chat_id")
+                or os.getenv("ALERT_TELEGRAM_CHAT_ID", "")
+            ),
+            webhook_url=str(
+                cfg.get("alert_webhook_url") or os.getenv("ALERT_WEBHOOK_URL", "")
+            ),
+            cooldown_seconds=float(cfg.get("alert_cooldown_seconds", 900.0) or 900.0),
+        )
+
+
+def reset_alert_dedupe() -> None:
+    """Clear the cooldown map (tests and manual ops)."""
+    with _DEDUPE_LOCK:
+        _LAST_SENT.clear()
+
+
+def _post_json(url: str, payload: dict) -> None:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10):
+        pass
+
+
+def send_alert(
+    subject: str,
+    body: str,
+    key: Optional[str] = None,
+    config: Optional[AlertConfig] = None,
+    transport: Optional[Callable[[str, dict], None]] = None,
+) -> dict:
+    """Dispatch an alert to every configured channel.
+
+    Returns {"sent": bool, "deduped": bool, "channels": [...]}; never raises.
+    `transport(url, payload)` is injectable for tests.
+    """
+    config = config or AlertConfig.from_config(None)
+    result = {"sent": False, "deduped": False, "channels": []}
+    if not config.enabled:
+        return result
+
+    dedupe_key = key or subject
+    now = time.monotonic()
+    with _DEDUPE_LOCK:
+        last = _LAST_SENT.get(dedupe_key)
+        if last is not None and now - last < config.cooldown_seconds:
+            result["deduped"] = True
+            return result
+
+    post = transport or _post_json
+    channels: List[str] = []
+
+    if config.telegram_bot_token and config.telegram_chat_id:
+        try:
+            post(
+                f"https://api.telegram.org/bot{config.telegram_bot_token}/sendMessage",
+                {
+                    "chat_id": config.telegram_chat_id,
+                    "text": f"{subject}\n\n{body}",
+                },
+            )
+            channels.append("telegram")
+        except Exception as exc:
+            print(f"[ALERTS] Telegram delivery failed: {exc}")
+
+    if config.webhook_url:
+        try:
+            post(
+                config.webhook_url,
+                {"subject": subject, "body": body, "sent_at": time.time()},
+            )
+            channels.append("webhook")
+        except Exception as exc:
+            print(f"[ALERTS] Webhook delivery failed: {exc}")
+
+    if channels:
+        with _DEDUPE_LOCK:
+            _LAST_SENT[dedupe_key] = now
+        result["sent"] = True
+        result["channels"] = channels
+    return result
+
+
+def notify_safety_block(
+    symbol: str,
+    reasons: List[str],
+    config: Optional[AlertConfig] = None,
+    transport: Optional[Callable[[str, dict], None]] = None,
+) -> dict:
+    """Alert that the safety layer blocked order flow.
+
+    Keyed by the reasons (not the symbol), so one tripped breaker produces
+    one alert per cooldown window no matter how many orders it blocks.
+    """
+    reasons = [str(r) for r in (reasons or [])]
+    return send_alert(
+        subject="🛑 Safety layer blocked order flow",
+        body=f"Symbol: {symbol}\n" + "\n".join(f"- {r}" for r in reasons),
+        key="safety_block|" + "|".join(sorted(reasons)),
+        config=config,
+        transport=transport,
+    )
+
+
+def notify_kill_switch(reason: str, config: Optional[AlertConfig] = None) -> dict:
+    """Alert that the kill switch was engaged."""
+    return send_alert(
+        subject="🔴 Kill switch engaged",
+        body=reason or "manual halt",
+        key="kill_switch_engaged",
+        config=config,
+    )

--- a/tradingagents/backtest/__init__.py
+++ b/tradingagents/backtest/__init__.py
@@ -1,0 +1,51 @@
+"""Deterministic backtesting and evaluation for agent trading decisions.
+
+Public surface:
+- run_backtest / run_walk_forward: replay dated BUY/SELL/HOLD signals over
+  OHLCV bars via backtrader with next-open execution (no lookahead).
+- run_recorded_backtest: evaluate the decisions already persisted under
+  eval_results/ without spending a single LLM call.
+- metrics: pure-math Sharpe / drawdown / win-rate helpers.
+"""
+
+from .engine import (
+    BacktestResult,
+    WalkForwardResult,
+    normalize_price_frame,
+    run_backtest,
+    run_recorded_backtest,
+    run_recorded_walk_forward,
+    run_walk_forward,
+)
+from .metrics import (
+    CRYPTO_DAYS_PER_YEAR,
+    TRADING_DAYS_PER_YEAR,
+    annualized_return,
+    cumulative_return,
+    max_drawdown,
+    sharpe_ratio,
+    summarize_performance,
+    win_rate,
+)
+from .signals import ACTION_ALIASES, load_recorded_signals, normalize_action
+
+__all__ = [
+    "ACTION_ALIASES",
+    "BacktestResult",
+    "CRYPTO_DAYS_PER_YEAR",
+    "TRADING_DAYS_PER_YEAR",
+    "WalkForwardResult",
+    "annualized_return",
+    "cumulative_return",
+    "load_recorded_signals",
+    "max_drawdown",
+    "normalize_action",
+    "normalize_price_frame",
+    "run_backtest",
+    "run_recorded_backtest",
+    "run_recorded_walk_forward",
+    "run_walk_forward",
+    "sharpe_ratio",
+    "summarize_performance",
+    "win_rate",
+]

--- a/tradingagents/backtest/__init__.py
+++ b/tradingagents/backtest/__init__.py
@@ -28,6 +28,11 @@ from .metrics import (
     win_rate,
 )
 from .signals import ACTION_ALIASES, load_recorded_signals, normalize_action
+from .teach import (
+    compute_decision_outcomes,
+    default_agent_memories,
+    teach_memories_from_history,
+)
 
 __all__ = [
     "ACTION_ALIASES",
@@ -36,7 +41,9 @@ __all__ = [
     "TRADING_DAYS_PER_YEAR",
     "WalkForwardResult",
     "annualized_return",
+    "compute_decision_outcomes",
     "cumulative_return",
+    "default_agent_memories",
     "load_recorded_signals",
     "max_drawdown",
     "normalize_action",
@@ -47,5 +54,6 @@ __all__ = [
     "run_walk_forward",
     "sharpe_ratio",
     "summarize_performance",
+    "teach_memories_from_history",
     "win_rate",
 ]

--- a/tradingagents/backtest/engine.py
+++ b/tradingagents/backtest/engine.py
@@ -24,6 +24,57 @@ from .metrics import (
 from .signals import load_recorded_signals
 
 
+_BPS = 1e-4  # one basis point as a fraction
+
+
+class _VolatilitySlippageBroker(bt.brokers.BackBroker):
+    """Backtesting broker whose slippage scales with recent volatility.
+
+    Each fill slips by ``vol_fraction`` of the previous completed bar's range
+    (high - low, as a fraction of its close), clamped to
+    [``min_bps``, ``max_bps``] basis points.  Calm tape costs little; wide
+    bars — where market orders realistically eat through the book — cost
+    more.  The fill-bar's own range is never used, so the model needs no
+    intrabar knowledge.
+    """
+
+    def __init__(self, vol_fraction=0.1, min_bps=1.0, max_bps=50.0):
+        super().__init__()
+        self._vol_fraction = float(vol_fraction)
+        self._min_perc = float(min_bps) * _BPS
+        self._max_perc = float(max_bps) * _BPS
+        self._slippage_feed = None
+        # Base-class slippage plumbing reads p.slip_perc; make fills at the
+        # open slip like set_slippage_perc() would.
+        self.p.slip_open = True
+        self.p.slip_match = True
+        self.p.slip_out = False
+
+    def set_slippage_feed(self, data) -> None:
+        self._slippage_feed = data
+
+    def _dynamic_perc(self) -> float:
+        feed = self._slippage_feed
+        try:
+            close = float(feed.close[-1])
+            bar_range = max(float(feed.high[-1]) - float(feed.low[-1]), 0.0)
+            if close <= 0:
+                return self._min_perc
+            perc = self._vol_fraction * bar_range / close
+        except (IndexError, TypeError, AttributeError):
+            # First bar (no completed predecessor) or no feed registered.
+            return self._min_perc
+        return min(max(perc, self._min_perc), self._max_perc)
+
+    def _slip_up(self, pmax, price, doslip=True, lim=False):
+        self.p.slip_perc = self._dynamic_perc()
+        return super()._slip_up(pmax, price, doslip=doslip, lim=lim)
+
+    def _slip_down(self, pmin, price, doslip=True, lim=False):
+        self.p.slip_perc = self._dynamic_perc()
+        return super()._slip_down(pmin, price, doslip=doslip, lim=lim)
+
+
 class _SignalReplayStrategy(bt.Strategy):
     """Executes an externally supplied {date: action} map, nothing else."""
 
@@ -101,6 +152,7 @@ class BacktestResult:
     start_date: Optional[str] = None
     end_date: Optional[str] = None
     rejected_orders: List[dict] = field(default_factory=list)
+    slippage: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
@@ -110,6 +162,7 @@ class BacktestResult:
             "end_date": self.end_date,
             "num_orders": len(self.orders),
             "rejected_orders": list(self.rejected_orders),
+            "slippage": dict(self.slippage),
             "equity_curve": {
                 ts.date().isoformat(): value
                 for ts, value in self.equity_curve.items()
@@ -171,12 +224,56 @@ def run_backtest(
     allow_shorts: bool = False,
     position_pct: float = 0.95,
     periods_per_year: int = TRADING_DAYS_PER_YEAR,
+    slippage_model: str = "fixed",
+    slippage_bps: float = 5.0,
+    slippage_vol_fraction: float = 0.1,
+    slippage_min_bps: float = 1.0,
+    slippage_max_bps: float = 50.0,
 ) -> BacktestResult:
-    """Replay dated signals over price history and measure performance."""
+    """Replay dated signals over price history and measure performance.
+
+    Slippage models (zero-slippage backtests systematically overstate
+    performance, so a small fixed cost is applied by default):
+
+    - ``"fixed"``: every fill slips by ``slippage_bps`` basis points against
+      the trade (default 5 bps).
+    - ``"volatility"``: the slip is ``slippage_vol_fraction`` of the previous
+      bar's high-low range (as a fraction of its close), clamped to
+      [``slippage_min_bps``, ``slippage_max_bps``] — cheap in calm tape,
+      expensive across wide bars.
+    - ``"none"``: frictionless fills (not recommended outside tests).
+    """
     frame = normalize_price_frame(prices)
 
     cerebro = bt.Cerebro()
-    cerebro.adddata(bt.feeds.PandasData(dataname=frame))
+    data_feed = bt.feeds.PandasData(dataname=frame)
+    cerebro.adddata(data_feed)
+
+    if slippage_model == "volatility":
+        broker = _VolatilitySlippageBroker(
+            vol_fraction=slippage_vol_fraction,
+            min_bps=slippage_min_bps,
+            max_bps=slippage_max_bps,
+        )
+        broker.set_slippage_feed(data_feed)
+        cerebro.setbroker(broker)
+        slippage_config = {
+            "model": "volatility",
+            "vol_fraction": float(slippage_vol_fraction),
+            "min_bps": float(slippage_min_bps),
+            "max_bps": float(slippage_max_bps),
+        }
+    elif slippage_model == "fixed":
+        if float(slippage_bps) > 0:
+            cerebro.broker.set_slippage_perc(float(slippage_bps) * _BPS)
+        slippage_config = {"model": "fixed", "bps": float(slippage_bps)}
+    elif slippage_model == "none":
+        slippage_config = {"model": "none"}
+    else:
+        raise ValueError(
+            f"Unknown slippage_model {slippage_model!r}; expected 'fixed', 'volatility', or 'none'."
+        )
+
     cerebro.broker.setcash(float(initial_cash))
     cerebro.broker.setcommission(commission=float(commission))
     cerebro.addstrategy(
@@ -204,6 +301,7 @@ def run_backtest(
         start_date=frame.index[0].date().isoformat(),
         end_date=frame.index[-1].date().isoformat(),
         rejected_orders=list(strategy.rejected_orders),
+        slippage=slippage_config,
     )
 
 

--- a/tradingagents/backtest/engine.py
+++ b/tradingagents/backtest/engine.py
@@ -1,0 +1,335 @@
+"""Walk-forward backtesting engine built on backtrader.
+
+The engine replays a series of dated BUY/SELL/HOLD signals against
+historical OHLCV bars. Orders are submitted when a bar closes and fill at
+the *next* bar's open (backtrader's default, cheat-on-open disabled), so a
+decision made on day t can never benefit from day t's own price — the same
+information-set discipline required to avoid lookahead bias in walk-forward
+evaluation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+import backtrader as bt
+import pandas as pd
+
+from .metrics import (
+    CRYPTO_DAYS_PER_YEAR,
+    TRADING_DAYS_PER_YEAR,
+    summarize_performance,
+)
+from .signals import load_recorded_signals
+
+
+class _SignalReplayStrategy(bt.Strategy):
+    """Executes an externally supplied {date: action} map, nothing else."""
+
+    params = (
+        ("signals", None),  # dict[str iso-date, "BUY"|"SELL"|"HOLD"]
+        ("allow_shorts", False),
+        ("position_pct", 0.95),  # fraction of portfolio value per full position
+    )
+
+    def __init__(self):
+        self.equity_dates: List[pd.Timestamp] = []
+        self.equity_values: List[float] = []
+        self.closed_trade_pnls: List[float] = []
+        self.executed_orders: List[dict] = []
+        self.rejected_orders: List[dict] = []
+        # Signals sorted by date so ones falling on non-trading days (weekends,
+        # halts) apply on the next available bar instead of silently dropping.
+        self._pending = sorted((self.p.signals or {}).items())
+        self._cursor = 0
+
+    def _consume_signals_up_to(self, bar_date: str) -> Optional[str]:
+        action = None
+        while self._cursor < len(self._pending) and self._pending[self._cursor][0] <= bar_date:
+            action = self._pending[self._cursor][1]
+            self._cursor += 1
+        return action
+
+    def next(self):
+        bar_date = self.data.datetime.date(0)
+        self.equity_dates.append(pd.Timestamp(bar_date))
+        self.equity_values.append(float(self.broker.getvalue()))
+
+        action = self._consume_signals_up_to(bar_date.isoformat())
+        if action == "BUY":
+            self.order_target_percent(target=self.p.position_pct)
+        elif action == "SELL":
+            target = -self.p.position_pct if self.p.allow_shorts else 0.0
+            self.order_target_percent(target=target)
+        # HOLD / None: keep the current position untouched.
+
+    def notify_order(self, order):
+        if order.status == order.Completed:
+            self.executed_orders.append(
+                {
+                    "date": self.data.datetime.date(0).isoformat(),
+                    "side": "buy" if order.isbuy() else "sell",
+                    "size": float(order.executed.size),
+                    "price": float(order.executed.price),
+                }
+            )
+        elif order.status in (order.Margin, order.Rejected):
+            # Sizing uses the signal bar's close but fills at the next open;
+            # a large overnight gap can make the order unaffordable. Surface
+            # that instead of letting the trade vanish silently.
+            self.rejected_orders.append(
+                {
+                    "date": self.data.datetime.date(0).isoformat(),
+                    "side": "buy" if order.isbuy() else "sell",
+                    "status": "margin" if order.status == order.Margin else "rejected",
+                }
+            )
+
+    def notify_trade(self, trade):
+        if trade.isclosed:
+            self.closed_trade_pnls.append(float(trade.pnlcomm))
+
+
+@dataclass
+class BacktestResult:
+    equity_curve: pd.Series
+    trade_pnls: List[float]
+    orders: List[dict]
+    metrics: dict
+    signals_used: int
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    rejected_orders: List[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "metrics": dict(self.metrics),
+            "signals_used": self.signals_used,
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+            "num_orders": len(self.orders),
+            "rejected_orders": list(self.rejected_orders),
+            "equity_curve": {
+                ts.date().isoformat(): value
+                for ts, value in self.equity_curve.items()
+            },
+        }
+
+
+@dataclass
+class WalkForwardResult:
+    windows: List[dict] = field(default_factory=list)
+    full_period: Optional[BacktestResult] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "windows": list(self.windows),
+            "full_period": self.full_period.to_dict() if self.full_period else None,
+        }
+
+
+def normalize_price_frame(prices: pd.DataFrame) -> pd.DataFrame:
+    """Coerce an OHLCV frame into the shape backtrader's PandasData expects.
+
+    Accepts the ['timestamp', open, high, low, close, volume] layout produced
+    by AlpacaUtils.get_stock_data (any column casing) or a frame already
+    indexed by datetime. Raises ValueError on anything unusable.
+    """
+    if prices is None or len(prices) == 0:
+        raise ValueError("No price data supplied for backtest.")
+
+    frame = prices.copy()
+    frame.columns = [str(c).lower() for c in frame.columns]
+
+    if "timestamp" in frame.columns:
+        frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+        frame = frame.set_index("timestamp")
+    elif not isinstance(frame.index, pd.DatetimeIndex):
+        raise ValueError("Price data needs a 'timestamp' column or a DatetimeIndex.")
+
+    if getattr(frame.index, "tz", None) is not None:
+        frame.index = frame.index.tz_localize(None)
+
+    required = {"open", "high", "low", "close"}
+    missing = required - set(frame.columns)
+    if missing:
+        raise ValueError(f"Price data is missing columns: {sorted(missing)}")
+    if "volume" not in frame.columns:
+        frame["volume"] = 0.0
+
+    frame = frame[["open", "high", "low", "close", "volume"]].astype(float)
+    frame = frame[~frame.index.duplicated(keep="last")].sort_index()
+    return frame
+
+
+def run_backtest(
+    prices: pd.DataFrame,
+    signals: Dict[str, str],
+    initial_cash: float = 100_000.0,
+    commission: float = 0.001,
+    allow_shorts: bool = False,
+    position_pct: float = 0.95,
+    periods_per_year: int = TRADING_DAYS_PER_YEAR,
+) -> BacktestResult:
+    """Replay dated signals over price history and measure performance."""
+    frame = normalize_price_frame(prices)
+
+    cerebro = bt.Cerebro()
+    cerebro.adddata(bt.feeds.PandasData(dataname=frame))
+    cerebro.broker.setcash(float(initial_cash))
+    cerebro.broker.setcommission(commission=float(commission))
+    cerebro.addstrategy(
+        _SignalReplayStrategy,
+        signals=dict(signals or {}),
+        allow_shorts=allow_shorts,
+        position_pct=position_pct,
+    )
+    strategy = cerebro.run()[0]
+
+    equity_curve = pd.Series(
+        strategy.equity_values, index=strategy.equity_dates, dtype=float
+    )
+    metrics = summarize_performance(
+        equity_curve,
+        strategy.closed_trade_pnls,
+        periods_per_year=periods_per_year,
+    )
+    return BacktestResult(
+        equity_curve=equity_curve,
+        trade_pnls=list(strategy.closed_trade_pnls),
+        orders=list(strategy.executed_orders),
+        metrics=metrics,
+        signals_used=len(signals or {}),
+        start_date=frame.index[0].date().isoformat(),
+        end_date=frame.index[-1].date().isoformat(),
+        rejected_orders=list(strategy.rejected_orders),
+    )
+
+
+def run_walk_forward(
+    prices: pd.DataFrame,
+    signals: Dict[str, str],
+    window_bars: int = 63,
+    min_window_bars: int = 5,
+    **backtest_kwargs,
+) -> WalkForwardResult:
+    """Evaluate signals over consecutive non-overlapping out-of-sample windows.
+
+    LLM decision replay has no parameters to re-fit between folds, so the
+    walk-forward's purpose here is robustness: instead of one full-period
+    number, each ~quarterly window (63 trading bars by default) restarts with
+    fresh capital and reports its own metrics, exposing regime dependence a
+    single lucky backtest would hide. A trailing window shorter than
+    `min_window_bars` is folded into its predecessor.
+    """
+    frame = normalize_price_frame(prices)
+    if window_bars < 2:
+        raise ValueError("window_bars must be at least 2.")
+
+    boundaries = list(range(0, len(frame), window_bars))
+    windows: List[dict] = []
+    for start in boundaries:
+        end = start + window_bars
+        # Absorb a too-short trailing remainder into the final window.
+        if len(frame) - end < min_window_bars:
+            end = len(frame)
+        chunk = frame.iloc[start:end]
+        if len(chunk) < 2:
+            break
+        result = run_backtest(chunk, signals, **backtest_kwargs)
+        windows.append(
+            {
+                "start_date": result.start_date,
+                "end_date": result.end_date,
+                "bars": len(chunk),
+                "metrics": result.metrics,
+            }
+        )
+        if end == len(frame):
+            break
+
+    full = run_backtest(frame, signals, **backtest_kwargs)
+    return WalkForwardResult(windows=windows, full_period=full)
+
+
+def run_recorded_backtest(
+    symbol: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    eval_results_dir: str = "eval_results",
+    price_loader: Optional[Callable[[str, str, Optional[str]], pd.DataFrame]] = None,
+    **backtest_kwargs,
+) -> BacktestResult:
+    """Backtest the signals this deployment has already produced for `symbol`.
+
+    Pulls decisions from the persisted run logs (zero LLM cost) and prices
+    from Alpaca (with its existing yfinance fallback). `price_loader` exists
+    for tests and alternative data sources.
+    """
+    signals = load_recorded_signals(symbol, eval_results_dir=eval_results_dir)
+    if not signals:
+        raise ValueError(
+            f"No recorded completed runs with final signals found for {symbol} "
+            f"under {eval_results_dir}/."
+        )
+
+    first_signal = min(signals)
+    start = start_date or first_signal
+    if start > first_signal:
+        # Signals before the price window would misleadingly fire on its
+        # first bar; drop them so the backtest matches the requested range.
+        signals = {d: a for d, a in signals.items() if d >= start}
+        if not signals:
+            raise ValueError(
+                f"All recorded signals for {symbol} predate start_date={start}."
+            )
+
+    if price_loader is None:
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        price_loader = AlpacaUtils.get_stock_data
+
+    prices = price_loader(symbol, start, end_date)
+    backtest_kwargs.setdefault(
+        "periods_per_year",
+        CRYPTO_DAYS_PER_YEAR if "/" in symbol else TRADING_DAYS_PER_YEAR,
+    )
+    return run_backtest(prices, signals, **backtest_kwargs)
+
+
+def run_recorded_walk_forward(
+    symbol: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    eval_results_dir: str = "eval_results",
+    price_loader: Optional[Callable[[str, str, Optional[str]], pd.DataFrame]] = None,
+    window_bars: int = 63,
+    **backtest_kwargs,
+) -> WalkForwardResult:
+    """Walk-forward evaluation of this deployment's recorded decisions."""
+    signals = load_recorded_signals(symbol, eval_results_dir=eval_results_dir)
+    if not signals:
+        raise ValueError(
+            f"No recorded completed runs with final signals found for {symbol} "
+            f"under {eval_results_dir}/."
+        )
+
+    start = start_date or min(signals)
+    signals = {d: a for d, a in signals.items() if d >= start}
+    if not signals:
+        raise ValueError(
+            f"All recorded signals for {symbol} predate start_date={start}."
+        )
+
+    if price_loader is None:
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        price_loader = AlpacaUtils.get_stock_data
+
+    prices = price_loader(symbol, start, end_date)
+    backtest_kwargs.setdefault(
+        "periods_per_year",
+        CRYPTO_DAYS_PER_YEAR if "/" in symbol else TRADING_DAYS_PER_YEAR,
+    )
+    return run_walk_forward(prices, signals, window_bars=window_bars, **backtest_kwargs)

--- a/tradingagents/backtest/metrics.py
+++ b/tradingagents/backtest/metrics.py
@@ -1,0 +1,108 @@
+"""Pure-math performance metrics for backtest evaluation.
+
+All functions operate on plain sequences / pandas objects and never touch
+the network, the broker, or an LLM, so every number shown in the UI is
+reproducible in a unit test. Metric names follow the TradingAgents paper
+(arXiv:2412.20138): cumulative return, annualized return, Sharpe ratio,
+and maximum drawdown, plus win rate over closed trades.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Sequence
+
+import pandas as pd
+
+TRADING_DAYS_PER_YEAR = 252
+CRYPTO_DAYS_PER_YEAR = 365
+
+
+def _as_series(equity_curve) -> pd.Series:
+    if isinstance(equity_curve, pd.Series):
+        return equity_curve.astype(float)
+    return pd.Series(list(equity_curve), dtype=float)
+
+
+def cumulative_return(equity_curve) -> Optional[float]:
+    """Total return over the whole curve, e.g. 0.25 for +25%."""
+    curve = _as_series(equity_curve)
+    if len(curve) < 2 or curve.iloc[0] <= 0:
+        return None
+    return float(curve.iloc[-1] / curve.iloc[0] - 1.0)
+
+
+def annualized_return(equity_curve, periods_per_year: int = TRADING_DAYS_PER_YEAR) -> Optional[float]:
+    """Geometric annualized return assuming one curve point per period."""
+    curve = _as_series(equity_curve)
+    total = cumulative_return(curve)
+    if total is None:
+        return None
+    periods = len(curve) - 1
+    growth = 1.0 + total
+    if growth <= 0:
+        return -1.0
+    return float(growth ** (periods_per_year / periods) - 1.0)
+
+
+def sharpe_ratio(
+    equity_curve,
+    risk_free_rate: float = 0.0,
+    periods_per_year: int = TRADING_DAYS_PER_YEAR,
+) -> Optional[float]:
+    """Annualized Sharpe ratio from per-period equity values.
+
+    `risk_free_rate` is annual; it is converted to a per-period rate.
+    Returns None when the curve is too short or volatility is zero,
+    rather than fabricating a number.
+    """
+    curve = _as_series(equity_curve)
+    if len(curve) < 3:
+        return None
+    returns = curve.pct_change().dropna()
+    if len(returns) < 2:
+        return None
+    per_period_rf = (1.0 + risk_free_rate) ** (1.0 / periods_per_year) - 1.0
+    excess = returns - per_period_rf
+    std = float(excess.std(ddof=1))
+    if not math.isfinite(std) or std == 0.0:
+        return None
+    return float(excess.mean() / std * math.sqrt(periods_per_year))
+
+
+def max_drawdown(equity_curve) -> Optional[float]:
+    """Largest peak-to-trough decline as a positive fraction (0.2 = -20%)."""
+    curve = _as_series(equity_curve)
+    if len(curve) < 2:
+        return None
+    running_peak = curve.cummax()
+    drawdowns = 1.0 - curve / running_peak
+    return float(drawdowns.max())
+
+
+def win_rate(trade_pnls: Sequence[float]) -> Optional[float]:
+    """Fraction of closed trades with positive net PnL; None when no trades."""
+    pnls = [float(p) for p in trade_pnls]
+    if not pnls:
+        return None
+    return sum(1 for p in pnls if p > 0) / len(pnls)
+
+
+def summarize_performance(
+    equity_curve,
+    trade_pnls: Sequence[float] = (),
+    risk_free_rate: float = 0.0,
+    periods_per_year: int = TRADING_DAYS_PER_YEAR,
+) -> dict:
+    """All headline metrics in one dict (values may be None when undefined)."""
+    curve = _as_series(equity_curve)
+    return {
+        "cumulative_return": cumulative_return(curve),
+        "annualized_return": annualized_return(curve, periods_per_year),
+        "sharpe_ratio": sharpe_ratio(curve, risk_free_rate, periods_per_year),
+        "max_drawdown": max_drawdown(curve),
+        "win_rate": win_rate(trade_pnls),
+        "num_trades": len(list(trade_pnls)),
+        "num_periods": max(len(curve) - 1, 0),
+        "final_equity": float(curve.iloc[-1]) if len(curve) else None,
+    }

--- a/tradingagents/backtest/signals.py
+++ b/tradingagents/backtest/signals.py
@@ -1,0 +1,84 @@
+"""Signal sources for backtesting.
+
+The primary source replays decisions the multi-agent pipeline already made
+and persisted under ``eval_results/`` (see tradingagents/run_logger.py), so
+evaluating past agent behavior costs zero LLM calls. Signals are normalized
+to a common BUY/SELL/HOLD vocabulary; trading-mode outputs map onto it
+(LONG->BUY, SHORT->SELL, NEUTRAL->HOLD).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, Optional
+
+ACTION_ALIASES = {
+    "BUY": "BUY",
+    "LONG": "BUY",
+    "SELL": "SELL",
+    "SHORT": "SELL",
+    "HOLD": "HOLD",
+    "NEUTRAL": "HOLD",
+}
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def normalize_action(raw) -> Optional[str]:
+    """Map any recognized signal spelling to BUY/SELL/HOLD, else None."""
+    if raw is None:
+        return None
+    return ACTION_ALIASES.get(str(raw).strip().upper())
+
+
+def _sanitize_symbol_for_path(symbol: str) -> str:
+    # Must mirror run_logger._sanitize_for_path so we find its output dirs
+    # (importing it would trigger the module's stale-log recovery side effect).
+    sanitized = re.sub(r"[^\w\-.]+", "_", symbol.strip())
+    return sanitized or "unknown"
+
+
+def load_recorded_signals(
+    symbol: str,
+    eval_results_dir: str = "eval_results",
+) -> Dict[str, str]:
+    """Read persisted run logs and return {trade_date: normalized_action}.
+
+    Only completed runs with a recognizable final signal count. When several
+    runs exist for the same trade date, the most recently started one wins —
+    it reflects the newest configuration of the pipeline.
+    """
+    runs_dir = (
+        Path(eval_results_dir)
+        / _sanitize_symbol_for_path(symbol)
+        / "TradingAgentsStrategy_logs"
+        / "runs"
+    )
+    if not runs_dir.is_dir():
+        return {}
+
+    best_per_date: Dict[str, tuple] = {}  # date -> (started_at, action)
+    for path in sorted(runs_dir.glob("*.json")):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        if payload.get("status") != "completed":
+            continue
+        trade_date = str(payload.get("trade_date") or "").strip()
+        if not _DATE_RE.match(trade_date):
+            continue
+        action = normalize_action((payload.get("summary") or {}).get("final_signal"))
+        if action is None:
+            continue
+
+        started_at = str(payload.get("started_at") or "")
+        current = best_per_date.get(trade_date)
+        if current is None or started_at > current[0]:
+            best_per_date[trade_date] = (started_at, action)
+
+    return {date: action for date, (_, action) in sorted(best_per_date.items())}

--- a/tradingagents/backtest/teach.py
+++ b/tradingagents/backtest/teach.py
@@ -1,0 +1,281 @@
+"""Backtest -> self-learning-memory bridge ("intensive teaching").
+
+Replays the decisions this deployment already recorded under
+``eval_results/`` against historical prices and injects one dated lesson per
+decision into the persistent per-agent ChromaDB memories, so a fresh agent
+starts with the distilled experience of its own recorded history instead of
+an empty memory (FinMem's train-then-test warm-up, arXiv:2311.13743).
+
+Discipline mirrors the backtest engine: a decision made on day t enters at
+the *next* bar's open and its outcome is measured at the open ``horizon_bars``
+later — no lookahead. Lessons are built strictly from what the run log
+recorded at decision time plus that realized outcome; no new LLM forecasts
+are generated for historical dates, so pretraining contamination cannot leak
+into the replayed decisions.
+
+Teaching is idempotent: every lesson carries a ``teach_key`` and memories
+that already hold it are skipped, so re-running the bridge never duplicates.
+Lessons are also tagged ``source=backtest_teach`` so later memory
+maintenance can treat batch-taught lessons differently from live ones.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Optional
+
+import pandas as pd
+
+from .engine import normalize_price_frame
+from .signals import load_recorded_signals
+
+_REPORT_KEYS = (
+    "market_report",
+    "sentiment_report",
+    "news_report",
+    "fundamentals_report",
+)
+
+
+def compute_decision_outcomes(
+    prices: pd.DataFrame,
+    signals: Dict[str, str],
+    horizon_bars: int = 5,
+) -> List[dict]:
+    """Realized outcome of each dated decision under next-open execution.
+
+    For a decision dated t, entry is the open of the first bar strictly
+    after t and exit is the open ``horizon_bars`` bars later (or the last
+    bar, flagged ``partial``). ``decision_return`` is signed by the action:
+    BUY earns the asset move, SELL earns its negation, HOLD earns nothing
+    (the asset move is still reported so a lesson can describe what holding
+    avoided or missed). Decisions with no bar after them are dropped.
+    """
+    if horizon_bars < 1:
+        raise ValueError("horizon_bars must be at least 1.")
+
+    frame = normalize_price_frame(prices)
+    bar_dates = [ts.date().isoformat() for ts in frame.index]
+    opens = frame["open"].tolist()
+
+    outcomes: List[dict] = []
+    for trade_date, action in sorted((signals or {}).items()):
+        # First bar strictly after the decision date.
+        entry_idx = next(
+            (i for i, d in enumerate(bar_dates) if d > trade_date), None
+        )
+        if entry_idx is None:
+            continue
+
+        exit_idx = entry_idx + horizon_bars
+        partial = exit_idx > len(frame) - 1
+        if partial:
+            exit_idx = len(frame) - 1
+        if exit_idx <= entry_idx:
+            continue
+
+        entry_price = float(opens[entry_idx])
+        exit_price = float(opens[exit_idx])
+        if entry_price <= 0:
+            continue
+        asset_return = exit_price / entry_price - 1.0
+
+        if action == "BUY":
+            decision_return = asset_return
+        elif action == "SELL":
+            decision_return = -asset_return
+        else:  # HOLD
+            decision_return = 0.0
+
+        outcomes.append(
+            {
+                "trade_date": trade_date,
+                "action": action,
+                "entry_date": bar_dates[entry_idx],
+                "entry_price": entry_price,
+                "exit_date": bar_dates[exit_idx],
+                "exit_price": exit_price,
+                "horizon_used": exit_idx - entry_idx,
+                "asset_return": asset_return,
+                "decision_return": decision_return,
+                "partial": partial,
+            }
+        )
+    return outcomes
+
+
+def _situation_from_state(state: dict) -> Optional[str]:
+    parts = [str(state[k]) for k in _REPORT_KEYS if state.get(k)]
+    return "\n\n".join(parts) if parts else None
+
+
+def _deterministic_lesson(symbol: str, outcome: dict) -> str:
+    action = outcome["action"]
+    horizon = outcome["horizon_used"]
+    asset_pct = f"{outcome['asset_return']:+.1%}"
+    span = "" if not outcome["partial"] else " (horizon truncated by data end)"
+
+    if action == "HOLD":
+        body = (
+            f"HOLD meant not participating in a {asset_pct} move over the next "
+            f"{horizon} bars{span}."
+        )
+        if abs(outcome["asset_return"]) >= 0.02:
+            verdict = (
+                "A move this size suggests the situation carried a tradable "
+                "signal that the HOLD decision left unused — look for what the "
+                "reports underweighted."
+            )
+        else:
+            verdict = "The quiet follow-through supports having stayed flat."
+    else:
+        realized = f"{outcome['decision_return']:+.1%}"
+        body = (
+            f"The {action} decision realized {realized} over the next {horizon} "
+            f"bars{span} (asset moved {asset_pct}; entry at the next open "
+            f"{outcome['entry_price']:.4g} on {outcome['entry_date']}, exit at "
+            f"the open {outcome['exit_price']:.4g} on {outcome['exit_date']})."
+        )
+        if outcome["decision_return"] > 0:
+            verdict = (
+                "The reasoning behind this call was validated by the market — "
+                "weight similar setups accordingly."
+            )
+        else:
+            verdict = (
+                "The market went against this call — in similar situations, "
+                "re-examine the evidence that drove it before repeating the trade."
+            )
+
+    return (
+        f"[Backtest lesson] {symbol} on {outcome['trade_date']}: final decision "
+        f"was {action}. {body} {verdict}"
+    )
+
+
+def default_agent_memories(config: Optional[dict] = None) -> Dict[str, object]:
+    """The five reflection memories, named exactly as TradingAgentsGraph names
+    them so batch-taught lessons are what the live agents later retrieve.
+
+    Imports are deferred: tradingagents.agents pulls dataflows at import
+    time, and the backtest package must stay importable without it.
+    """
+    from tradingagents.agents.utils.memory import FinancialSituationMemory
+
+    if config is None:
+        from tradingagents.default_config import DEFAULT_CONFIG
+
+        config = DEFAULT_CONFIG
+    return {
+        name: FinancialSituationMemory(f"{name}_memory", config)
+        for name in ("bull", "bear", "trader", "invest_judge", "risk_manager")
+    }
+
+
+def teach_memories_from_history(
+    symbol: str,
+    memories: Dict[str, object],
+    price_loader: Optional[Callable[[str, str, Optional[str]], pd.DataFrame]] = None,
+    reflector=None,
+    horizon_bars: int = 5,
+    eval_results_dir: str = "eval_results",
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> dict:
+    """Batch-inject realized-outcome lessons for `symbol` into agent memories.
+
+    `memories` maps component name -> FinancialSituationMemory (the same map
+    reflect_on_outcome uses). When `reflector` is given, each decision's
+    lesson is written by one quick-LLM call
+    (``reflect_on_final_decision``); otherwise a deterministic template is
+    used — zero LLM cost, embeddings only.
+
+    Returns a summary dict; raises ValueError when the symbol has no
+    recorded completed decisions to teach from.
+    """
+    signals = load_recorded_signals(symbol, eval_results_dir=eval_results_dir)
+    if start_date:
+        signals = {d: a for d, a in signals.items() if d >= start_date}
+    if end_date:
+        signals = {d: a for d, a in signals.items() if d <= end_date}
+    if not signals:
+        raise ValueError(
+            f"No recorded completed runs with final signals found for {symbol} "
+            f"under {eval_results_dir}/."
+        )
+
+    if price_loader is None:
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        price_loader = AlpacaUtils.get_stock_data
+
+    prices = price_loader(symbol, min(signals), end_date)
+    outcomes = compute_decision_outcomes(prices, signals, horizon_bars=horizon_bars)
+
+    from tradingagents.run_logger import load_final_state_snapshot
+
+    summary = {
+        "symbol": symbol,
+        "signals_found": len(signals),
+        "outcomes_computed": len(outcomes),
+        "decisions_taught": 0,
+        "decisions_skipped_duplicate": 0,
+        "decisions_skipped_no_state": 0,
+        "lessons_written": 0,
+    }
+
+    for outcome in outcomes:
+        trade_date = outcome["trade_date"]
+        teach_key = f"{symbol}|{trade_date}|{horizon_bars}"
+
+        targets = {
+            name: memory
+            for name, memory in memories.items()
+            if memory is not None
+            and not memory.has_metadata_value("teach_key", teach_key)
+        }
+        if not targets:
+            summary["decisions_skipped_duplicate"] += 1
+            continue
+
+        state = load_final_state_snapshot(
+            symbol, trade_date, eval_results_dir=eval_results_dir
+        )
+        situation = _situation_from_state(state) if state else None
+        if not situation:
+            summary["decisions_skipped_no_state"] += 1
+            continue
+
+        if reflector is not None:
+            final_decision = str(
+                state.get("final_trade_decision") or outcome["action"]
+            )
+            lesson = reflector.reflect_on_final_decision(
+                final_decision,
+                raw_return=outcome["decision_return"],
+                alpha_return=None,
+            )
+        else:
+            lesson = _deterministic_lesson(symbol, outcome)
+
+        metadata = {
+            "source": "backtest_teach",
+            "teach_key": teach_key,
+            "symbol": symbol,
+            "trade_date": trade_date,
+            "action": outcome["action"],
+            "decision_return": float(outcome["decision_return"]),
+            "horizon_bars": int(horizon_bars),
+        }
+        written = 0
+        for memory in targets.values():
+            before = memory.situation_collection.count()
+            memory.add_situations([(situation, lesson)], extra_metadata=metadata)
+            written += memory.situation_collection.count() - before
+
+        # written == 0 means embeddings were unavailable and nothing stored;
+        # such decisions are simply not counted as taught.
+        if written:
+            summary["decisions_taught"] += 1
+            summary["lessons_written"] += written
+
+    return summary

--- a/tradingagents/daily_report.py
+++ b/tradingagents/daily_report.py
@@ -1,0 +1,194 @@
+"""Daily operations report assembled from data the system already persists.
+
+One function call produces a Markdown (and simple HTML) digest of a
+trading day: the decisions made (run logs), the safety layer's guard
+status, estimated LLM cost for the day (model-attributed), and cumulative
+realized performance per symbol from the decision log. Scheduling is left
+to the operator (cron / Task Scheduler) — the report itself is pure local
+file reading, no network, no LLM calls.
+"""
+
+from __future__ import annotations
+
+import html as html_lib
+import json
+from datetime import date
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+def _day_runs(eval_results_dir: str, day: str) -> List[dict]:
+    root = Path(eval_results_dir)
+    if not root.is_dir():
+        return []
+    runs = []
+    for path in sorted(root.glob("*/TradingAgentsStrategy_logs/runs/*.json")):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        started_day = str(payload.get("started_at") or "")[:10]
+        if started_day != day and str(payload.get("trade_date")) != day:
+            continue
+        summary = payload.get("summary") or {}
+        runs.append(
+            {
+                "symbol": str(payload.get("symbol") or "?"),
+                "status": str(payload.get("status") or "?"),
+                "signal": str(summary.get("final_signal") or "—"),
+                "tokens": int(summary.get("total_llm_tokens", 0) or 0),
+                "errors": int(summary.get("error_events", 0) or 0),
+            }
+        )
+    return runs
+
+
+def _decisions_section(runs: List[dict]) -> List[str]:
+    lines = ["## Decisions"]
+    if not runs:
+        lines.append("No completed analyses recorded for this day.")
+        return lines
+    lines.append("| Symbol | Signal | Status | LLM tokens | Errors |")
+    lines.append("|---|---|---|---:|---:|")
+    for run in runs:
+        lines.append(
+            f"| {run['symbol']} | {run['signal']} | {run['status']} "
+            f"| {run['tokens']:,} | {run['errors']} |"
+        )
+    return lines
+
+
+def _safety_section(guard) -> List[str]:
+    lines = ["## Safety status"]
+    if guard is None:
+        lines.append("Safety guard unavailable.")
+        return lines
+    try:
+        status = guard.status()
+    except Exception as exc:
+        lines.append(f"Safety status unavailable: {exc}")
+        return lines
+    if status.get("kill_switch_active"):
+        lines.append(
+            f"- 🔴 **KILL SWITCH ENGAGED**: {status.get('kill_switch_reason') or 'no reason recorded'}"
+        )
+    for name, view in (status.get("guards") or {}).items():
+        icon = "✅" if view.get("ok") else "🛑"
+        lines.append(f"- {icon} {name}: {view.get('status')}")
+    for reason in status.get("reasons") or []:
+        lines.append(f"- ⚠️ {reason}")
+    return lines
+
+
+def _cost_section(day: str, config: dict) -> List[str]:
+    lines = ["## LLM cost (estimated)"]
+    try:
+        from tradingagents.llm_cost import aggregate_costs, scan_run_costs
+
+        records = scan_run_costs(
+            eval_results_dir=config.get("results_dir", "eval_results"),
+            overrides=config.get("llm_pricing_per_million"),
+        )
+        day_bucket = aggregate_costs(records)["per_day"].get(day)
+    except Exception as exc:
+        lines.append(f"Cost data unavailable: {exc}")
+        return lines
+    if not day_bucket:
+        lines.append("No token usage recorded for this day.")
+        return lines
+    lines.append(
+        f"- {day_bucket['runs']} analysis run(s), {day_bucket['total_tokens']:,} tokens, "
+        f"≈ ${day_bucket['cost_usd']:,.2f}"
+    )
+    if day_bucket.get("unpriced_tokens"):
+        lines.append(
+            f"- {day_bucket['unpriced_tokens']:,} tokens from unpriced models are "
+            "excluded from the dollar figure."
+        )
+    lines.append(
+        "- Estimates are an upper bound (cache discounts are not recorded)."
+    )
+    return lines
+
+
+def _performance_section(config: dict) -> List[str]:
+    lines = ["## Realized performance (cumulative)"]
+    try:
+        from tradingagents.llm_cost import realized_returns_by_symbol
+
+        returns = realized_returns_by_symbol(config)
+    except Exception as exc:
+        lines.append(f"Decision-log data unavailable: {exc}")
+        return lines
+    if not returns:
+        lines.append("No resolved decisions in the log yet.")
+        return lines
+    lines.append("| Symbol | Resolved decisions | Avg realized return |")
+    lines.append("|---|---:|---:|")
+    for symbol in sorted(returns):
+        bucket = returns[symbol]
+        lines.append(
+            f"| {symbol} | {bucket['resolved']} | {bucket['avg_return']:+.2%} |"
+        )
+    return lines
+
+
+def generate_daily_report(
+    day: Optional[str] = None,
+    config: Optional[dict] = None,
+    guard=None,
+) -> str:
+    """Markdown digest for one trading day, from persisted data only."""
+    day = day or date.today().isoformat()
+    config = dict(config or {})
+    if guard is None:
+        try:
+            from tradingagents.safety import get_safety_guard
+
+            guard = get_safety_guard()
+        except Exception:
+            guard = None
+
+    runs = _day_runs(config.get("results_dir", "eval_results"), day)
+    parts: List[str] = [f"# Daily Trading Report — {day}", ""]
+    for section in (
+        _decisions_section(runs),
+        _safety_section(guard),
+        _cost_section(day, config),
+        _performance_section(config),
+    ):
+        parts.extend(section)
+        parts.append("")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def write_daily_report(
+    day: Optional[str] = None,
+    output_dir: str = "reports",
+    config: Optional[dict] = None,
+    guard=None,
+) -> Tuple[str, str]:
+    """Write the day's report as Markdown and a simple HTML page.
+
+    Returns (markdown_path, html_path).
+    """
+    day = day or date.today().isoformat()
+    markdown = generate_daily_report(day=day, config=config, guard=guard)
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    md_path = out / f"{day}.md"
+    md_path.write_text(markdown, encoding="utf-8")
+
+    html_body = html_lib.escape(markdown)
+    html_path = out / f"{day}.html"
+    html_path.write_text(
+        "<!doctype html><html><head><meta charset='utf-8'>"
+        f"<title>Daily Trading Report — {day}</title></head>"
+        "<body style='background:#111;color:#eee;font-family:monospace'>"
+        f"<pre style='white-space:pre-wrap;max-width:960px;margin:2rem auto'>{html_body}</pre>"
+        "</body></html>",
+        encoding="utf-8",
+    )
+    return str(md_path), str(html_path)

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -1063,11 +1063,22 @@ class AlpacaUtils:
                 f"Intent was generated with {intent.current_position.value} position; live position is {current_position}."
             )
 
+        target_position = {
+            "BUY": "LONG",
+            "LONG": "LONG",
+            "SHORT": "SHORT",
+        }.get(signal)
+        opens_new_exposure = bool(
+            target_position
+            and str(current_position or "NEUTRAL").upper() != target_position
+        )
+
         # Deterministic risk gate: the LLM decided direction; position size is
         # recomputed mathematically for position-opening actions when enabled.
         effective_amount = dollar_amount
         risk_sizing_info = None
-        if risk_params is not None and signal in {"BUY", "LONG", "SHORT"}:
+        risk_stop_price = None
+        if risk_params is not None and opens_new_exposure:
             order_side = "sell" if signal == "SHORT" else "buy"
             try:
                 sizing = AlpacaUtils.compute_risk_sized_amount(
@@ -1092,11 +1103,33 @@ class AlpacaUtils:
                         "risk_sizing": {"applied": True, **sizing.to_dict()},
                     }
                 effective_amount = sizing.notional
+                risk_stop_price = sizing.stop_loss_price
                 risk_sizing_info = {"applied": True, **sizing.to_dict()}
 
-        protective_prices = AlpacaUtils._resolve_protective_prices(
-            intent, signal, is_crypto, warnings
+        protective_prices = (
+            AlpacaUtils._resolve_protective_prices(
+                intent, signal, is_crypto, warnings
+            )
+            if opens_new_exposure
+            else None
         )
+        controls = intent.risk_controls
+        if (
+            risk_stop_price
+            and not is_crypto
+            and get_config().get("protective_bracket_orders_enabled", True)
+            and not controls.stop_loss_price
+        ):
+            target_price = (
+                (protective_prices or {}).get("take_profit_price")
+                or controls.take_profit_price
+            )
+            stop_is_consistent = not target_price or (
+                signal in {"BUY", "LONG"} and risk_stop_price < target_price
+            ) or (signal == "SHORT" and target_price < risk_stop_price)
+            if stop_is_consistent:
+                protective_prices = dict(protective_prices or {})
+                protective_prices["stop_loss_price"] = risk_stop_price
 
         execute_kwargs = dict(
             symbol=symbol,
@@ -1124,7 +1157,7 @@ class AlpacaUtils:
                     "Protective order submission was rejected by the broker; "
                     f"entered with a plain market order instead ({action_result.get('protective_error')})."
                 )
-        if protective_status == "advisory_only" and (
+        if protective_status == "advisory_only" and opens_new_exposure and (
             intent.risk_controls.required_controls
             or intent.risk_controls.stop_loss
             or intent.risk_controls.take_profit
@@ -1242,40 +1275,61 @@ class AlpacaUtils:
             except Exception:
                 guard = None
 
-            if guard is not None and guard.enabled:
-                verdict = guard.check_order(symbol, dollar_amount)
-                if verdict.allowed:
-                    account_state, position_value = AlpacaUtils._safety_context(symbol)
+            results = []
+
+            def _check_safety(
+                sym: str, amount: float, *, risk_reducing: bool = False
+            ):
+                """Run the guard immediately before an actual broker order.
+
+                Position flips close the old exposure first, then independently
+                gate the new exposure. This prevents a tripped loss breaker from
+                trapping a position while still refusing the replacement order.
+                """
+                if guard is None or not guard.enabled:
+                    return None
+                verdict = guard.check_order(
+                    sym,
+                    amount,
+                    risk_reducing=risk_reducing,
+                )
+                if verdict.allowed and not risk_reducing:
+                    account_state, position_value = AlpacaUtils._safety_context(sym)
                     if account_state:
                         verdict = guard.check_order(
-                            symbol,
-                            dollar_amount,
+                            sym,
+                            amount,
                             account=account_state,
                             position_value=position_value,
                         )
-                if not verdict.allowed:
-                    error_msg = "Safety layer blocked order flow: " + " ".join(verdict.reasons)
-                    print(f"[SAFETY] {error_msg}")
-                    # Ops alert (deduped by reason, so a tripped breaker
-                    # alerts once per cooldown window, not once per order).
-                    try:
-                        from tradingagents.alerts import notify_safety_block
+                return verdict
 
-                        notify_safety_block(symbol, verdict.reasons)
-                    except Exception:
-                        pass
-                    return {
-                        "success": False,
-                        "safety_blocked": True,
-                        "symbol": symbol,
-                        "current_position": current_position,
-                        "signal": signal,
-                        "actions": [],
-                        "error": error_msg,
-                        "safety_checks": verdict.checks,
-                    }
+            def _safety_failure(sym: str, verdict) -> dict:
+                error_msg = "Safety layer blocked order flow: " + " ".join(
+                    verdict.reasons
+                )
+                print(f"[SAFETY] {error_msg}")
+                # Ops alert (deduped by reason, so a tripped breaker alerts
+                # once per cooldown window, not once per order).
+                try:
+                    from tradingagents.alerts import notify_safety_block
 
-            results = []
+                    notify_safety_block(sym, verdict.reasons)
+                except Exception:
+                    pass
+                return {
+                    "success": False,
+                    "safety_blocked": True,
+                    "broker_attempted": False,
+                    "error": error_msg,
+                    "safety_checks": verdict.checks,
+                }
+
+            def _close_position(sym: str) -> dict:
+                verdict = _check_safety(sym, 0.0, risk_reducing=True)
+                if verdict is not None and not verdict.allowed:
+                    return _safety_failure(sym, verdict)
+                return AlpacaUtils.close_position(sym)
 
             # Helper to calculate integer quantity for any orders (used by both trading modes)
             def _calc_qty(sym: str, amount: float) -> Optional[int]:
@@ -1300,6 +1354,10 @@ class AlpacaUtils:
                 rejected, so a broker-side validation error never blocks the entry
                 the agents decided on (matching previous behaviour).
                 """
+                verdict = _check_safety(sym, amount)
+                if verdict is not None and not verdict.allowed:
+                    return _safety_failure(sym, verdict)
+
                 is_crypto_sym = "/" in sym.upper()
                 if is_crypto_sym and side == "buy":
                     # Crypto buys use exact notional sizing (no bracket support).
@@ -1309,6 +1367,7 @@ class AlpacaUtils:
                 if qty_int is None:
                     return {
                         "success": False,
+                        "broker_attempted": False,
                         "error": (
                             f"No trustworthy price or affordable whole-share quantity for {sym}; "
                             f"{side} order skipped"
@@ -1339,11 +1398,11 @@ class AlpacaUtils:
                         results.append({"action": "hold", "message": f"Keeping LONG position in {symbol}"})
                     elif signal == "NEUTRAL":
                         # Close LONG position
-                        close_result = AlpacaUtils.close_position(symbol)
+                        close_result = _close_position(symbol)
                         results.append({"action": "close_long", "result": close_result})
                     elif signal == "SHORT":
                         # Close LONG and open SHORT
-                        close_result = AlpacaUtils.close_position(symbol)
+                        close_result = _close_position(symbol)
                         results.append({"action": "close_long", "result": close_result})
                         if close_result.get("success"):
                             # Check if this is crypto - Alpaca doesn't support crypto short selling directly
@@ -1360,11 +1419,11 @@ class AlpacaUtils:
                         results.append({"action": "hold", "message": f"Keeping SHORT position in {symbol}"})
                     elif signal == "NEUTRAL":
                         # Close SHORT position
-                        close_result = AlpacaUtils.close_position(symbol)
+                        close_result = _close_position(symbol)
                         results.append({"action": "close_short", "result": close_result})
                     elif signal == "LONG":
                         # Close SHORT and open LONG
-                        close_result = AlpacaUtils.close_position(symbol)
+                        close_result = _close_position(symbol)
                         results.append({"action": "close_short", "result": close_result})
                         if close_result.get("success"):
                             long_result = _open_position(symbol, "buy", dollar_amount)
@@ -1401,7 +1460,7 @@ class AlpacaUtils:
                 elif signal == "SELL":
                     if has_position:
                         # Sell position
-                        sell_result = AlpacaUtils.close_position(symbol)
+                        sell_result = _close_position(symbol)
                         results.append({"action": "sell", "result": sell_result})
                     else:
                         results.append({"action": "hold", "message": f"No position to sell in {symbol}"})
@@ -1423,8 +1482,13 @@ class AlpacaUtils:
             has_failures = False
             for action in results:
                 if "result" in action:
-                    order_success = bool(action["result"].get("success", True))
-                    if guard is not None and guard.enabled:
+                    action_result = action["result"]
+                    order_success = bool(action_result.get("success", True))
+                    if (
+                        guard is not None
+                        and guard.enabled
+                        and action_result.get("broker_attempted", True)
+                    ):
                         # Feed the consecutive-rejection circuit breaker.
                         try:
                             guard.record_order_result(order_success)
@@ -1433,14 +1497,28 @@ class AlpacaUtils:
                     if not order_success:
                         has_failures = True
 
-
-            return {
+            response = {
                 "success": not has_failures,
                 "symbol": symbol,
                 "current_position": current_position,
                 "signal": signal,
                 "actions": results
             }
+            safety_failure = next(
+                (
+                    action["result"]
+                    for action in results
+                    if action.get("result", {}).get("safety_blocked")
+                ),
+                None,
+            )
+            if safety_failure:
+                response.update(
+                    safety_blocked=True,
+                    error=safety_failure.get("error"),
+                    safety_checks=safety_failure.get("safety_checks", {}),
+                )
+            return response
             
         except Exception as e:
             error_msg = f"Error executing trading action for {symbol}: {e}"

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -925,7 +925,36 @@ class AlpacaUtils:
         return result
 
     @staticmethod
-    def execute_trading_action(symbol: str, current_position: str, signal: str, 
+    def _safety_context(symbol: str):
+        """Best-effort account snapshot for the safety layer's breakers.
+
+        Returns (account, position_value); either may be None when the broker
+        is unreachable — the guard reports those checks as skipped instead of
+        guessing.
+        """
+        try:
+            client = get_alpaca_trading_client()
+            acct = client.get_account()
+            account = {
+                "equity": float(acct.equity),
+                "last_equity": float(acct.last_equity),
+            }
+        except Exception:
+            return None, None
+
+        position_value = 0.0
+        try:
+            key = symbol.upper().replace("/", "")
+            for pos in client.get_all_positions():
+                if pos.symbol.upper() == key:
+                    position_value = abs(float(pos.market_value))
+                    break
+        except Exception:
+            position_value = None
+        return account, position_value
+
+    @staticmethod
+    def execute_trading_action(symbol: str, current_position: str, signal: str,
                              dollar_amount: float, allow_shorts: bool = False) -> dict:
         """
         Execute trading action based on current position and signal
@@ -941,8 +970,45 @@ class AlpacaUtils:
             Dictionary with execution results
         """
         try:
+            # Deterministic safety gate — consulted before any broker call and
+            # entirely independent of the agents' reasoning. Cheap local checks
+            # (kill switch, notional cap, rejection streak) run first; account-
+            # based circuit breakers run only if those pass.
+            guard = None
+            try:
+                from tradingagents.safety import get_safety_guard
+
+                guard = get_safety_guard()
+            except Exception:
+                guard = None
+
+            if guard is not None and guard.enabled:
+                verdict = guard.check_order(symbol, dollar_amount)
+                if verdict.allowed:
+                    account_state, position_value = AlpacaUtils._safety_context(symbol)
+                    if account_state:
+                        verdict = guard.check_order(
+                            symbol,
+                            dollar_amount,
+                            account=account_state,
+                            position_value=position_value,
+                        )
+                if not verdict.allowed:
+                    error_msg = "Safety layer blocked order flow: " + " ".join(verdict.reasons)
+                    print(f"[SAFETY] {error_msg}")
+                    return {
+                        "success": False,
+                        "safety_blocked": True,
+                        "symbol": symbol,
+                        "current_position": current_position,
+                        "signal": signal,
+                        "actions": [],
+                        "error": error_msg,
+                        "safety_checks": verdict.checks,
+                    }
+
             results = []
-            
+
             # Helper to calculate integer quantity for any orders (used by both trading modes)
             def _calc_qty(sym: str, amount: float) -> int:
                 """Return integer share qty based on latest quote price."""
@@ -1078,10 +1144,18 @@ class AlpacaUtils:
             # Check if any critical actions failed
             has_failures = False
             for action in results:
-                if "result" in action and not action["result"].get("success", True):
-                    has_failures = True
-                    break
-                    
+                if "result" in action:
+                    order_success = bool(action["result"].get("success", True))
+                    if guard is not None and guard.enabled:
+                        # Feed the consecutive-rejection circuit breaker.
+                        try:
+                            guard.record_order_result(order_success)
+                        except Exception:
+                            pass
+                    if not order_success:
+                        has_failures = True
+
+
             return {
                 "success": not has_failures,
                 "symbol": symbol,

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -15,7 +15,10 @@ from alpaca.trading.enums import AssetClass, AssetStatus, OrderSide, QueryOrderS
 from alpaca.common.enums import Sort
 from .config import get_api_key, get_alpaca_use_paper, get_config
 from .ticker_utils import TickerUtils
-from tradingagents.agents.schemas import TradeIntent, trade_intent_action
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tradingagents.agents.schemas import TradeIntent
 
 
 # Fallback dictionary for company names
@@ -227,6 +230,8 @@ def _is_supported_data_fallback_error(error: Exception) -> bool:
             "subscription",
             "permission",
             "unauthorized",
+            # nginx-level 401s arrive as HTML pages with this phrasing
+            "authorization required",
             "forbidden",
             "not found",
             "empty",
@@ -835,7 +840,7 @@ class AlpacaUtils:
     def execute_trade_intent(
         symbol: str,
         current_position: str,
-        trade_intent: Union[TradeIntent, Dict[str, Any]],
+        trade_intent: Union["TradeIntent", Dict[str, Any]],
         dollar_amount: float,
         allow_shorts: bool = False,
     ) -> dict:
@@ -845,6 +850,11 @@ class AlpacaUtils:
         method intentionally delegates to the existing simple market/close
         execution path until bracket/OCO/OTO order placement is implemented.
         """
+        # Imported lazily: a module-level import of the agents package from
+        # here creates a dataflows <-> agents import cycle that breaks
+        # whenever dataflows is imported first.
+        from tradingagents.agents.schemas import TradeIntent, trade_intent_action
+
         try:
             intent = (
                 trade_intent

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -10,8 +10,15 @@ from alpaca.data.requests import StockBarsRequest, CryptoBarsRequest, StockLates
 from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
 from alpaca.data.enums import DataFeed
 from alpaca.trading.client import TradingClient
-from alpaca.trading.requests import GetAssetsRequest, GetOrdersRequest, MarketOrderRequest, ClosePositionRequest
-from alpaca.trading.enums import AssetClass, AssetStatus, OrderSide, QueryOrderStatus, TimeInForce
+from alpaca.trading.requests import (
+    GetAssetsRequest,
+    GetOrdersRequest,
+    MarketOrderRequest,
+    ClosePositionRequest,
+    StopLossRequest,
+    TakeProfitRequest,
+)
+from alpaca.trading.enums import AssetClass, AssetStatus, OrderClass, OrderSide, QueryOrderStatus, TimeInForce
 from alpaca.common.enums import Sort
 from .config import get_api_key, get_alpaca_use_paper, get_config
 from .ticker_utils import TickerUtils
@@ -788,6 +795,77 @@ class AlpacaUtils:
             return {"success": False, "error": error_msg}
 
     @staticmethod
+    def place_protected_market_order(
+        symbol: str,
+        side: str,
+        qty: float,
+        stop_loss_price: float = None,
+        take_profit_price: float = None,
+    ) -> dict:
+        """Place a market order with broker-side protective child orders.
+
+        Uses order_class=bracket when both a stop and a target are given, and
+        order_class=oto for a single protective leg.  Equities only: Alpaca
+        does not support bracket/OTO orders for crypto, and protective legs
+        require a whole-share quantity (no notional sizing).  Time in force is
+        GTC so the protective legs survive past the trading day.
+        """
+        try:
+            if not stop_loss_price and not take_profit_price:
+                return {"success": False, "error": "No protective price supplied"}
+
+            client = get_alpaca_trading_client()
+            alpaca_symbol = symbol.upper().replace("/", "")
+            order_side = OrderSide.BUY if side.lower() == "buy" else OrderSide.SELL
+
+            stop_loss = (
+                StopLossRequest(stop_price=round(float(stop_loss_price), 2))
+                if stop_loss_price
+                else None
+            )
+            take_profit = (
+                TakeProfitRequest(limit_price=round(float(take_profit_price), 2))
+                if take_profit_price
+                else None
+            )
+            order_class = (
+                OrderClass.BRACKET if (stop_loss and take_profit) else OrderClass.OTO
+            )
+
+            order_request = MarketOrderRequest(
+                symbol=alpaca_symbol,
+                side=order_side,
+                time_in_force=TimeInForce.GTC,
+                qty=int(qty),
+                order_class=order_class,
+                stop_loss=stop_loss,
+                take_profit=take_profit,
+            )
+            order = client.submit_order(order_request)
+
+            return {
+                "success": True,
+                "order_id": order.id,
+                "symbol": order.symbol,
+                "side": order.side,
+                "qty": float(order.qty) if order.qty else None,
+                "status": order.status,
+                "order_class": "bracket" if order_class == OrderClass.BRACKET else "oto",
+                "stop_loss_price": float(stop_loss.stop_price) if stop_loss else None,
+                "take_profit_price": float(take_profit.limit_price) if take_profit else None,
+                "message": (
+                    f"Placed {side} {order_class.value} order for {symbol} "
+                    f"(stop={stop_loss.stop_price if stop_loss else None}, "
+                    f"target={take_profit.limit_price if take_profit else None})"
+                ),
+            }
+
+        except Exception as e:
+            error_msg = f"Error placing protected {side} order for {symbol}: {e}"
+            print(error_msg)
+            return {"success": False, "error": error_msg}
+
+    @staticmethod
     def close_position(symbol: str, percentage: float = 100.0) -> dict:
         """
         Close a position (partially or completely)
@@ -902,31 +980,98 @@ class AlpacaUtils:
             warnings.append(
                 f"Intent was generated with {intent.current_position.value} position; live position is {current_position}."
             )
-        if (
-            intent.risk_controls.mode == "advisory_only"
-            and (
-                intent.risk_controls.required_controls
-                or intent.risk_controls.stop_loss
-                or intent.risk_controls.take_profit
-            )
-        ):
-            warnings.append("Broker stop-loss/take-profit orders were not submitted; controls remain advisory.")
 
-        result = AlpacaUtils.execute_trading_action(
+        protective_prices = AlpacaUtils._resolve_protective_prices(
+            intent, signal, is_crypto, warnings
+        )
+
+        execute_kwargs = dict(
             symbol=symbol,
             current_position=current_position,
             signal=signal,
             dollar_amount=dollar_amount,
             allow_shorts=allow_shorts,
         )
+        if protective_prices:
+            execute_kwargs["protective_prices"] = protective_prices
+
+        result = AlpacaUtils.execute_trading_action(**execute_kwargs)
         result["trade_intent"] = intent.model_dump(mode="json")
+
+        protective_status = "advisory_only"
+        for action in result.get("actions", []):
+            action_result = action.get("result") or {}
+            if action_result.get("order_class") == "bracket":
+                protective_status = "submitted_bracket"
+            elif action_result.get("order_class") == "oto":
+                protective_status = "submitted_oto"
+            elif action_result.get("protective_fallback"):
+                protective_status = "bracket_rejected_fallback_plain"
+                warnings.append(
+                    "Protective order submission was rejected by the broker; "
+                    f"entered with a plain market order instead ({action_result.get('protective_error')})."
+                )
+        if protective_status == "advisory_only" and (
+            intent.risk_controls.required_controls
+            or intent.risk_controls.stop_loss
+            or intent.risk_controls.take_profit
+        ):
+            warnings.append("Broker stop-loss/take-profit orders were not submitted; controls remain advisory.")
+
         result["intent_warnings"] = warnings
-        result["protective_order_status"] = "advisory_only"
+        result["protective_order_status"] = protective_status
         return result
 
     @staticmethod
-    def execute_trading_action(symbol: str, current_position: str, signal: str, 
-                             dollar_amount: float, allow_shorts: bool = False) -> dict:
+    def _resolve_protective_prices(intent, signal, is_crypto, warnings):
+        """Decide which protective price levels can be submitted to the broker.
+
+        Returns a dict for place_protected_market_order, or None when the
+        intent must stay advisory (no numeric levels, crypto asset, disabled
+        by config, non-opening action, or inconsistent levels).
+        """
+        from tradingagents.agents.schemas import extract_protective_price
+
+        controls = intent.risk_controls
+        stop_price = controls.stop_loss_price or extract_protective_price(controls.stop_loss)
+        target_price = controls.take_profit_price or extract_protective_price(controls.take_profit)
+        if not stop_price and not target_price:
+            return None
+
+        opening_long = signal in {"BUY", "LONG"}
+        opening_short = signal == "SHORT"
+        if not opening_long and not opening_short:
+            return None  # closes/holds carry nothing to protect
+
+        if is_crypto:
+            warnings.append(
+                "Protective bracket/OTO orders are not supported for crypto assets; controls remain advisory."
+            )
+            return None
+
+        if not get_config().get("protective_bracket_orders_enabled", True):
+            warnings.append(
+                "Protective bracket orders are disabled by configuration; controls remain advisory."
+            )
+            return None
+
+        if stop_price and target_price:
+            inverted = (opening_long and stop_price >= target_price) or (
+                opening_short and target_price >= stop_price
+            )
+            if inverted:
+                warnings.append(
+                    f"Protective prices are inconsistent for a {'long' if opening_long else 'short'} entry "
+                    f"(stop={stop_price}, target={target_price}); controls remain advisory."
+                )
+                return None
+
+        return {"stop_loss_price": stop_price, "take_profit_price": target_price}
+
+    @staticmethod
+    def execute_trading_action(symbol: str, current_position: str, signal: str,
+                             dollar_amount: float, allow_shorts: bool = False,
+                             protective_prices: Optional[Dict[str, float]] = None) -> dict:
         """
         Execute trading action based on current position and signal
         
@@ -957,7 +1102,35 @@ class AlpacaUtils:
                 except Exception:
                     # Fallback: at least 1 share
                     return 1
-            
+
+            def _open_position(sym: str, side: str, amount: float) -> dict:
+                """Open a position, attaching broker protective orders when available.
+
+                Falls back to a plain market order if the protected submission is
+                rejected, so a broker-side validation error never blocks the entry
+                the agents decided on (matching previous behaviour).
+                """
+                is_crypto_sym = "/" in sym.upper()
+                if not is_crypto_sym and protective_prices:
+                    qty_int = _calc_qty(sym, amount)
+                    protected = AlpacaUtils.place_protected_market_order(
+                        sym,
+                        side,
+                        qty_int,
+                        stop_loss_price=protective_prices.get("stop_loss_price"),
+                        take_profit_price=protective_prices.get("take_profit_price"),
+                    )
+                    if protected.get("success"):
+                        return protected
+                    fallback = AlpacaUtils.place_market_order(sym, side, qty=qty_int)
+                    fallback["protective_fallback"] = True
+                    fallback["protective_error"] = protected.get("error")
+                    return fallback
+                if is_crypto_sym and side == "buy":
+                    # Crypto buys use exact notional sizing (no bracket support).
+                    return AlpacaUtils.place_market_order(sym, side, notional=amount)
+                return AlpacaUtils.place_market_order(sym, side, qty=_calc_qty(sym, amount))
+
             if allow_shorts:
                 # Trading mode: LONG/NEUTRAL/SHORT signals
                 signal = signal.upper()
@@ -980,9 +1153,7 @@ class AlpacaUtils:
                                 error_msg = f"Direct short selling not supported for crypto assets like {symbol}. Position closed but short not opened."
                                 results.append({"action": "open_short", "result": {"success": False, "error": error_msg}})
                             else:
-                                # Calculate integer quantity for short (fractional shares cannot be shorted)
-                                qty_int = _calc_qty(symbol, dollar_amount)
-                                short_result = AlpacaUtils.place_market_order(symbol, "sell", qty=qty_int)
+                                short_result = _open_position(symbol, "sell", dollar_amount)
                                 results.append({"action": "open_short", "result": short_result})
                 
                 elif current_position == "SHORT":
@@ -997,28 +1168,12 @@ class AlpacaUtils:
                         close_result = AlpacaUtils.close_position(symbol)
                         results.append({"action": "close_short", "result": close_result})
                         if close_result.get("success"):
-                            # Open LONG position - use notional amount for crypto, quantity for stocks
-                            is_crypto = "/" in symbol.upper()
-                            if is_crypto:
-                                # For crypto, use exact dollar amount (notional)
-                                long_result = AlpacaUtils.place_market_order(symbol, "buy", notional=dollar_amount)
-                            else:
-                                # For stocks, calculate quantity
-                                qty_int = _calc_qty(symbol, dollar_amount)
-                                long_result = AlpacaUtils.place_market_order(symbol, "buy", qty=qty_int)
+                            long_result = _open_position(symbol, "buy", dollar_amount)
                             results.append({"action": "open_long", "result": long_result})
                 
                 elif current_position == "NEUTRAL":
                     if signal == "LONG":
-                        # Open LONG position - use notional amount for crypto, quantity for stocks
-                        is_crypto = "/" in symbol.upper()
-                        if is_crypto:
-                            # For crypto, use exact dollar amount (notional)
-                            long_result = AlpacaUtils.place_market_order(symbol, "buy", notional=dollar_amount)
-                        else:
-                            # For stocks, calculate quantity
-                            qty_int = _calc_qty(symbol, dollar_amount)
-                            long_result = AlpacaUtils.place_market_order(symbol, "buy", qty=qty_int)
+                        long_result = _open_position(symbol, "buy", dollar_amount)
                         results.append({"action": "open_long", "result": long_result})
                     elif signal == "SHORT":
                         # Check if this is crypto - Alpaca doesn't support crypto short selling directly
@@ -1027,9 +1182,7 @@ class AlpacaUtils:
                             error_msg = f"Direct short selling not supported for crypto assets like {symbol}. Consider using derivatives or margin trading platforms."
                             results.append({"action": "open_short", "result": {"success": False, "error": error_msg}})
                         else:
-                            # For stocks, attempt short selling
-                            qty_int = _calc_qty(symbol, dollar_amount)
-                            short_result = AlpacaUtils.place_market_order(symbol, "sell", qty=qty_int)
+                            short_result = _open_position(symbol, "sell", dollar_amount)
                             results.append({"action": "open_short", "result": short_result})
                     elif signal == "NEUTRAL":
                         results.append({"action": "hold", "message": f"No position needed for {symbol}"})
@@ -1043,15 +1196,7 @@ class AlpacaUtils:
                     if has_position:
                         results.append({"action": "hold", "message": f"Already have position in {symbol}"})
                     else:
-                        # Buy position - use notional amount for crypto, quantity for stocks
-                        is_crypto = "/" in symbol.upper()
-                        if is_crypto:
-                            # For crypto, use exact dollar amount (notional)
-                            buy_result = AlpacaUtils.place_market_order(symbol, "buy", notional=dollar_amount)
-                        else:
-                            # For stocks, calculate quantity
-                            qty_int = _calc_qty(symbol, dollar_amount)
-                            buy_result = AlpacaUtils.place_market_order(symbol, "buy", qty=qty_int)
+                        buy_result = _open_position(symbol, "buy", dollar_amount)
                         results.append({"action": "buy", "result": buy_result})
                 
                 elif signal == "SELL":

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -996,6 +996,14 @@ class AlpacaUtils:
                 if not verdict.allowed:
                     error_msg = "Safety layer blocked order flow: " + " ".join(verdict.reasons)
                     print(f"[SAFETY] {error_msg}")
+                    # Ops alert (deduped by reason, so a tripped breaker
+                    # alerts once per cooldown window, not once per order).
+                    try:
+                        from tradingagents.alerts import notify_safety_block
+
+                        notify_safety_block(symbol, verdict.reasons)
+                    except Exception:
+                        pass
                     return {
                         "success": False,
                         "safety_blocked": True,

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -4,7 +4,7 @@ import os
 import pandas as pd
 import time
 from datetime import datetime, timedelta
-from typing import Annotated, Union, Optional, List, Dict, Any
+from typing import Annotated, Union, Optional, List, Dict, Any, TYPE_CHECKING
 from alpaca.data.historical import StockHistoricalDataClient, CryptoHistoricalDataClient
 from alpaca.data.requests import StockBarsRequest, CryptoBarsRequest, StockLatestQuoteRequest, CryptoLatestQuoteRequest
 from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
@@ -15,7 +15,10 @@ from alpaca.trading.enums import AssetClass, AssetStatus, OrderSide, QueryOrderS
 from alpaca.common.enums import Sort
 from .config import get_api_key, get_alpaca_use_paper, get_config
 from .ticker_utils import TickerUtils
-from tradingagents.agents.schemas import TradeIntent, trade_intent_action
+# Imported lazily inside execute_trade_intent: a module-level import would
+# create a circular import (dataflows -> agents -> dataflows.interface).
+if TYPE_CHECKING:
+    from tradingagents.agents.schemas import TradeIntent
 
 
 # Fallback dictionary for company names
@@ -835,7 +838,7 @@ class AlpacaUtils:
     def execute_trade_intent(
         symbol: str,
         current_position: str,
-        trade_intent: Union[TradeIntent, Dict[str, Any]],
+        trade_intent: Union["TradeIntent", Dict[str, Any]],
         dollar_amount: float,
         allow_shorts: bool = False,
     ) -> dict:
@@ -845,6 +848,8 @@ class AlpacaUtils:
         method intentionally delegates to the existing simple market/close
         execution path until bracket/OCO/OTO order placement is implemented.
         """
+        from tradingagents.agents.schemas import TradeIntent, trade_intent_action
+
         try:
             intent = (
                 trade_intent

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -16,6 +16,12 @@ from alpaca.common.enums import Sort
 from .config import get_api_key, get_alpaca_use_paper, get_config
 from .ticker_utils import TickerUtils
 from tradingagents.agents.schemas import TradeIntent, trade_intent_action
+from tradingagents.risk.position_sizing import (
+    PositionSizer,
+    RiskParameters,
+    SizingDecision,
+    compute_atr,
+)
 
 
 # Fallback dictionary for company names
@@ -832,12 +838,77 @@ class AlpacaUtils:
             return {"success": False, "error": error_msg}
 
     @staticmethod
+    def get_account_risk_snapshot() -> dict:
+        """Numeric account snapshot for the deterministic risk engine.
+
+        Unlike get_account_info, this raises on API failure instead of
+        returning zeros: silent zero equity would read as "no capital" and
+        corrupt every downstream sizing decision.
+        """
+        client = get_alpaca_trading_client()
+        account = client.get_account()
+        equity = float(account.equity)
+        gross_exposure = 0.0
+        for position in client.get_all_positions():
+            try:
+                gross_exposure += abs(float(position.market_value))
+            except (TypeError, ValueError):
+                continue
+        return {"equity": equity, "gross_exposure": gross_exposure}
+
+    @staticmethod
+    def compute_risk_sized_amount(
+        symbol: str,
+        confidence: str,
+        requested_notional: float,
+        risk_params: Optional[dict] = None,
+        side: str = "buy",
+    ) -> SizingDecision:
+        """Run the deterministic sizing engine against live account/market data.
+
+        Raises when required data (account snapshot, price) is unavailable so
+        the caller can decide whether to fail open or block.
+        """
+        params = RiskParameters.from_dict(risk_params)
+        snapshot = AlpacaUtils.get_account_risk_snapshot()
+
+        quote = AlpacaUtils.get_latest_quote(symbol)
+        quoted = [
+            float(p)
+            for p in (quote.get("bid_price"), quote.get("ask_price"))
+            if p and float(p) > 0
+        ]
+        price = sum(quoted) / len(quoted) if quoted else None
+
+        bars = AlpacaUtils.get_stock_data_window(
+            symbol, look_back_days=max(40, params.atr_period * 3)
+        )
+        atr = compute_atr(bars, period=params.atr_period)
+
+        if price is None:
+            try:
+                price = float(bars["close"].iloc[-1])
+            except Exception:
+                raise ValueError(f"No price data available for {symbol}")
+
+        return PositionSizer(params).size_position(
+            equity=snapshot["equity"],
+            price=price,
+            atr=atr,
+            confidence=confidence,
+            requested_notional=requested_notional,
+            current_gross_exposure=snapshot["gross_exposure"],
+            side=side,
+        )
+
+    @staticmethod
     def execute_trade_intent(
         symbol: str,
         current_position: str,
         trade_intent: Union[TradeIntent, Dict[str, Any]],
         dollar_amount: float,
         allow_shorts: bool = False,
+        risk_params: Optional[dict] = None,
     ) -> dict:
         """Validate and execute a typed TradeIntent.
 
@@ -912,16 +983,49 @@ class AlpacaUtils:
         ):
             warnings.append("Broker stop-loss/take-profit orders were not submitted; controls remain advisory.")
 
+        # Deterministic risk gate: the LLM decided direction; position size is
+        # recomputed mathematically for position-opening actions when enabled.
+        effective_amount = dollar_amount
+        risk_sizing_info = None
+        if risk_params is not None and signal in {"BUY", "LONG", "SHORT"}:
+            order_side = "sell" if signal == "SHORT" else "buy"
+            try:
+                sizing = AlpacaUtils.compute_risk_sized_amount(
+                    symbol=symbol,
+                    confidence=intent.confidence,
+                    requested_notional=dollar_amount,
+                    risk_params=risk_params,
+                    side=order_side,
+                )
+            except Exception as e:
+                warnings.append(
+                    f"Risk sizing unavailable ({e}); falling back to configured notional."
+                )
+                risk_sizing_info = {"applied": False, "error": str(e)}
+            else:
+                if not sizing.approved:
+                    return {
+                        "success": False,
+                        "error": f"Trade blocked by deterministic risk engine: {sizing.reason}",
+                        "trade_intent": intent.model_dump(mode="json"),
+                        "intent_warnings": warnings,
+                        "risk_sizing": {"applied": True, **sizing.to_dict()},
+                    }
+                effective_amount = sizing.notional
+                risk_sizing_info = {"applied": True, **sizing.to_dict()}
+
         result = AlpacaUtils.execute_trading_action(
             symbol=symbol,
             current_position=current_position,
             signal=signal,
-            dollar_amount=dollar_amount,
+            dollar_amount=effective_amount,
             allow_shorts=allow_shorts,
         )
         result["trade_intent"] = intent.model_dump(mode="json")
         result["intent_warnings"] = warnings
         result["protective_order_status"] = "advisory_only"
+        if risk_sizing_info is not None:
+            result["risk_sizing"] = risk_sizing_info
         return result
 
     @staticmethod
@@ -944,19 +1048,35 @@ class AlpacaUtils:
             results = []
             
             # Helper to calculate integer quantity for any orders (used by both trading modes)
-            def _calc_qty(sym: str, amount: float) -> int:
-                """Return integer share qty based on latest quote price."""
+            def _calc_qty(sym: str, amount: float) -> Optional[int]:
+                """Return integer share qty from the latest quote, or None when no
+                trustworthy price exists. Never guess a price: a wrong assumption
+                converts a dollar budget into that many shares."""
                 try:
                     quote = AlpacaUtils.get_latest_quote(sym)
                     price = quote.get("bid_price") or quote.get("ask_price")
-                    if not price or price <= 0:
-                        # Fallback: assume $1 to avoid div-by-zero; will raise later if Alpaca rejects
-                        price = 1
-                    qty = int(amount / price)
-                    return max(qty, 1)
+                    price = float(price) if price else 0.0
                 except Exception:
-                    # Fallback: at least 1 share
-                    return 1
+                    return None
+                if price <= 0:
+                    return None
+                return max(int(amount / price), 1)
+
+            def _qty_order(sym: str, side: str, action_name: str) -> dict:
+                """Place a qty-based market order, failing safely without price data."""
+                qty_int = _calc_qty(sym, dollar_amount)
+                if qty_int is None:
+                    return {
+                        "action": action_name,
+                        "result": {
+                            "success": False,
+                            "error": f"No trustworthy price data for {sym}; {side} order skipped",
+                        },
+                    }
+                return {
+                    "action": action_name,
+                    "result": AlpacaUtils.place_market_order(sym, side, qty=qty_int),
+                }
             
             if allow_shorts:
                 # Trading mode: LONG/NEUTRAL/SHORT signals
@@ -980,10 +1100,8 @@ class AlpacaUtils:
                                 error_msg = f"Direct short selling not supported for crypto assets like {symbol}. Position closed but short not opened."
                                 results.append({"action": "open_short", "result": {"success": False, "error": error_msg}})
                             else:
-                                # Calculate integer quantity for short (fractional shares cannot be shorted)
-                                qty_int = _calc_qty(symbol, dollar_amount)
-                                short_result = AlpacaUtils.place_market_order(symbol, "sell", qty=qty_int)
-                                results.append({"action": "open_short", "result": short_result})
+                                # Fractional shares cannot be shorted; use integer qty
+                                results.append(_qty_order(symbol, "sell", "open_short"))
                 
                 elif current_position == "SHORT":
                     if signal == "SHORT":
@@ -1002,11 +1120,10 @@ class AlpacaUtils:
                             if is_crypto:
                                 # For crypto, use exact dollar amount (notional)
                                 long_result = AlpacaUtils.place_market_order(symbol, "buy", notional=dollar_amount)
+                                results.append({"action": "open_long", "result": long_result})
                             else:
                                 # For stocks, calculate quantity
-                                qty_int = _calc_qty(symbol, dollar_amount)
-                                long_result = AlpacaUtils.place_market_order(symbol, "buy", qty=qty_int)
-                            results.append({"action": "open_long", "result": long_result})
+                                results.append(_qty_order(symbol, "buy", "open_long"))
                 
                 elif current_position == "NEUTRAL":
                     if signal == "LONG":
@@ -1015,11 +1132,10 @@ class AlpacaUtils:
                         if is_crypto:
                             # For crypto, use exact dollar amount (notional)
                             long_result = AlpacaUtils.place_market_order(symbol, "buy", notional=dollar_amount)
+                            results.append({"action": "open_long", "result": long_result})
                         else:
                             # For stocks, calculate quantity
-                            qty_int = _calc_qty(symbol, dollar_amount)
-                            long_result = AlpacaUtils.place_market_order(symbol, "buy", qty=qty_int)
-                        results.append({"action": "open_long", "result": long_result})
+                            results.append(_qty_order(symbol, "buy", "open_long"))
                     elif signal == "SHORT":
                         # Check if this is crypto - Alpaca doesn't support crypto short selling directly
                         is_crypto = "/" in symbol.upper()
@@ -1028,9 +1144,7 @@ class AlpacaUtils:
                             results.append({"action": "open_short", "result": {"success": False, "error": error_msg}})
                         else:
                             # For stocks, attempt short selling
-                            qty_int = _calc_qty(symbol, dollar_amount)
-                            short_result = AlpacaUtils.place_market_order(symbol, "sell", qty=qty_int)
-                            results.append({"action": "open_short", "result": short_result})
+                            results.append(_qty_order(symbol, "sell", "open_short"))
                     elif signal == "NEUTRAL":
                         results.append({"action": "hold", "message": f"No position needed for {symbol}"})
             
@@ -1048,11 +1162,10 @@ class AlpacaUtils:
                         if is_crypto:
                             # For crypto, use exact dollar amount (notional)
                             buy_result = AlpacaUtils.place_market_order(symbol, "buy", notional=dollar_amount)
+                            results.append({"action": "buy", "result": buy_result})
                         else:
                             # For stocks, calculate quantity
-                            qty_int = _calc_qty(symbol, dollar_amount)
-                            buy_result = AlpacaUtils.place_market_order(symbol, "buy", qty=qty_int)
-                        results.append({"action": "buy", "result": buy_result})
+                            results.append(_qty_order(symbol, "buy", "buy"))
                 
                 elif signal == "SELL":
                     if has_position:

--- a/tradingagents/dataflows/reddit_utils.py
+++ b/tradingagents/dataflows/reddit_utils.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from typing import Annotated, List
 import os
 import re
-from .alpaca_utils import AlpacaUtils
 
 REDDIT_USER_AGENT = "TradingAgents/1.0"
 REDDIT_CATEGORY_SUBREDDITS = {
@@ -46,6 +45,11 @@ def get_company_name(ticker: str) -> str:
     normalized = (ticker or "").strip().upper()
     if not normalized:
         return ticker
+
+    # Imported here, not at module level: alpaca_utils pulls in the agents
+    # package, which imports dataflows.interface, which imports this module —
+    # a top-level import breaks whenever dataflows is imported before agents.
+    from .alpaca_utils import AlpacaUtils
 
     company_name = AlpacaUtils.get_company_name(normalized)
     if company_name and company_name.strip().upper() != normalized:

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -51,6 +51,7 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 200,
     # Trading settings
     "allow_shorts": False,  # False = Investment mode (BUY/HOLD/SELL), True = Trading mode (LONG/NEUTRAL/SHORT)
+    "protective_bracket_orders_enabled": True,  # Submit stop-loss/take-profit as real bracket/OTO child orders on equity entries (crypto unsupported by Alpaca)
     # Execution settings
     "parallel_analysts": True,  # True = Run analysts in parallel for faster execution, False = Sequential execution
     "parallel_risk_first_round": True,  # Run Risky/Safe/Neutral in parallel only for round 1, then revert to linear flow

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -59,6 +59,12 @@ DEFAULT_CONFIG = {
     "max_drawdown_halt_pct": 15.0,  # Circuit breaker: halt when equity falls this % below the high-water mark
     "max_consecutive_rejections": 5,  # Circuit breaker: halt after this many broker rejections in a row
     "daily_llm_token_budget": 0,  # Refuse new analyses after this many LLM tokens per day; 0 = unlimited
+    # Operational alerts (Telegram / webhook; stdlib-only, failure-isolated)
+    "alerts_enabled": True,  # Master switch; channels below must also be configured
+    "alert_telegram_bot_token": None,  # Or env ALERT_TELEGRAM_BOT_TOKEN
+    "alert_telegram_chat_id": None,  # Or env ALERT_TELEGRAM_CHAT_ID
+    "alert_webhook_url": None,  # Generic JSON webhook; or env ALERT_WEBHOOK_URL
+    "alert_cooldown_seconds": 900,  # Identical alerts suppressed within this window
     # Execution settings
     "parallel_analysts": True,  # True = Run analysts in parallel for faster execution, False = Sequential execution
     "parallel_risk_first_round": True,  # Run Risky/Safe/Neutral in parallel only for round 1, then revert to linear flow

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -51,6 +51,14 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 200,
     # Trading settings
     "allow_shorts": False,  # False = Investment mode (BUY/HOLD/SELL), True = Trading mode (LONG/NEUTRAL/SHORT)
+    # Production safety layer (deterministic, independent of agent logic)
+    "safety_enabled": True,  # Master switch for pre-trade checks + circuit breakers + kill switch
+    "max_trade_notional_usd": 25000.0,  # Per-order notional cap; 0 = uncapped
+    "max_symbol_concentration_pct": 25.0,  # Max per-symbol exposure as % of equity; 0 = uncapped
+    "daily_loss_halt_pct": 10.0,  # Circuit breaker: halt trading when equity falls this % vs yesterday
+    "max_drawdown_halt_pct": 15.0,  # Circuit breaker: halt when equity falls this % below the high-water mark
+    "max_consecutive_rejections": 5,  # Circuit breaker: halt after this many broker rejections in a row
+    "daily_llm_token_budget": 0,  # Refuse new analyses after this many LLM tokens per day; 0 = unlimited
     # Execution settings
     "parallel_analysts": True,  # True = Run analysts in parallel for faster execution, False = Sequential execution
     "parallel_risk_first_round": True,  # Run Risky/Safe/Neutral in parallel only for round 1, then revert to linear flow

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -51,6 +51,17 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 200,
     # Trading settings
     "allow_shorts": False,  # False = Investment mode (BUY/HOLD/SELL), True = Trading mode (LONG/NEUTRAL/SHORT)
+    # Market regime detection (deterministic, fit-free; filter not signal)
+    "regime_detection_enabled": True,  # Inject regime block into the market report and scale sizing
+    "regime_vol_window": 20,  # Bars for realized-volatility estimate
+    "regime_turbulent_percentile": 75.0,  # Vol percentile above which the regime is turbulent
+    "regime_turbulent_abs_annual_vol_pct": 40.0,  # Absolute annualized-vol floor for turbulence
+    "regime_trend_window": 50,  # SMA window for the trend dimension
+    "regime_thin_liquidity_ratio": 0.7,  # Recent/baseline dollar-volume ratio below this = thinning
+    "regime_turbulent_size_factor": 0.5,  # Size multiplier in turbulent volatility
+    "regime_downtrend_size_factor": 0.75,  # Size multiplier in a downtrend
+    "regime_thin_liquidity_size_factor": 0.85,  # Size multiplier when liquidity is thinning
+    "regime_min_risk_multiplier": 0.25,  # Floor for the combined regime multiplier
     # Execution settings
     "parallel_analysts": True,  # True = Run analysts in parallel for faster execution, False = Sequential execution
     "parallel_risk_first_round": True,  # Run Risky/Safe/Neutral in parallel only for round 1, then revert to linear flow

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -51,6 +51,11 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 200,
     # Trading settings
     "allow_shorts": False,  # False = Investment mode (BUY/HOLD/SELL), True = Trading mode (LONG/NEUTRAL/SHORT)
+    # Deterministic risk sizing: when enabled, position size for opening trades
+    # is recomputed by tradingagents.risk (fractional Kelly, ATR stops, exposure
+    # caps) with the configured trade amount acting as a hard ceiling.
+    "risk_sizing_enabled": False,
+    "risk_sizing_params": {},  # optional RiskParameters overrides (see tradingagents/risk/position_sizing.py)
     # Execution settings
     "parallel_analysts": True,  # True = Run analysts in parallel for faster execution, False = Sequential execution
     "parallel_risk_first_round": True,  # Run Risky/Safe/Neutral in parallel only for round 1, then revert to linear flow

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -51,6 +51,15 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 200,
     # Trading settings
     "allow_shorts": False,  # False = Investment mode (BUY/HOLD/SELL), True = Trading mode (LONG/NEUTRAL/SHORT)
+    # Portfolio-level intelligence (deterministic sizing above per-symbol decisions)
+    "portfolio_intelligence_enabled": True,  # Master switch for portfolio-aware sizing of new long exposure
+    "portfolio_lookback_bars": 60,  # Daily bars used for correlation / volatility estimates
+    "portfolio_high_correlation": 0.6,  # Positive correlation above this = duplicated risk
+    "portfolio_correlated_size_factor": 0.5,  # Size multiplier applied on a correlation hit
+    "portfolio_vol_sizing_enabled": True,  # Inverse-volatility (simplified risk parity) sizing
+    "portfolio_target_daily_vol_pct": 2.0,  # Realized daily vol above this scales size by target/realized
+    "portfolio_max_gross_exposure_pct": 100.0,  # Total book value cap as % of equity; 0 = uncapped
+    "portfolio_min_size_factor": 0.25,  # Floor on combined penalties so trades never silently vanish
     # Execution settings
     "parallel_analysts": True,  # True = Run analysts in parallel for faster execution, False = Sequential execution
     "parallel_risk_first_round": True,  # Run Risky/Safe/Neutral in parallel only for round 1, then revert to linear flow

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -19,6 +19,13 @@ DEFAULT_CONFIG = {
     # Feed realized outcomes back into the per-agent memories (5 quick-LLM
     # reflection calls per resolved decision). Requires OpenAI embeddings.
     "reflection_on_outcome_enabled": True,
+    # FinMem-style memory maintenance (arXiv:2311.13743): Ebbinghaus time
+    # decay with importance-scaled stability, near-duplicate pruning, and a
+    # per-collection size cap. Runs after outcome reflections.
+    "memory_maintenance_enabled": True,
+    "memory_max_entries_per_collection": 500,
+    "memory_duplicate_similarity_threshold": 0.97,
+    "memory_recency_purge_threshold": 0.05,
     "checkpoint_enabled": False,
     # "data_dir": "/Users/yluo/Documents/Code/ScAI/FR1-data",
     "data_dir": "data/ScAI/FR1-data",

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -10,6 +10,15 @@ DEFAULT_CONFIG = {
         os.path.join(_TRADINGAGENTS_HOME, "memory", "trading_memory.md"),
     ),
     "memory_log_max_entries": None,
+    # Self-learning memory: when set, the per-agent ChromaDB reflection
+    # memories persist across restarts instead of resetting each session.
+    "agent_memory_dir": os.getenv(
+        "TRADINGAGENTS_AGENT_MEMORY_DIR",
+        os.path.join(_TRADINGAGENTS_HOME, "memory", "agent_memory"),
+    ),
+    # Feed realized outcomes back into the per-agent memories (5 quick-LLM
+    # reflection calls per resolved decision). Requires OpenAI embeddings.
+    "reflection_on_outcome_enabled": True,
     "checkpoint_enabled": False,
     # "data_dir": "/Users/yluo/Documents/Code/ScAI/FR1-data",
     "data_dir": "data/ScAI/FR1-data",

--- a/tradingagents/graph/reflection.py
+++ b/tradingagents/graph/reflection.py
@@ -96,6 +96,39 @@ class Reflector:
         )
         risk_manager_memory.add_situations([(situation, result)])
 
+    def reflect_on_outcome(
+        self,
+        state: Dict[str, Any],
+        returns_losses: str,
+        memories: Dict[str, Any],
+    ) -> Dict[str, bool]:
+        """Run every per-agent reflection against a realized outcome.
+
+        `state` is a final_state dict (live or recovered from a run log) and
+        `memories` maps component name -> FinancialSituationMemory. Each
+        component is isolated: one failure (missing key, LLM error) must not
+        block the remaining lessons from being written.
+        """
+        reflectors = {
+            "bull": self.reflect_bull_researcher,
+            "bear": self.reflect_bear_researcher,
+            "trader": self.reflect_trader,
+            "invest_judge": self.reflect_invest_judge,
+            "risk_manager": self.reflect_risk_manager,
+        }
+        results: Dict[str, bool] = {}
+        for name, reflect in reflectors.items():
+            memory = memories.get(name)
+            if memory is None:
+                continue
+            try:
+                reflect(state, returns_losses, memory)
+                results[name] = True
+            except Exception as exc:
+                print(f"[REFLECTION] Skipped {name} reflection: {exc}")
+                results[name] = False
+        return results
+
     def reflect_on_final_decision(
         self,
         final_decision: str,

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -337,17 +337,20 @@ class TradingAgentsGraph:
                 f"Realized return over {holding_days} trading days: "
                 f"{raw_return:+.1%} (alpha: {alpha_text})."
             )
-            self.reflector.reflect_on_outcome(
-                state,
-                returns_losses,
-                {
-                    "bull": self.bull_memory,
-                    "bear": self.bear_memory,
-                    "trader": self.trader_memory,
-                    "invest_judge": self.invest_judge_memory,
-                    "risk_manager": self.risk_manager_memory,
-                },
-            )
+            memories = {
+                "bull": self.bull_memory,
+                "bear": self.bear_memory,
+                "trader": self.trader_memory,
+                "invest_judge": self.invest_judge_memory,
+                "risk_manager": self.risk_manager_memory,
+            }
+            self.reflector.reflect_on_outcome(state, returns_losses, memories)
+            if self.config.get("memory_maintenance_enabled", True):
+                from tradingagents.agents.utils.memory_maintenance import (
+                    maintain_all_memories,
+                )
+
+                maintain_all_memories(memories, self.config)
         except Exception as exc:
             print(f"[REFLECTION] Outcome reflection skipped for {ticker} {trade_date}: {exc}")
 

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -135,12 +135,12 @@ class TradingAgentsGraph:
         
         self.toolkit = Toolkit(config=self.config)
 
-        # Initialize memories
-        self.bull_memory = FinancialSituationMemory("bull_memory")
-        self.bear_memory = FinancialSituationMemory("bear_memory")
-        self.trader_memory = FinancialSituationMemory("trader_memory")
-        self.invest_judge_memory = FinancialSituationMemory("invest_judge_memory")
-        self.risk_manager_memory = FinancialSituationMemory("risk_manager_memory")
+        # Initialize memories (persistent when agent_memory_dir is configured)
+        self.bull_memory = FinancialSituationMemory("bull_memory", self.config)
+        self.bear_memory = FinancialSituationMemory("bear_memory", self.config)
+        self.trader_memory = FinancialSituationMemory("trader_memory", self.config)
+        self.invest_judge_memory = FinancialSituationMemory("invest_judge_memory", self.config)
+        self.risk_manager_memory = FinancialSituationMemory("risk_manager_memory", self.config)
         self.memory_log = TradingMemoryLog(self.config)
 
         # Create tool nodes
@@ -301,6 +301,55 @@ class TradingAgentsGraph:
                 holding_days=holding_days,
                 reflection=reflection,
             )
+            self._reflect_agents_on_outcome(
+                ticker, entry_date_text, raw_return, alpha_return, holding_days
+            )
+
+    def _reflect_agents_on_outcome(
+        self,
+        ticker: str,
+        trade_date: str,
+        raw_return: float,
+        alpha_return: Optional[float],
+        holding_days: int,
+    ) -> None:
+        """Feed a realized outcome back into the per-agent ChromaDB memories.
+
+        Recovers the original run's final_state from the persisted run log,
+        so each agent reflects on the exact situation it saw when the
+        decision was made — not on today's state. Best-effort by design:
+        reflection failures must never affect the current analysis run.
+        """
+        if not self.config.get("reflection_on_outcome_enabled", True):
+            return
+        try:
+            from tradingagents.run_logger import load_final_state_snapshot
+
+            state = load_final_state_snapshot(ticker, trade_date)
+            if not state:
+                return
+            alpha_text = (
+                f"{alpha_return:+.1%} vs benchmark"
+                if alpha_return is not None
+                else "n/a"
+            )
+            returns_losses = (
+                f"Realized return over {holding_days} trading days: "
+                f"{raw_return:+.1%} (alpha: {alpha_text})."
+            )
+            self.reflector.reflect_on_outcome(
+                state,
+                returns_losses,
+                {
+                    "bull": self.bull_memory,
+                    "bear": self.bear_memory,
+                    "trader": self.trader_memory,
+                    "invest_judge": self.invest_judge_memory,
+                    "risk_manager": self.risk_manager_memory,
+                },
+            )
+        except Exception as exc:
+            print(f"[REFLECTION] Outcome reflection skipped for {ticker} {trade_date}: {exc}")
 
     def _create_tool_nodes(self) -> Dict[str, ToolNode]:
         """Create tool nodes for different data sources."""

--- a/tradingagents/llm_cost.py
+++ b/tradingagents/llm_cost.py
@@ -1,0 +1,255 @@
+"""LLM cost accounting over the persisted run logs.
+
+Turns the token usage the audit logger already records into attributable
+dollar estimates: per analysis run, per day, per symbol, and per model.
+Attribution — not an aggregate bill — is the point; an unattributed total
+cannot answer "which symbol or model made costs jump".
+
+Honesty rules:
+- Prices drift and differ by account tier, so the built-in table is an
+  estimate and every entry can be overridden via the
+  ``llm_pricing_per_million`` config key.
+- Unknown models are never guessed: their tokens are surfaced separately
+  as ``unpriced_tokens`` instead of silently costing $0.
+- Run logs do not record cache-read discounts, so estimates are an upper
+  bound on the true bill.
+
+Everything here is pure file reading and arithmetic — zero network calls.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# USD per 1M tokens: {"input": ..., "output": ...}. Prefix-matched
+# (longest prefix wins), case-insensitive. Estimates — override via the
+# `llm_pricing_per_million` config key when your bill disagrees.
+DEFAULT_PRICING_PER_MILLION: Dict[str, Dict[str, float]] = {
+    # OpenAI
+    "gpt-5.4-mini": {"input": 0.25, "output": 2.00},
+    "gpt-5.4-nano": {"input": 0.05, "output": 0.40},
+    "gpt-5-mini": {"input": 0.25, "output": 2.00},
+    "gpt-5-nano": {"input": 0.05, "output": 0.40},
+    "gpt-5": {"input": 1.25, "output": 10.00},
+    "gpt-4.1-mini": {"input": 0.40, "output": 1.60},
+    "gpt-4.1-nano": {"input": 0.10, "output": 0.40},
+    "gpt-4.1": {"input": 2.00, "output": 8.00},
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    "gpt-4o": {"input": 2.50, "output": 10.00},
+    "o4-mini": {"input": 1.10, "output": 4.40},
+    "o3": {"input": 2.00, "output": 8.00},
+    # Anthropic
+    "claude-3-5-haiku": {"input": 0.80, "output": 4.00},
+    "claude-haiku": {"input": 0.80, "output": 4.00},
+    "claude-sonnet": {"input": 3.00, "output": 15.00},
+    "claude-opus": {"input": 15.00, "output": 75.00},
+    "claude": {"input": 3.00, "output": 15.00},
+    # DeepSeek
+    "deepseek-chat": {"input": 0.27, "output": 1.10},
+    "deepseek-reasoner": {"input": 0.55, "output": 2.19},
+    # Google
+    "gemini-2.5-flash": {"input": 0.30, "output": 2.50},
+    "gemini-2.5-pro": {"input": 1.25, "output": 10.00},
+    # xAI
+    "grok-4": {"input": 3.00, "output": 15.00},
+    "grok-3-mini": {"input": 0.30, "output": 0.50},
+    "grok": {"input": 3.00, "output": 15.00},
+}
+
+
+def resolve_pricing(
+    model: str, overrides: Optional[Dict[str, Dict[str, float]]] = None
+) -> Optional[Dict[str, float]]:
+    """Longest-prefix price lookup; overrides shadow the defaults."""
+    table = dict(DEFAULT_PRICING_PER_MILLION)
+    for key, value in (overrides or {}).items():
+        if isinstance(value, dict) and "input" in value and "output" in value:
+            table[key.lower()] = {
+                "input": float(value["input"]),
+                "output": float(value["output"]),
+            }
+    name = str(model or "").lower()
+    best_prefix = None
+    for prefix in table:
+        if name.startswith(prefix.lower()):
+            if best_prefix is None or len(prefix) > len(best_prefix):
+                best_prefix = prefix
+    return dict(table[best_prefix]) if best_prefix else None
+
+
+def estimate_cost_usd(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    overrides: Optional[Dict[str, Dict[str, float]]] = None,
+) -> Optional[float]:
+    """Dollar estimate for a token count, or None for unknown models."""
+    pricing = resolve_pricing(model, overrides=overrides)
+    if pricing is None:
+        return None
+    return (
+        int(input_tokens or 0) * pricing["input"]
+        + int(output_tokens or 0) * pricing["output"]
+    ) / 1_000_000.0
+
+
+def scan_run_costs(
+    eval_results_dir: str = "eval_results",
+    overrides: Optional[Dict[str, Dict[str, float]]] = None,
+) -> List[dict]:
+    """One cost record per persisted run, model-attributed where possible.
+
+    Token counts come from each run's llm_call events (which carry the
+    model name and usage); runs without usable events fall back to the
+    summary totals as unpriced tokens.
+    """
+    root = Path(eval_results_dir)
+    if not root.is_dir():
+        return []
+
+    records: List[dict] = []
+    for path in sorted(root.glob("*/TradingAgentsStrategy_logs/runs/*.json")):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        per_model: Dict[str, Dict[str, int]] = {}
+        for event in payload.get("events") or []:
+            if event.get("type") != "llm_call":
+                continue
+            event_payload = event.get("payload") or {}
+            usage = event_payload.get("usage") or {}
+            model = str(event_payload.get("model") or "").strip()
+            input_tokens = int(usage.get("input_tokens", 0) or 0)
+            output_tokens = int(usage.get("output_tokens", 0) or 0)
+            if not model or (input_tokens <= 0 and output_tokens <= 0):
+                continue
+            bucket = per_model.setdefault(model, {"input": 0, "output": 0})
+            bucket["input"] += input_tokens
+            bucket["output"] += output_tokens
+
+        input_total = sum(b["input"] for b in per_model.values())
+        output_total = sum(b["output"] for b in per_model.values())
+        cost: Optional[float] = None
+        unpriced = 0
+        models: Dict[str, dict] = {}
+        for model, bucket in per_model.items():
+            model_cost = estimate_cost_usd(
+                model, bucket["input"], bucket["output"], overrides=overrides
+            )
+            models[model] = {
+                "input_tokens": bucket["input"],
+                "output_tokens": bucket["output"],
+                "cost_usd": model_cost,
+            }
+            if model_cost is None:
+                unpriced += bucket["input"] + bucket["output"]
+            else:
+                cost = (cost or 0.0) + model_cost
+
+        total_tokens = input_total + output_total
+        if not per_model:
+            # No attributable events: report the summary total as unpriced.
+            total_tokens = int(
+                (payload.get("summary") or {}).get("total_llm_tokens", 0) or 0
+            )
+            unpriced = total_tokens
+
+        records.append(
+            {
+                "symbol": str(payload.get("symbol") or path.parts[-4]),
+                "trade_date": str(payload.get("trade_date") or ""),
+                "started_at": str(payload.get("started_at") or ""),
+                "status": str(payload.get("status") or ""),
+                "run_id": str(payload.get("run_id") or path.stem),
+                "input_tokens": input_total,
+                "output_tokens": output_total,
+                "total_tokens": total_tokens,
+                "cost_usd": cost,
+                "unpriced_tokens": unpriced,
+                "models": models,
+            }
+        )
+    return records
+
+
+def _bucket(target: Dict[str, dict], key: str) -> dict:
+    return target.setdefault(
+        key, {"runs": 0, "total_tokens": 0, "cost_usd": 0.0, "unpriced_tokens": 0}
+    )
+
+
+def aggregate_costs(records: List[dict]) -> dict:
+    """Roll run records up into per-day, per-symbol, per-model, and totals."""
+    per_day: Dict[str, dict] = {}
+    per_symbol: Dict[str, dict] = {}
+    per_model: Dict[str, dict] = {}
+    totals = {"runs": 0, "total_tokens": 0, "cost_usd": 0.0, "unpriced_tokens": 0}
+
+    for record in records:
+        day = (record.get("started_at") or "")[:10] or record.get("trade_date") or "?"
+        cost = record.get("cost_usd") or 0.0
+        for bucket in (_bucket(per_day, day), _bucket(per_symbol, record["symbol"]), totals):
+            bucket["runs"] += 1
+            bucket["total_tokens"] += int(record.get("total_tokens", 0) or 0)
+            bucket["cost_usd"] += cost
+            bucket["unpriced_tokens"] += int(record.get("unpriced_tokens", 0) or 0)
+        for model, stats in (record.get("models") or {}).items():
+            model_bucket = per_model.setdefault(
+                model, {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0, "unpriced": False}
+            )
+            model_bucket["input_tokens"] += stats.get("input_tokens", 0)
+            model_bucket["output_tokens"] += stats.get("output_tokens", 0)
+            if stats.get("cost_usd") is None:
+                model_bucket["unpriced"] = True
+            else:
+                model_bucket["cost_usd"] += stats["cost_usd"]
+
+    return {
+        "per_day": per_day,
+        "per_symbol": per_symbol,
+        "per_model": per_model,
+        "totals": totals,
+    }
+
+
+def parse_return_pct(raw) -> Optional[float]:
+    """'+3.2%' -> 0.032; anything unparseable -> None."""
+    if raw is None:
+        return None
+    text = str(raw).strip().rstrip("%")
+    try:
+        return float(text) / 100.0
+    except ValueError:
+        return None
+
+
+def realized_returns_by_symbol(config: Optional[dict] = None) -> Dict[str, dict]:
+    """Average realized return per symbol from the resolved decision log.
+
+    Joins the cost side ("what did analyzing this symbol cost") with the
+    outcome side ("what did its decisions actually return").
+    """
+    from tradingagents.agents.utils.memory import TradingMemoryLog
+
+    log = TradingMemoryLog(config or {})
+    per_symbol: Dict[str, dict] = {}
+    for entry in log.load_entries():
+        if entry.get("pending"):
+            continue
+        realized = parse_return_pct(entry.get("raw"))
+        if realized is None:
+            continue
+        bucket = per_symbol.setdefault(
+            entry["ticker"], {"resolved": 0, "sum_return": 0.0}
+        )
+        bucket["resolved"] += 1
+        bucket["sum_return"] += realized
+
+    for bucket in per_symbol.values():
+        bucket["avg_return"] = bucket["sum_return"] / bucket["resolved"]
+    return per_symbol

--- a/tradingagents/portfolio/__init__.py
+++ b/tradingagents/portfolio/__init__.py
@@ -1,0 +1,306 @@
+"""Deterministic portfolio-level intelligence.
+
+The agent pipeline analyzes each symbol in isolation; nothing ever looks at
+the book as a whole. This layer sits above the per-symbol decisions and
+adjusts the size of NEW long exposure with three plain-arithmetic guards —
+zero LLM involvement, so it cannot be argued out of a limit:
+
+- **Correlation penalty**: a candidate whose returns correlate above a
+  threshold (default 0.6 — the level practitioners treat as duplicated
+  risk) with any existing position is scaled down. Only positive
+  correlation is penalized; a strong negative correlation is a hedge.
+- **Inverse-volatility sizing** (simplified risk parity): realized daily
+  volatility above the target scales the size by target/realized. Chosen
+  over optimization because it needs no return forecasts and stays stable.
+- **Gross exposure cap**: total book value is clipped to a percentage of
+  equity; this is the only guard allowed to zero a trade, and it says why.
+
+Sizing rules: factors never size a trade UP (the agents' requested amount
+is the ceiling), missing data never punishes (factor 1.0 plus a warning),
+and combined penalties are floored so trades cannot silently vanish.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Tuple
+
+import pandas as pd
+
+_MIN_OVERLAP_BARS = 20  # fewer shared bars than this makes correlation noise
+
+
+@dataclass
+class PortfolioLimitsConfig:
+    enabled: bool = True
+    lookback_bars: int = 60
+    high_correlation: float = 0.6
+    correlated_size_factor: float = 0.5
+    vol_sizing_enabled: bool = True
+    target_daily_vol_pct: float = 2.0
+    max_gross_exposure_pct: float = 100.0
+    min_size_factor: float = 0.25
+
+    @classmethod
+    def from_config(cls, config: Optional[dict]) -> "PortfolioLimitsConfig":
+        cfg = config or {}
+        mapping = {
+            "enabled": "portfolio_intelligence_enabled",
+            "lookback_bars": "portfolio_lookback_bars",
+            "high_correlation": "portfolio_high_correlation",
+            "correlated_size_factor": "portfolio_correlated_size_factor",
+            "vol_sizing_enabled": "portfolio_vol_sizing_enabled",
+            "target_daily_vol_pct": "portfolio_target_daily_vol_pct",
+            "max_gross_exposure_pct": "portfolio_max_gross_exposure_pct",
+            "min_size_factor": "portfolio_min_size_factor",
+        }
+        kwargs = {}
+        for field_name, key in mapping.items():
+            if cfg.get(key) is not None:
+                kwargs[field_name] = cfg[key]
+        return cls(**kwargs)
+
+
+@dataclass
+class PortfolioVerdict:
+    symbol: str
+    requested_notional: float
+    adjusted_notional: float
+    allowed: bool
+    config: PortfolioLimitsConfig
+    correlations: Dict[str, float] = field(default_factory=dict)
+    factors: Dict[str, float] = field(default_factory=dict)
+    reasons: List[str] = field(default_factory=list)
+
+
+def daily_returns(prices) -> pd.Series:
+    """Close-to-close daily returns from an OHLCV frame or a close series."""
+    if isinstance(prices, pd.Series):
+        closes = prices.astype(float)
+    else:
+        frame = prices.copy()
+        frame.columns = [str(c).lower() for c in frame.columns]
+        if "timestamp" in frame.columns:
+            frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+            frame = frame.set_index("timestamp")
+        if "close" not in frame.columns:
+            raise ValueError("Price data needs a 'close' column.")
+        closes = frame["close"].astype(float)
+    return closes.pct_change().dropna()
+
+
+def realized_daily_vol(returns: pd.Series) -> float:
+    """Standard deviation of daily returns; 0.0 when undefined."""
+    if returns is None or len(returns) < 2:
+        return 0.0
+    vol = float(returns.std())
+    return vol if pd.notna(vol) else 0.0
+
+
+def _candidate_returns(
+    symbol: str, price_history: Dict[str, pd.DataFrame], lookback: int
+) -> Optional[pd.Series]:
+    frame = (price_history or {}).get(symbol)
+    if frame is None or len(frame) < 3:
+        return None
+    try:
+        return daily_returns(frame).tail(lookback)
+    except (ValueError, KeyError, TypeError):
+        return None
+
+
+def assess_new_position(
+    symbol: str,
+    requested_notional: float,
+    equity: Optional[float],
+    open_positions: Dict[str, float],
+    price_history: Dict[str, pd.DataFrame],
+    config: Optional[PortfolioLimitsConfig] = None,
+) -> PortfolioVerdict:
+    """Size a proposed NEW position against the whole book.
+
+    `open_positions` maps symbol -> absolute market value; `price_history`
+    maps symbol -> OHLCV frame (the candidate's own history included).
+    """
+    config = config or PortfolioLimitsConfig()
+    requested = max(float(requested_notional or 0.0), 0.0)
+    verdict = PortfolioVerdict(
+        symbol=symbol,
+        requested_notional=requested,
+        adjusted_notional=requested,
+        allowed=True,
+        config=config,
+    )
+
+    candidate = _candidate_returns(symbol, price_history, config.lookback_bars)
+    factor = 1.0
+
+    # --- correlation against every open position -----------------------------
+    if candidate is not None and open_positions:
+        max_positive = None
+        for other_symbol in open_positions:
+            if other_symbol == symbol:
+                continue
+            other = _candidate_returns(other_symbol, price_history, config.lookback_bars)
+            if other is None:
+                continue
+            aligned = pd.concat([candidate, other], axis=1, join="inner").dropna()
+            if len(aligned) < _MIN_OVERLAP_BARS:
+                continue
+            corr = float(aligned.iloc[:, 0].corr(aligned.iloc[:, 1]))
+            if pd.isna(corr):
+                continue
+            verdict.correlations[other_symbol] = corr
+            if max_positive is None or corr > max_positive:
+                max_positive = corr
+        if max_positive is not None and max_positive > config.high_correlation:
+            factor *= config.correlated_size_factor
+            verdict.factors["correlation"] = config.correlated_size_factor
+            worst = max(verdict.correlations, key=verdict.correlations.get)
+            verdict.reasons.append(
+                f"High correlation with open position {worst} "
+                f"({max_positive:+.2f} > {config.high_correlation:g}): "
+                f"size scaled by {config.correlated_size_factor:g}."
+            )
+
+    # --- inverse-volatility sizing -------------------------------------------
+    if config.vol_sizing_enabled and candidate is not None:
+        vol_pct = realized_daily_vol(candidate) * 100.0
+        if vol_pct > config.target_daily_vol_pct > 0:
+            vol_factor = config.target_daily_vol_pct / vol_pct
+            factor *= vol_factor
+            verdict.factors["volatility"] = vol_factor
+            verdict.reasons.append(
+                f"Realized daily volatility {vol_pct:.2f}% exceeds the "
+                f"{config.target_daily_vol_pct:g}% target: size scaled by {vol_factor:.2f}."
+            )
+
+    if candidate is None:
+        verdict.reasons.append(
+            f"Price history unavailable for {symbol} — correlation and "
+            "volatility sizing skipped, size unchanged."
+        )
+
+    # Penalties are floored so a trade the agents wanted cannot silently
+    # shrink to dust; only the exposure cap below may zero it.
+    if factor < config.min_size_factor:
+        factor = config.min_size_factor
+        verdict.factors["floor"] = config.min_size_factor
+    verdict.adjusted_notional = requested * factor
+
+    # --- gross exposure cap ----------------------------------------------------
+    cap_pct = float(config.max_gross_exposure_pct or 0)
+    equity_value = float(equity) if equity else None
+    if cap_pct > 0 and equity_value and equity_value > 0:
+        gross = sum(abs(float(v or 0.0)) for v in (open_positions or {}).values())
+        headroom = equity_value * cap_pct / 100.0 - gross
+        if verdict.adjusted_notional > headroom:
+            clipped = max(headroom, 0.0)
+            verdict.reasons.append(
+                f"Gross exposure ${gross:,.0f} against a "
+                f"{cap_pct:g}% cap of ${equity_value:,.0f} equity leaves "
+                f"${max(headroom, 0.0):,.0f} headroom: size clipped."
+            )
+            verdict.adjusted_notional = clipped
+    elif cap_pct > 0:
+        verdict.reasons.append(
+            "Account equity unavailable — gross exposure cap skipped."
+        )
+
+    verdict.allowed = verdict.adjusted_notional > 0
+    return verdict
+
+
+def adjust_new_position_notional(
+    symbol: str,
+    action: str,
+    requested_notional: float,
+    gather_state: Callable[[], Tuple[Optional[float], Dict[str, float], Dict[str, pd.DataFrame]]],
+    config: Optional[PortfolioLimitsConfig] = None,
+) -> float:
+    """Execution-time hook: portfolio-aware size for NEW long exposure only.
+
+    SELL/HOLD/NEUTRAL (closing or keeping) pass through untouched — the
+    layer limits what gets added to the book, never what leaves it. Any
+    failure in `gather_state` (broker down, bad data) returns the original
+    amount: the portfolio layer must never block a trade by breaking.
+    """
+    config = config or PortfolioLimitsConfig()
+    if not config.enabled or str(action or "").upper() not in ("BUY", "LONG"):
+        return requested_notional
+    try:
+        equity, open_positions, price_history = gather_state()
+        verdict = assess_new_position(
+            symbol,
+            requested_notional,
+            equity,
+            open_positions or {},
+            price_history or {},
+            config=config,
+        )
+        for reason in verdict.reasons:
+            print(f"[PORTFOLIO] {symbol}: {reason}")
+        if verdict.adjusted_notional != requested_notional:
+            print(
+                f"[PORTFOLIO] {symbol}: requested ${requested_notional:,.0f} -> "
+                f"adjusted ${verdict.adjusted_notional:,.0f}"
+            )
+        return verdict.adjusted_notional
+    except Exception as exc:
+        print(f"[PORTFOLIO] Sizing skipped for {symbol}: {exc}")
+        return requested_notional
+
+
+def gather_portfolio_state_via_alpaca(
+    symbol: str,
+    lookback_days: int = 120,
+) -> Tuple[Optional[float], Dict[str, float], Dict[str, pd.DataFrame]]:
+    """Collect (equity, open positions, price history) from Alpaca.
+
+    Imported lazily so this package stays importable without the dataflows
+    stack; the caller wraps failures via adjust_new_position_notional.
+    """
+    from datetime import date, timedelta
+
+    from tradingagents.dataflows.alpaca_utils import (
+        AlpacaUtils,
+        get_alpaca_trading_client,
+    )
+
+    client = get_alpaca_trading_client()
+    account = client.get_account()
+    try:
+        equity = float(account.equity)
+    except (TypeError, ValueError):
+        equity = None
+
+    open_positions: Dict[str, float] = {}
+    for pos in client.get_all_positions():
+        try:
+            open_positions[str(pos.symbol).upper()] = abs(float(pos.market_value))
+        except (TypeError, ValueError):
+            continue
+
+    start = (date.today() - timedelta(days=lookback_days)).isoformat()
+    price_history: Dict[str, pd.DataFrame] = {}
+    for wanted in {symbol.upper().replace("/", ""), *open_positions}:
+        try:
+            price_history[wanted] = AlpacaUtils.get_stock_data(wanted, start, None)
+        except Exception:
+            continue
+    # The candidate may have been requested with its display symbol.
+    key = symbol.upper().replace("/", "")
+    if key in price_history and symbol not in price_history:
+        price_history[symbol] = price_history[key]
+    return equity, open_positions, price_history
+
+
+__all__ = [
+    "PortfolioLimitsConfig",
+    "PortfolioVerdict",
+    "adjust_new_position_notional",
+    "assess_new_position",
+    "daily_returns",
+    "gather_portfolio_state_via_alpaca",
+    "realized_daily_vol",
+]

--- a/tradingagents/regime.py
+++ b/tradingagents/regime.py
@@ -7,7 +7,7 @@ A cheap, fit-free regime filter over three observable dimensions:
   wild assets — whose own percentile history looks unremarkable — still
   read as turbulent.
 - **Trend**: price vs its SMA plus the SMA's recent slope (up/down/sideways).
-- **Liquidity**: recent average dollar volume vs a longer baseline
+- **Liquidity**: recent average share volume vs a longer baseline
   (thinning/normal/surging).
 
 Threshold rules were chosen over an HMM deliberately: practitioners get

--- a/tradingagents/regime.py
+++ b/tradingagents/regime.py
@@ -1,0 +1,319 @@
+"""Deterministic market-regime detection.
+
+A cheap, fit-free regime filter over three observable dimensions:
+
+- **Volatility**: realized vol (20-bar) ranked against its own trailing
+  history (252 bars), with an absolute annualized floor so persistently
+  wild assets — whose own percentile history looks unremarkable — still
+  read as turbulent.
+- **Trend**: price vs its SMA plus the SMA's recent slope (up/down/sideways).
+- **Liquidity**: recent average dollar volume vs a longer baseline
+  (thinning/normal/surging).
+
+Threshold rules were chosen over an HMM deliberately: practitioners get
+most of the regime-filter value from the realized-vol percentile plus a
+trend filter, with no fitting, no initialization sensitivity, and no new
+dependency. The output is used as a *filter*, not a signal generator —
+hostile regimes shrink position sizes (multiplicative factors with a
+floor), they never flip the agents' decisions. Missing data reads as
+unknown with multiplier 1.0: absence of evidence never punishes.
+
+Two integration points, both failure-isolated and config-gated:
+- ``regime_report_block`` appends a deterministic markdown section to the
+  market analyst's report, which every downstream agent already reads.
+- ``regime_risk_multiplier`` scales the trade amount at execution time.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Optional
+
+import pandas as pd
+
+_ANNUALIZATION = math.sqrt(252)
+
+
+@dataclass
+class RegimeConfig:
+    enabled: bool = True
+    vol_window: int = 20
+    vol_percentile_window: int = 252
+    calm_percentile: float = 40.0
+    turbulent_percentile: float = 75.0
+    turbulent_abs_annual_vol_pct: float = 40.0
+    trend_window: int = 50
+    trend_slope_bars: int = 5
+    liquidity_window: int = 20
+    liquidity_baseline_window: int = 60
+    thin_liquidity_ratio: float = 0.7
+    surging_liquidity_ratio: float = 1.5
+    turbulent_size_factor: float = 0.5
+    downtrend_size_factor: float = 0.75
+    thin_liquidity_size_factor: float = 0.85
+    min_risk_multiplier: float = 0.25
+
+    @classmethod
+    def from_config(cls, config: Optional[dict]) -> "RegimeConfig":
+        cfg = config or {}
+        mapping = {
+            "enabled": "regime_detection_enabled",
+            "vol_window": "regime_vol_window",
+            "turbulent_percentile": "regime_turbulent_percentile",
+            "turbulent_abs_annual_vol_pct": "regime_turbulent_abs_annual_vol_pct",
+            "trend_window": "regime_trend_window",
+            "thin_liquidity_ratio": "regime_thin_liquidity_ratio",
+            "turbulent_size_factor": "regime_turbulent_size_factor",
+            "downtrend_size_factor": "regime_downtrend_size_factor",
+            "thin_liquidity_size_factor": "regime_thin_liquidity_size_factor",
+            "min_risk_multiplier": "regime_min_risk_multiplier",
+        }
+        kwargs = {}
+        for field_name, key in mapping.items():
+            if cfg.get(key) is not None:
+                kwargs[field_name] = cfg[key]
+        return cls(**kwargs)
+
+
+@dataclass
+class RegimeAssessment:
+    symbol: str
+    volatility_state: str  # calm | normal | turbulent | unknown
+    trend_state: str  # up | down | sideways | unknown
+    liquidity_state: str  # normal | thinning | surging | unknown
+    label: str  # favorable | mixed | hostile | unknown
+    risk_multiplier: float
+    metrics: Dict[str, float] = field(default_factory=dict)
+    notes: list = field(default_factory=list)
+
+    def to_markdown(self) -> str:
+        lines = [
+            "## Market Regime (deterministic indicator)",
+            f"- **Regime**: {self.label}"
+            + (f" — position sizing scaled to {self.risk_multiplier:.0%}" if self.risk_multiplier < 1.0 else ""),
+            f"- **Volatility**: {self.volatility_state}"
+            + (
+                f" (realized {self.metrics['annualized_vol_pct']:.1f}% annualized, "
+                f"p{self.metrics['vol_percentile']:.0f} of its own history)"
+                if "annualized_vol_pct" in self.metrics
+                else ""
+            ),
+            f"- **Trend**: {self.trend_state}"
+            + (
+                f" (price {self.metrics['price_vs_sma_pct']:+.1f}% vs SMA{int(self.metrics.get('trend_window', 0))})"
+                if "price_vs_sma_pct" in self.metrics
+                else ""
+            ),
+            f"- **Liquidity**: {self.liquidity_state}"
+            + (
+                f" (recent dollar volume {self.metrics['liquidity_ratio']:.2f}x its baseline)"
+                if "liquidity_ratio" in self.metrics
+                else ""
+            ),
+        ]
+        if self.notes:
+            lines.extend(f"- {note}" for note in self.notes)
+        lines.append(
+            "- This block is computed deterministically from price/volume history "
+            "— treat it as context for risk posture, not as a trade signal."
+        )
+        return "\n".join(lines)
+
+
+def _normalize(prices: pd.DataFrame) -> pd.DataFrame:
+    frame = prices.copy()
+    frame.columns = [str(c).lower() for c in frame.columns]
+    if "timestamp" in frame.columns:
+        frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+        frame = frame.set_index("timestamp")
+    if "close" not in frame.columns:
+        raise ValueError("Price data needs a 'close' column.")
+    if "volume" not in frame.columns:
+        frame["volume"] = 0.0
+    return frame.sort_index()
+
+
+def classify_regime(
+    prices: pd.DataFrame,
+    config: Optional[RegimeConfig] = None,
+    symbol: str = "",
+) -> RegimeAssessment:
+    """Classify the current regime from an OHLCV history (newest last)."""
+    config = config or RegimeConfig()
+    unknown = RegimeAssessment(
+        symbol=symbol,
+        volatility_state="unknown",
+        trend_state="unknown",
+        liquidity_state="unknown",
+        label="unknown",
+        risk_multiplier=1.0,
+        notes=["Insufficient price history for regime classification."],
+    )
+    try:
+        frame = _normalize(prices)
+    except (ValueError, AttributeError, TypeError):
+        return unknown
+
+    closes = frame["close"].astype(float)
+    returns = closes.pct_change().dropna()
+    if len(returns) < config.vol_window + config.trend_slope_bars:
+        return unknown
+
+    metrics: Dict[str, float] = {}
+    notes = []
+
+    # --- volatility ------------------------------------------------------------
+    rolling_vol = returns.rolling(config.vol_window).std().dropna()
+    current_vol = float(rolling_vol.iloc[-1])
+    annualized_pct = current_vol * _ANNUALIZATION * 100.0
+    history = rolling_vol.tail(config.vol_percentile_window)
+    percentile = float((history <= current_vol).mean() * 100.0)
+    metrics["annualized_vol_pct"] = annualized_pct
+    metrics["vol_percentile"] = percentile
+
+    if (
+        percentile >= config.turbulent_percentile
+        or annualized_pct >= config.turbulent_abs_annual_vol_pct
+    ):
+        vol_state = "turbulent"
+        if annualized_pct >= config.turbulent_abs_annual_vol_pct:
+            notes.append(
+                f"Absolute volatility floor hit: {annualized_pct:.0f}% annualized "
+                f"exceeds {config.turbulent_abs_annual_vol_pct:g}%."
+            )
+    elif percentile <= config.calm_percentile:
+        vol_state = "calm"
+    else:
+        vol_state = "normal"
+
+    # --- trend -------------------------------------------------------------------
+    if len(closes) >= config.trend_window + config.trend_slope_bars:
+        sma = closes.rolling(config.trend_window).mean().dropna()
+        price = float(closes.iloc[-1])
+        sma_now = float(sma.iloc[-1])
+        sma_then = float(sma.iloc[-1 - config.trend_slope_bars])
+        metrics["price_vs_sma_pct"] = (price / sma_now - 1.0) * 100.0
+        metrics["trend_window"] = float(config.trend_window)
+        if price > sma_now and sma_now > sma_then:
+            trend_state = "up"
+        elif price < sma_now and sma_now < sma_then:
+            trend_state = "down"
+        else:
+            trend_state = "sideways"
+    else:
+        trend_state = "unknown"
+
+    # --- liquidity -----------------------------------------------------------------
+    # Share volume, not dollar volume: a price collapse would drag dollar
+    # volume down by itself and double-count what the trend factor already
+    # penalizes. Thinning here means participation drying up.
+    volume = frame["volume"].astype(float).dropna()
+    needed = config.liquidity_window + config.liquidity_baseline_window
+    if float(volume.sum()) > 0 and len(volume) >= needed:
+        recent = float(volume.tail(config.liquidity_window).mean())
+        # Baseline strictly precedes the recent window, otherwise a slow
+        # bleed would drag its own baseline down and hide the thinning.
+        baseline = float(volume.iloc[-needed : -config.liquidity_window].mean())
+        if baseline > 0:
+            ratio = recent / baseline
+            metrics["liquidity_ratio"] = ratio
+            if ratio < config.thin_liquidity_ratio:
+                liquidity_state = "thinning"
+            elif ratio > config.surging_liquidity_ratio:
+                liquidity_state = "surging"
+            else:
+                liquidity_state = "normal"
+        else:
+            liquidity_state = "unknown"
+    else:
+        liquidity_state = "unknown"
+
+    # --- multiplier and label --------------------------------------------------------
+    multiplier = 1.0
+    if vol_state == "turbulent":
+        multiplier *= config.turbulent_size_factor
+    if trend_state == "down":
+        multiplier *= config.downtrend_size_factor
+    if liquidity_state == "thinning":
+        multiplier *= config.thin_liquidity_size_factor
+    multiplier = max(multiplier, config.min_risk_multiplier)
+
+    if vol_state == "turbulent" or (trend_state == "down" and liquidity_state == "thinning"):
+        label = "hostile"
+    elif trend_state == "up" and vol_state in ("calm", "normal") and liquidity_state != "thinning":
+        label = "favorable"
+    else:
+        label = "mixed"
+
+    return RegimeAssessment(
+        symbol=symbol,
+        volatility_state=vol_state,
+        trend_state=trend_state,
+        liquidity_state=liquidity_state,
+        label=label,
+        risk_multiplier=multiplier if label != "favorable" else 1.0,
+        metrics=metrics,
+        notes=notes,
+    )
+
+
+def _default_price_loader():
+    from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+    return AlpacaUtils.get_stock_data
+
+
+def _load_assessment(
+    symbol: str,
+    price_loader: Optional[Callable] = None,
+    config: Optional[RegimeConfig] = None,
+) -> Optional[RegimeAssessment]:
+    from datetime import date, timedelta
+
+    config = config or RegimeConfig()
+    if not config.enabled:
+        return None
+    loader = price_loader or _default_price_loader()
+    start = (date.today() - timedelta(days=550)).isoformat()
+    prices = loader(symbol, start, None)
+    return classify_regime(prices, config=config, symbol=symbol)
+
+
+def regime_report_block(
+    symbol: str,
+    price_loader: Optional[Callable] = None,
+    config: Optional[RegimeConfig] = None,
+) -> str:
+    """Markdown regime block for the market report; '' when unavailable."""
+    try:
+        assessment = _load_assessment(symbol, price_loader, config)
+        if assessment is None or assessment.label == "unknown":
+            return ""
+        return assessment.to_markdown()
+    except Exception as exc:
+        print(f"[REGIME] Report block skipped for {symbol}: {exc}")
+        return ""
+
+
+def regime_risk_multiplier(
+    symbol: str,
+    price_loader: Optional[Callable] = None,
+    config: Optional[RegimeConfig] = None,
+) -> float:
+    """Position-size multiplier in [min_risk_multiplier, 1.0]; 1.0 on failure."""
+    try:
+        assessment = _load_assessment(symbol, price_loader, config)
+        if assessment is None:
+            return 1.0
+        if assessment.risk_multiplier < 1.0:
+            print(
+                f"[REGIME] {symbol}: {assessment.label} regime "
+                f"(vol={assessment.volatility_state}, trend={assessment.trend_state}, "
+                f"liquidity={assessment.liquidity_state}) -> "
+                f"size x{assessment.risk_multiplier:.2f}"
+            )
+        return assessment.risk_multiplier
+    except Exception as exc:
+        print(f"[REGIME] Sizing skipped for {symbol}: {exc}")
+        return 1.0

--- a/tradingagents/risk/__init__.py
+++ b/tradingagents/risk/__init__.py
@@ -1,0 +1,26 @@
+"""Deterministic quantitative risk layer.
+
+Separates the LLM's directional decision (BUY/SELL/LONG/SHORT) from the
+mathematical position-sizing decision, following the direction-agent /
+quantity-agent split used by risk-sensitive trading frameworks.
+"""
+
+from tradingagents.risk.position_sizing import (
+    DEFAULT_CONFIDENCE_EDGE,
+    FALLBACK_STOP_PCT,
+    PositionSizer,
+    RiskParameters,
+    SizingDecision,
+    compute_atr,
+    kelly_position_fraction,
+)
+
+__all__ = [
+    "DEFAULT_CONFIDENCE_EDGE",
+    "FALLBACK_STOP_PCT",
+    "PositionSizer",
+    "RiskParameters",
+    "SizingDecision",
+    "compute_atr",
+    "kelly_position_fraction",
+]

--- a/tradingagents/risk/position_sizing.py
+++ b/tradingagents/risk/position_sizing.py
@@ -1,0 +1,245 @@
+"""Deterministic position sizing: fractional Kelly, ATR stops, exposure caps.
+
+Everything in this module is pure math over explicit inputs — no broker or
+LLM calls — so the sizing behavior is fully unit-testable and independent of
+model output quality. The LLM decides direction; this layer decides size.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pandas as pd
+
+# Conservative (win_rate, win/loss ratio) estimates per LLM confidence level.
+# Deliberately shrunk: Kelly sizing is fragile to estimation error, so these
+# assume only a slight edge even at high confidence.
+DEFAULT_CONFIDENCE_EDGE = {
+    "high": (0.55, 1.5),
+    "medium": (0.52, 1.3),
+    "low": (0.50, 1.1),
+}
+
+# Assumed stop distance as a fraction of price when no volatility data exists.
+FALLBACK_STOP_PCT = 0.05
+
+
+def compute_atr(bars, period: int = 14) -> Optional[float]:
+    """Wilder-smoothed Average True Range from an OHLC DataFrame.
+
+    Returns None whenever the data cannot support a meaningful ATR
+    (missing columns, too few rows, NaNs, or a non-positive result) so
+    callers can fall back to a conservative default instead of crashing.
+    """
+    try:
+        if bars is None or len(bars) < period + 1:
+            return None
+        columns = {str(c).lower(): c for c in bars.columns}
+        high = bars[columns["high"]].astype(float).reset_index(drop=True)
+        low = bars[columns["low"]].astype(float).reset_index(drop=True)
+        close = bars[columns["close"]].astype(float).reset_index(drop=True)
+    except (KeyError, TypeError, ValueError, AttributeError):
+        return None
+
+    prev_close = close.shift(1)
+    true_range = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()],
+        axis=1,
+    ).max(axis=1)
+    true_range = true_range.iloc[1:]  # first row has no previous close
+
+    if len(true_range) < period or true_range.isna().any():
+        return None
+
+    atr = float(true_range.iloc[:period].mean())
+    for value in true_range.iloc[period:]:
+        atr = (atr * (period - 1) + float(value)) / period
+
+    if not math.isfinite(atr) or atr <= 0:
+        return None
+    return atr
+
+
+def kelly_position_fraction(
+    win_rate: float, win_loss_ratio: float, kelly_fraction: float = 0.5
+) -> float:
+    """Fractional Kelly allocation, clamped to [0, inf).
+
+    Kelly % = W - (1 - W) / R, scaled down by `kelly_fraction`. Any invalid
+    or edge-free input yields 0.0 (do not allocate) rather than an error.
+    """
+    try:
+        win_rate = float(win_rate)
+        win_loss_ratio = float(win_loss_ratio)
+        kelly_fraction = float(kelly_fraction)
+    except (TypeError, ValueError):
+        return 0.0
+    if not 0.0 < win_rate < 1.0 or win_loss_ratio <= 0.0 or kelly_fraction <= 0.0:
+        return 0.0
+    edge = win_rate - (1.0 - win_rate) / win_loss_ratio
+    return max(0.0, edge * kelly_fraction)
+
+
+@dataclass(frozen=True)
+class RiskParameters:
+    """Tunable, deterministic risk limits. Defaults are intentionally strict."""
+
+    risk_per_trade_pct: float = 0.01  # fraction of equity risked per trade
+    kelly_fraction: float = 0.5  # half-Kelly
+    atr_period: int = 14
+    atr_stop_multiplier: float = 2.0
+    max_position_pct: float = 0.20  # single-position notional / equity
+    max_total_exposure_pct: float = 0.80  # gross portfolio exposure / equity
+    min_notional: float = 10.0
+    confidence_edge: dict = field(
+        default_factory=lambda: dict(DEFAULT_CONFIDENCE_EDGE)
+    )
+
+    @classmethod
+    def from_dict(cls, overrides: Optional[dict]) -> "RiskParameters":
+        """Build parameters from a config dict, ignoring unknown keys."""
+        if not overrides:
+            return cls()
+        known = {f.name for f in dataclasses.fields(cls)}
+        return cls(**{k: v for k, v in overrides.items() if k in known})
+
+
+@dataclass(frozen=True)
+class SizingDecision:
+    approved: bool
+    notional: float
+    stop_loss_price: Optional[float]
+    risk_amount: float
+    caps_applied: list
+    reason: str
+
+    def to_dict(self) -> dict:
+        return {
+            "approved": self.approved,
+            "notional": self.notional,
+            "stop_loss_price": self.stop_loss_price,
+            "risk_amount": self.risk_amount,
+            "caps_applied": list(self.caps_applied),
+            "reason": self.reason,
+        }
+
+
+def _rejection(reason: str, notes: Optional[list] = None) -> SizingDecision:
+    return SizingDecision(
+        approved=False,
+        notional=0.0,
+        stop_loss_price=None,
+        risk_amount=0.0,
+        caps_applied=list(notes or []),
+        reason=reason,
+    )
+
+
+class PositionSizer:
+    """Deterministic sizing engine applied after the LLM's direction call."""
+
+    def __init__(self, params: Optional[RiskParameters] = None):
+        self.params = params or RiskParameters()
+
+    def size_position(
+        self,
+        *,
+        equity: float,
+        price: float,
+        atr: Optional[float],
+        confidence: str,
+        requested_notional: float,
+        current_gross_exposure: float = 0.0,
+        side: str = "buy",
+    ) -> SizingDecision:
+        params = self.params
+        try:
+            equity = float(equity)
+            price = float(price)
+            requested_notional = float(requested_notional)
+            current_gross_exposure = max(0.0, float(current_gross_exposure or 0.0))
+        except (TypeError, ValueError):
+            return _rejection("Invalid numeric inputs for position sizing.")
+
+        if not math.isfinite(equity) or equity <= 0.0:
+            return _rejection(f"Invalid account equity: {equity}.")
+        if not math.isfinite(price) or price <= 0.0:
+            return _rejection(f"Invalid price: {price}.")
+        if not math.isfinite(requested_notional) or requested_notional <= 0.0:
+            return _rejection(f"Invalid requested notional: {requested_notional}.")
+
+        notes = []
+        if atr is not None and math.isfinite(atr) and atr > 0.0:
+            stop_distance = float(atr) * params.atr_stop_multiplier
+        else:
+            stop_distance = price * FALLBACK_STOP_PCT
+            notes.append("atr_unavailable_default_stop")
+
+        exposure_room = equity * params.max_total_exposure_pct - current_gross_exposure
+        if exposure_room < params.min_notional:
+            return _rejection(
+                "Portfolio exposure limit reached: "
+                f"gross exposure {current_gross_exposure:.2f} leaves only "
+                f"{max(exposure_room, 0.0):.2f} of the "
+                f"{params.max_total_exposure_pct:.0%} cap.",
+                notes,
+            )
+
+        risk_budget = equity * params.risk_per_trade_pct
+        risk_notional = (risk_budget / stop_distance) * price
+
+        edge = params.confidence_edge.get(
+            str(confidence).strip().lower(),
+            params.confidence_edge.get("low", DEFAULT_CONFIDENCE_EDGE["low"]),
+        )
+        win_rate, win_loss_ratio = edge
+        kelly_f = kelly_position_fraction(
+            win_rate, win_loss_ratio, params.kelly_fraction
+        )
+        if kelly_f <= 0.0:
+            return _rejection(
+                f"No positive edge for confidence '{confidence}'; Kelly allocation is zero.",
+                notes,
+            )
+        kelly_notional = equity * kelly_f
+
+        caps = {
+            "requested_notional": requested_notional,
+            "risk_per_trade": risk_notional,
+            "kelly": kelly_notional,
+            "max_position_pct": equity * params.max_position_pct,
+            "max_total_exposure": exposure_room,
+        }
+        notional = min(caps.values())
+        binding = [
+            name
+            for name, value in caps.items()
+            if math.isclose(value, notional, rel_tol=1e-9, abs_tol=1e-9)
+        ]
+
+        if notional < params.min_notional:
+            return _rejection(
+                f"Sized notional {notional:.2f} is below the minimum order "
+                f"size {params.min_notional:.2f} (binding cap: {binding[0]}).",
+                notes,
+            )
+
+        notional = round(notional, 2)
+        quantity = notional / price
+        risk_amount = round(quantity * stop_distance, 2)
+        if str(side).strip().lower() in ("sell", "short"):
+            stop_loss_price = round(price + stop_distance, 6)
+        else:
+            stop_loss_price = round(price - stop_distance, 6)
+
+        return SizingDecision(
+            approved=True,
+            notional=notional,
+            stop_loss_price=stop_loss_price,
+            risk_amount=risk_amount,
+            caps_applied=binding + notes,
+            reason=f"Sized {notional:.2f} bound by {', '.join(binding)}.",
+        )

--- a/tradingagents/run_logger.py
+++ b/tradingagents/run_logger.py
@@ -35,6 +35,43 @@ def _json_safe(value: Any) -> Any:
         return str(value)
 
 
+def _redact_sensitive_config(value: Any) -> Any:
+    """Remove credentials before persisting a run configuration."""
+    if isinstance(value, dict):
+        redacted = {}
+        for key, item in value.items():
+            normalized = str(key).strip().lower()
+            sensitive = (
+                normalized in {
+                    "api_key",
+                    "secret",
+                    "password",
+                    "token",
+                    "webhook_url",
+                    "alert_webhook_url",
+                }
+                or normalized.endswith(
+                    (
+                        "_api_key",
+                        "_api_secret",
+                        "_secret_key",
+                        "_client_secret",
+                        "_password",
+                        "_bot_token",
+                        "_chat_id",
+                    )
+                )
+            )
+            redacted[str(key)] = (
+                "[REDACTED]" if sensitive and item not in (None, "")
+                else _redact_sensitive_config(item)
+            )
+        return redacted
+    if isinstance(value, (list, tuple, set)):
+        return [_redact_sensitive_config(item) for item in value]
+    return value
+
+
 class RunAuditLogger:
     """
     Persist a complete audit trail for each analysis run.
@@ -139,7 +176,7 @@ class RunAuditLogger:
                 "started_at": _utc_now_iso(),
                 "ended_at": None,
                 "status": "running",
-                "config": _json_safe(config or {}),
+                "config": _json_safe(_redact_sensitive_config(config or {})),
                 "metadata": _json_safe(metadata or {}),
                 "events": [],
                 "snapshots": {},

--- a/tradingagents/run_logger.py
+++ b/tradingagents/run_logger.py
@@ -389,6 +389,49 @@ class RunAuditLogger:
             json.dump(run_data, f, indent=2, ensure_ascii=False)
 
 
+def load_final_state_snapshot(
+    symbol: str,
+    trade_date: str,
+    eval_results_dir: str = "eval_results",
+) -> Optional[Dict[str, Any]]:
+    """Return the final_state snapshot of the newest completed run for a date.
+
+    Lets outcome-time consumers (reflection, evaluation) recover the exact
+    market situation a past decision was made in, without keeping every run
+    in process memory. Returns None when no matching completed run exists.
+    """
+    runs_dir = (
+        Path(eval_results_dir)
+        / _sanitize_for_path(symbol or "unknown")
+        / "TradingAgentsStrategy_logs"
+        / "runs"
+    )
+    if not runs_dir.is_dir():
+        return None
+
+    best_payload = None
+    best_started_at = ""
+    for path in runs_dir.glob("*.json"):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except Exception:
+            continue
+        if payload.get("status") != "completed":
+            continue
+        if str(payload.get("trade_date")) != str(trade_date):
+            continue
+        final_state = (payload.get("snapshots") or {}).get("final_state")
+        if not isinstance(final_state, dict):
+            continue
+        started_at = str(payload.get("started_at") or "")
+        if started_at >= best_started_at:
+            best_started_at = started_at
+            best_payload = final_state
+
+    return best_payload
+
+
 _RUN_AUDIT_LOGGER = RunAuditLogger()
 
 

--- a/tradingagents/run_logger.py
+++ b/tradingagents/run_logger.py
@@ -233,9 +233,17 @@ class RunAuditLogger:
                 run_data["summary"]["total_llm_output_tokens"] += int(
                     usage.get("output_tokens", 0) or 0
                 )
-                run_data["summary"]["total_llm_tokens"] += int(
-                    usage.get("total_tokens", 0) or 0
-                )
+                total_tokens = int(usage.get("total_tokens", 0) or 0)
+                run_data["summary"]["total_llm_tokens"] += total_tokens
+                if total_tokens:
+                    # Feed the safety layer's daily LLM token budget; logging
+                    # must never fail because the guard is unavailable.
+                    try:
+                        from tradingagents.safety import get_safety_guard
+
+                        get_safety_guard().record_llm_tokens(total_tokens)
+                    except Exception:
+                        pass
             elif event_type == "agent_output":
                 run_data["summary"]["agent_output_events"] += 1
             elif event_type == "node_execution":

--- a/tradingagents/safety/__init__.py
+++ b/tradingagents/safety/__init__.py
@@ -1,0 +1,17 @@
+"""Deterministic production safety layer — independent of all agent logic."""
+
+from .guardrails import (
+    DEFAULT_SAFETY_CONFIG,
+    SafetyGuard,
+    SafetyVerdict,
+    get_safety_guard,
+    reset_safety_guard,
+)
+
+__all__ = [
+    "DEFAULT_SAFETY_CONFIG",
+    "SafetyGuard",
+    "SafetyVerdict",
+    "get_safety_guard",
+    "reset_safety_guard",
+]

--- a/tradingagents/safety/guardrails.py
+++ b/tradingagents/safety/guardrails.py
@@ -113,6 +113,14 @@ class SafetyGuard:
         self.kill_switch_path.parent.mkdir(parents=True, exist_ok=True)
         stamp = datetime.now(timezone.utc).isoformat()
         self.kill_switch_path.write_text(f"{reason} (engaged {stamp})", encoding="utf-8")
+        # Ops alert; imported lazily and failure-isolated so the safety
+        # layer keeps zero hard dependencies.
+        try:
+            from tradingagents.alerts import notify_kill_switch
+
+            notify_kill_switch(reason)
+        except Exception:
+            pass
 
     def release_kill_switch(self) -> None:
         try:

--- a/tradingagents/safety/guardrails.py
+++ b/tradingagents/safety/guardrails.py
@@ -1,0 +1,360 @@
+"""Deterministic production safety layer.
+
+Every guard here is plain arithmetic over injected state — zero LLM calls,
+zero imports from the agent stack — so it cannot be talked out of a halt by
+a model and keeps working when providers misbehave. Three stages:
+
+- pre-trade checks: per-order notional cap, per-symbol concentration cap
+- circuit breakers: daily loss halt, drawdown-from-high-water-mark halt,
+  consecutive-rejection halt (a data/connectivity glitch signal)
+- kill switch: a flag file that stops all order flow no matter what the
+  agents decide (ops can engage it by touching the file, no Python needed)
+
+A daily LLM token budget rides along: run logs already count tokens, the
+guard accumulates them per day and can refuse to start new analyses.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DEFAULT_SAFETY_CONFIG: Dict[str, Any] = {
+    "safety_enabled": True,
+    # Pre-trade checks
+    "max_trade_notional_usd": 25_000.0,  # 0 = uncapped
+    "max_symbol_concentration_pct": 25.0,  # of account equity; 0 = uncapped
+    # Circuit breakers
+    "daily_loss_halt_pct": 10.0,  # halt when equity drops this % vs yesterday
+    "max_drawdown_halt_pct": 15.0,  # halt when equity drops this % vs high-water mark
+    "max_consecutive_rejections": 5,  # halt after this many broker rejections in a row
+    # LLM cost cap
+    "daily_llm_token_budget": 0,  # tokens/day across all runs; 0 = unlimited
+}
+
+_SAFETY_HOME = Path(os.path.expanduser("~")) / ".tradingagents" / "safety"
+
+
+@dataclass
+class SafetyVerdict:
+    allowed: bool
+    reasons: List[str] = field(default_factory=list)
+    checks: Dict[str, dict] = field(default_factory=dict)
+
+
+def _today(when: Optional[str] = None) -> str:
+    return when or date.today().isoformat()
+
+
+class SafetyGuard:
+    """Thread-safe guard with a small JSON state file.
+
+    Persisted state: equity high-water mark, current rejection streak, and
+    per-day LLM token counts. The kill switch is a separate flag file so a
+    human (or cron job) can engage it with `touch`.
+    """
+
+    def __init__(
+        self,
+        config: Optional[Dict[str, Any]] = None,
+        state_path: Optional[Path] = None,
+        kill_switch_path: Optional[Path] = None,
+    ):
+        merged = dict(DEFAULT_SAFETY_CONFIG)
+        for key in merged:
+            if config and config.get(key) is not None:
+                merged[key] = config[key]
+        self.config = merged
+        self.state_path = Path(state_path or (_SAFETY_HOME / "state.json"))
+        self.kill_switch_path = Path(
+            kill_switch_path or (_SAFETY_HOME / "KILL_SWITCH")
+        )
+        self._lock = threading.RLock()
+        self._state = self._load_state()
+
+    # ----- state persistence -------------------------------------------------
+
+    def _load_state(self) -> Dict[str, Any]:
+        try:
+            raw = json.loads(self.state_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                return raw
+        except (OSError, ValueError):
+            pass
+        return {"high_water_mark": None, "consecutive_rejections": 0, "llm_tokens": {}}
+
+    def _save_state(self) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.state_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._state, indent=2), encoding="utf-8")
+        os.replace(tmp, self.state_path)
+
+    # ----- kill switch --------------------------------------------------------
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.config.get("safety_enabled", True))
+
+    def kill_switch_active(self) -> bool:
+        return self.kill_switch_path.exists()
+
+    def kill_switch_reason(self) -> str:
+        try:
+            return self.kill_switch_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return ""
+
+    def engage_kill_switch(self, reason: str = "manual halt") -> None:
+        self.kill_switch_path.parent.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).isoformat()
+        self.kill_switch_path.write_text(f"{reason} (engaged {stamp})", encoding="utf-8")
+
+    def release_kill_switch(self) -> None:
+        try:
+            self.kill_switch_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    # ----- order/rejection tracking -------------------------------------------
+
+    def record_order_result(self, success: bool) -> None:
+        with self._lock:
+            if success:
+                self._state["consecutive_rejections"] = 0
+            else:
+                self._state["consecutive_rejections"] = (
+                    int(self._state.get("consecutive_rejections", 0)) + 1
+                )
+            self._save_state()
+
+    def consecutive_rejections(self) -> int:
+        with self._lock:
+            return int(self._state.get("consecutive_rejections", 0))
+
+    # ----- LLM token budget ----------------------------------------------------
+
+    def record_llm_tokens(self, tokens: int, when: Optional[str] = None) -> None:
+        if not tokens:
+            return
+        day = _today(when)
+        with self._lock:
+            counts = self._state.setdefault("llm_tokens", {})
+            counts[day] = int(counts.get(day, 0)) + int(tokens)
+            # Keep the map from growing unbounded.
+            for old_day in sorted(counts)[:-31]:
+                del counts[old_day]
+            self._save_state()
+
+    def llm_tokens_used(self, when: Optional[str] = None) -> int:
+        day = _today(when)
+        with self._lock:
+            return int(self._state.get("llm_tokens", {}).get(day, 0))
+
+    def check_llm_budget(self, when: Optional[str] = None) -> SafetyVerdict:
+        budget = float(self.config.get("daily_llm_token_budget", 0) or 0)
+        used = self.llm_tokens_used(when)
+        if not self.enabled or budget <= 0 or used < budget:
+            return SafetyVerdict(
+                allowed=True,
+                checks={"llm_budget": {"status": "pass", "used": used, "budget": budget}},
+            )
+        return SafetyVerdict(
+            allowed=False,
+            reasons=[
+                f"Daily LLM token budget exhausted: {used:,.0f} of {budget:,.0f} tokens used."
+            ],
+            checks={"llm_budget": {"status": "fail", "used": used, "budget": budget}},
+        )
+
+    # ----- the main pre-order gate ----------------------------------------------
+
+    def check_order(
+        self,
+        symbol: str,
+        notional: float,
+        account: Optional[Dict[str, float]] = None,
+        position_value: Optional[float] = None,
+    ) -> SafetyVerdict:
+        """Deterministic gate every outbound order must pass.
+
+        `account` carries {"equity", "last_equity"} when available; checks
+        that need missing data are reported as skipped rather than guessed.
+        """
+        if not self.enabled:
+            return SafetyVerdict(
+                allowed=True, checks={"safety": {"status": "skipped", "detail": "disabled"}}
+            )
+
+        reasons: List[str] = []
+        checks: Dict[str, dict] = {}
+        equity = float(account["equity"]) if account and account.get("equity") else None
+        last_equity = (
+            float(account["last_equity"])
+            if account and account.get("last_equity")
+            else None
+        )
+
+        # Kill switch dominates everything.
+        if self.kill_switch_active():
+            reason = self.kill_switch_reason() or "engaged"
+            reasons.append(f"Kill switch is engaged: {reason}")
+            checks["kill_switch"] = {"status": "fail", "detail": reason}
+        else:
+            checks["kill_switch"] = {"status": "pass"}
+
+        # Pre-trade: per-order notional cap.
+        cap = float(self.config.get("max_trade_notional_usd", 0) or 0)
+        if cap > 0 and float(notional) > cap:
+            reasons.append(
+                f"Order notional ${float(notional):,.2f} exceeds max_trade_notional_usd ${cap:,.2f}."
+            )
+            checks["trade_notional"] = {"status": "fail", "notional": float(notional), "cap": cap}
+        else:
+            checks["trade_notional"] = {"status": "pass", "notional": float(notional), "cap": cap}
+
+        # Pre-trade: per-symbol concentration cap.
+        conc_pct = float(self.config.get("max_symbol_concentration_pct", 0) or 0)
+        if conc_pct > 0:
+            if equity:
+                exposure = float(position_value or 0.0) + float(notional)
+                limit = equity * conc_pct / 100.0
+                if exposure > limit:
+                    reasons.append(
+                        f"{symbol} exposure ${exposure:,.2f} would exceed "
+                        f"{conc_pct:g}% of equity (${limit:,.2f})."
+                    )
+                    checks["concentration"] = {
+                        "status": "fail",
+                        "exposure": exposure,
+                        "limit": limit,
+                    }
+                else:
+                    checks["concentration"] = {
+                        "status": "pass",
+                        "exposure": exposure,
+                        "limit": limit,
+                    }
+            else:
+                checks["concentration"] = {
+                    "status": "skipped",
+                    "detail": "account equity unavailable",
+                }
+        else:
+            checks["concentration"] = {"status": "pass", "detail": "uncapped"}
+
+        # Circuit breaker: daily loss.
+        halt_pct = float(self.config.get("daily_loss_halt_pct", 0) or 0)
+        if halt_pct > 0 and equity and last_equity:
+            change_pct = (equity - last_equity) / last_equity * 100.0
+            if change_pct <= -halt_pct:
+                reasons.append(
+                    f"Daily loss circuit breaker: equity is {change_pct:+.2f}% vs "
+                    f"yesterday (halt at -{halt_pct:g}%)."
+                )
+                checks["daily_loss"] = {"status": "fail", "change_pct": change_pct}
+            else:
+                checks["daily_loss"] = {"status": "pass", "change_pct": change_pct}
+        else:
+            checks["daily_loss"] = {
+                "status": "skipped" if halt_pct > 0 else "pass",
+                "detail": "account equity unavailable" if halt_pct > 0 else "uncapped",
+            }
+
+        # Circuit breaker: drawdown from persisted high-water mark.
+        dd_pct = float(self.config.get("max_drawdown_halt_pct", 0) or 0)
+        if equity:
+            with self._lock:
+                hwm = self._state.get("high_water_mark")
+                if hwm is None or equity > float(hwm):
+                    self._state["high_water_mark"] = equity
+                    self._save_state()
+                    hwm = equity
+            hwm = float(hwm)
+            if dd_pct > 0 and hwm > 0:
+                drawdown_pct = (hwm - equity) / hwm * 100.0
+                if drawdown_pct >= dd_pct:
+                    reasons.append(
+                        f"Drawdown circuit breaker: equity is {drawdown_pct:.2f}% below the "
+                        f"${hwm:,.2f} high-water mark (halt at {dd_pct:g}%)."
+                    )
+                    checks["drawdown"] = {"status": "fail", "drawdown_pct": drawdown_pct}
+                else:
+                    checks["drawdown"] = {"status": "pass", "drawdown_pct": drawdown_pct}
+            else:
+                checks["drawdown"] = {"status": "pass", "detail": "uncapped"}
+        else:
+            checks["drawdown"] = {
+                "status": "skipped" if dd_pct > 0 else "pass",
+                "detail": "account equity unavailable" if dd_pct > 0 else "uncapped",
+            }
+
+        # Circuit breaker: consecutive broker rejections (data-glitch signal).
+        max_rejects = int(self.config.get("max_consecutive_rejections", 0) or 0)
+        streak = self.consecutive_rejections()
+        if max_rejects > 0 and streak >= max_rejects:
+            reasons.append(
+                f"{streak} consecutive orders were rejected (halt at {max_rejects}); "
+                "possible data or connectivity problem."
+            )
+            checks["rejection_streak"] = {"status": "fail", "streak": streak}
+        else:
+            checks["rejection_streak"] = {"status": "pass", "streak": streak}
+
+        return SafetyVerdict(allowed=not reasons, reasons=reasons, checks=checks)
+
+    # ----- status for dashboards ---------------------------------------------
+
+    def status(self, account: Optional[Dict[str, float]] = None) -> Dict[str, Any]:
+        """Green/red snapshot of every guard for the WebUI panel."""
+        order_view = self.check_order("_status_", 0.0, account=account)
+        budget_view = self.check_llm_budget()
+        guards: Dict[str, dict] = {}
+        for name, check in {**order_view.checks, **budget_view.checks}.items():
+            guards[name] = {
+                "ok": check.get("status") != "fail",
+                "status": check.get("status"),
+                "detail": {k: v for k, v in check.items() if k != "status"},
+            }
+        return {
+            "enabled": self.enabled,
+            "kill_switch_active": self.kill_switch_active(),
+            "kill_switch_reason": self.kill_switch_reason(),
+            "reasons": list(order_view.reasons) + list(budget_view.reasons),
+            "guards": guards,
+            "config": dict(self.config),
+        }
+
+
+# ----- process-wide singleton ---------------------------------------------------
+
+_GUARD: Optional[SafetyGuard] = None
+_GUARD_LOCK = threading.Lock()
+
+
+def get_safety_guard() -> SafetyGuard:
+    """Process-wide guard configured from the runtime config (lazily)."""
+    global _GUARD
+    with _GUARD_LOCK:
+        if _GUARD is None:
+            config: Dict[str, Any] = {}
+            try:
+                # Imported lazily: the safety layer must stay importable even
+                # if the dataflows stack (and its dependencies) are not.
+                from tradingagents.dataflows.config import get_config
+
+                config = dict(get_config() or {})
+            except Exception:
+                config = {}
+            _GUARD = SafetyGuard(config=config)
+        return _GUARD
+
+
+def reset_safety_guard() -> None:
+    global _GUARD
+    with _GUARD_LOCK:
+        _GUARD = None

--- a/tradingagents/safety/guardrails.py
+++ b/tradingagents/safety/guardrails.py
@@ -204,11 +204,15 @@ class SafetyGuard:
         notional: float,
         account: Optional[Dict[str, float]] = None,
         position_value: Optional[float] = None,
+        risk_reducing: bool = False,
     ) -> SafetyVerdict:
         """Deterministic gate every outbound order must pass.
 
         `account` carries {"equity", "last_equity"} when available; checks
         that need missing data are reported as skipped rather than guessed.
+        Risk-reducing exits bypass exposure and circuit-breaker checks so a
+        loss halt cannot trap an existing position. The explicit kill switch
+        still blocks all broker order flow.
         """
         if not self.enabled:
             return SafetyVerdict(
@@ -229,6 +233,24 @@ class SafetyGuard:
             checks["kill_switch"] = {"status": "fail", "detail": reason}
         else:
             checks["kill_switch"] = {"status": "pass"}
+
+        if risk_reducing:
+            for name in (
+                "trade_notional",
+                "concentration",
+                "daily_loss",
+                "drawdown",
+                "rejection_streak",
+            ):
+                checks[name] = {
+                    "status": "skipped",
+                    "detail": "risk-reducing exit",
+                }
+            return SafetyVerdict(
+                allowed=not reasons,
+                reasons=reasons,
+                checks=checks,
+            )
 
         # Pre-trade: per-order notional cap.
         notional_value = _finite_float(notional) or 0.0

--- a/tradingagents/safety/guardrails.py
+++ b/tradingagents/safety/guardrails.py
@@ -17,6 +17,7 @@ guard accumulates them per day and can refuse to start new analyses.
 from __future__ import annotations
 
 import json
+import math
 import os
 import threading
 from dataclasses import dataclass, field
@@ -49,6 +50,22 @@ class SafetyVerdict:
 
 def _today(when: Optional[str] = None) -> str:
     return when or date.today().isoformat()
+
+
+def _finite_float(value) -> Optional[float]:
+    """Parse broker-supplied numbers defensively.
+
+    Outage artifacts show up here as NaN/inf equity or literal HTML error
+    pages in numeric fields. Anything non-finite or unparseable reads as
+    'unavailable' (None): a NaN that reaches a comparison silently passes
+    every breaker, and a NaN stored as the high-water mark disables the
+    drawdown breaker permanently.
+    """
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
 
 
 class SafetyGuard:
@@ -192,12 +209,10 @@ class SafetyGuard:
 
         reasons: List[str] = []
         checks: Dict[str, dict] = {}
-        equity = float(account["equity"]) if account and account.get("equity") else None
-        last_equity = (
-            float(account["last_equity"])
-            if account and account.get("last_equity")
-            else None
-        )
+        equity = _finite_float(account.get("equity")) if account else None
+        last_equity = _finite_float(account.get("last_equity")) if account else None
+        if last_equity == 0.0:
+            last_equity = None  # a 0 baseline can't produce a meaningful change %
 
         # Kill switch dominates everything.
         if self.kill_switch_active():
@@ -208,20 +223,21 @@ class SafetyGuard:
             checks["kill_switch"] = {"status": "pass"}
 
         # Pre-trade: per-order notional cap.
+        notional_value = _finite_float(notional) or 0.0
         cap = float(self.config.get("max_trade_notional_usd", 0) or 0)
-        if cap > 0 and float(notional) > cap:
+        if cap > 0 and notional_value > cap:
             reasons.append(
-                f"Order notional ${float(notional):,.2f} exceeds max_trade_notional_usd ${cap:,.2f}."
+                f"Order notional ${notional_value:,.2f} exceeds max_trade_notional_usd ${cap:,.2f}."
             )
-            checks["trade_notional"] = {"status": "fail", "notional": float(notional), "cap": cap}
+            checks["trade_notional"] = {"status": "fail", "notional": notional_value, "cap": cap}
         else:
-            checks["trade_notional"] = {"status": "pass", "notional": float(notional), "cap": cap}
+            checks["trade_notional"] = {"status": "pass", "notional": notional_value, "cap": cap}
 
         # Pre-trade: per-symbol concentration cap.
         conc_pct = float(self.config.get("max_symbol_concentration_pct", 0) or 0)
         if conc_pct > 0:
             if equity:
-                exposure = float(position_value or 0.0) + float(notional)
+                exposure = (_finite_float(position_value) or 0.0) + notional_value
                 limit = equity * conc_pct / 100.0
                 if exposure > limit:
                     reasons.append(

--- a/webui/__init__.py
+++ b/webui/__init__.py
@@ -1,4 +1,14 @@
 """
 Trading Agents Framework - Web UI Package
 """
-from webui.app_dash import run_app
+
+
+def __getattr__(name):
+    # Lazy so that importing webui submodules (e.g. webui.utils.prompt_capture
+    # from tradingagents.agents) does not build the Dash app, which fetches
+    # Alpaca account data.
+    if name == "run_app":
+        from webui.app_dash import run_app
+
+        return run_app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/webui/app_dash.py
+++ b/webui/app_dash.py
@@ -132,8 +132,20 @@ def run_app(port=7860, share=False, server_name="127.0.0.1", debug=False, max_th
     return 0
 
 
-# Create the app instance for use by other modules
-app = create_app()
+# The app instance is created lazily: building it eagerly at import time
+# fetches Alpaca account data, so any import of this module (directly or via
+# the webui package) would trigger network calls.
+_app = None
+
+
+def __getattr__(name):
+    global _app
+    if name == "app":
+        if _app is None:
+            _app = create_app()
+        return _app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 if __name__ == "__main__":
     run_app(debug=True) 

--- a/webui/callbacks/__init__.py
+++ b/webui/callbacks/__init__.py
@@ -10,6 +10,7 @@ from .control_callbacks import register_control_callbacks
 from .trading_callbacks import register_trading_callbacks
 from .storage_callbacks import register_storage_callbacks
 from .api_config_callbacks import register_api_config_callbacks
+from .safety_callbacks import register_safety_callbacks
 
 def register_all_callbacks(app):
     """Register all callback functions with the Dash app"""
@@ -19,4 +20,5 @@ def register_all_callbacks(app):
     register_control_callbacks(app)
     register_trading_callbacks(app)
     register_storage_callbacks(app)
-    register_api_config_callbacks(app) 
+    register_api_config_callbacks(app)
+    register_safety_callbacks(app)

--- a/webui/callbacks/__init__.py
+++ b/webui/callbacks/__init__.py
@@ -11,6 +11,7 @@ from .trading_callbacks import register_trading_callbacks
 from .storage_callbacks import register_storage_callbacks
 from .api_config_callbacks import register_api_config_callbacks
 from .safety_callbacks import register_safety_callbacks
+from .cost_callbacks import register_cost_callbacks
 
 def register_all_callbacks(app):
     """Register all callback functions with the Dash app"""
@@ -22,3 +23,4 @@ def register_all_callbacks(app):
     register_storage_callbacks(app)
     register_api_config_callbacks(app)
     register_safety_callbacks(app)
+    register_cost_callbacks(app)

--- a/webui/callbacks/__init__.py
+++ b/webui/callbacks/__init__.py
@@ -10,6 +10,7 @@ from .control_callbacks import register_control_callbacks
 from .trading_callbacks import register_trading_callbacks
 from .storage_callbacks import register_storage_callbacks
 from .api_config_callbacks import register_api_config_callbacks
+from .backtest_callbacks import register_backtest_callbacks
 
 def register_all_callbacks(app):
     """Register all callback functions with the Dash app"""
@@ -19,4 +20,5 @@ def register_all_callbacks(app):
     register_control_callbacks(app)
     register_trading_callbacks(app)
     register_storage_callbacks(app)
-    register_api_config_callbacks(app) 
+    register_api_config_callbacks(app)
+    register_backtest_callbacks(app)

--- a/webui/callbacks/backtest_callbacks.py
+++ b/webui/callbacks/backtest_callbacks.py
@@ -1,0 +1,215 @@
+"""
+Backtest callbacks for TradingAgents WebUI
+Runs the walk-forward backtest over recorded agent decisions and renders
+metrics, the equity curve, and per-window robustness results.
+"""
+
+import dash_bootstrap_components as dbc
+import plotly.graph_objects as go
+from dash import Input, Output, State, html
+
+from webui.config.constants import COLORS
+
+
+def _fmt_pct(value):
+    return "—" if value is None else f"{value:+.2%}"
+
+
+def _fmt_ratio(value):
+    return "—" if value is None else f"{value:.2f}"
+
+
+def _metric_color(value, invert=False):
+    if value is None:
+        return COLORS["pending"]
+    good = value < 0 if invert else value > 0
+    return COLORS["completed"] if good else COLORS["error"]
+
+
+def _metric_card(label, text, color):
+    return dbc.Col(
+        dbc.Card(
+            dbc.CardBody(
+                [
+                    html.Div(label, className="text-muted small"),
+                    html.Div(text, style={"color": color, "fontSize": "1.3rem", "fontWeight": 600}),
+                ],
+                className="p-2 text-center",
+            ),
+            style={"backgroundColor": COLORS["card"], "border": f"1px solid {COLORS['border']}"},
+        ),
+        md=2,
+        xs=6,
+        className="mb-2",
+    )
+
+
+def _build_metric_cards(metrics, signals_used):
+    sharpe = metrics.get("sharpe_ratio")
+    return dbc.Row(
+        [
+            _metric_card(
+                "Cumulative Return",
+                _fmt_pct(metrics.get("cumulative_return")),
+                _metric_color(metrics.get("cumulative_return")),
+            ),
+            _metric_card(
+                "Annualized Return",
+                _fmt_pct(metrics.get("annualized_return")),
+                _metric_color(metrics.get("annualized_return")),
+            ),
+            _metric_card("Sharpe Ratio", _fmt_ratio(sharpe), _metric_color(sharpe)),
+            _metric_card(
+                "Max Drawdown",
+                "—" if metrics.get("max_drawdown") is None else f"-{metrics['max_drawdown']:.2%}",
+                _metric_color(metrics.get("max_drawdown"), invert=True)
+                if metrics.get("max_drawdown")
+                else COLORS["pending"],
+            ),
+            _metric_card(
+                "Win Rate",
+                "—" if metrics.get("win_rate") is None else f"{metrics['win_rate']:.0%}",
+                COLORS["primary"],
+            ),
+            _metric_card(
+                "Trades / Signals",
+                f"{metrics.get('num_trades', 0)} / {signals_used}",
+                COLORS["text"],
+            ),
+        ],
+        className="g-2",
+    )
+
+
+def _build_equity_figure(equity_curve, symbol):
+    figure = go.Figure()
+    figure.add_trace(
+        go.Scatter(
+            x=list(equity_curve.index),
+            y=list(equity_curve.values),
+            mode="lines",
+            name="Equity",
+            line={"color": COLORS["primary"], "width": 2},
+            fill="tozeroy",
+            fillcolor="rgba(59, 130, 246, 0.08)",
+        )
+    )
+    figure.update_layout(
+        title=f"Equity Curve — {symbol}",
+        template="plotly_dark",
+        paper_bgcolor=COLORS["card"],
+        plot_bgcolor=COLORS["card"],
+        margin={"l": 40, "r": 20, "t": 40, "b": 30},
+        yaxis={"title": "Portfolio value ($)", "tickformat": ",.0f"},
+        showlegend=False,
+    )
+    return figure
+
+
+def _build_windows_table(windows):
+    if len(windows) < 2:
+        return None
+    header = html.Thead(
+        html.Tr(
+            [
+                html.Th("Window"),
+                html.Th("Bars"),
+                html.Th("Return"),
+                html.Th("Sharpe"),
+                html.Th("Max DD"),
+                html.Th("Win Rate"),
+            ]
+        )
+    )
+    rows = []
+    for window in windows:
+        metrics = window["metrics"]
+        cum = metrics.get("cumulative_return")
+        rows.append(
+            html.Tr(
+                [
+                    html.Td(f"{window['start_date']} → {window['end_date']}"),
+                    html.Td(window["bars"]),
+                    html.Td(
+                        _fmt_pct(cum),
+                        style={"color": _metric_color(cum)},
+                    ),
+                    html.Td(_fmt_ratio(metrics.get("sharpe_ratio"))),
+                    html.Td(
+                        "—" if metrics.get("max_drawdown") is None else f"-{metrics['max_drawdown']:.2%}"
+                    ),
+                    html.Td(
+                        "—" if metrics.get("win_rate") is None else f"{metrics['win_rate']:.0%}"
+                    ),
+                ]
+            )
+        )
+    return html.Div(
+        [
+            html.H6("Out-of-sample windows", className="mt-2"),
+            dbc.Table([header, html.Tbody(rows)], bordered=False, hover=True, size="sm", striped=True),
+        ]
+    )
+
+
+def register_backtest_callbacks(app):
+    """Register backtest callbacks with the Dash app"""
+
+    @app.callback(
+        [
+            Output("backtest-status", "children"),
+            Output("backtest-metrics", "children"),
+            Output("backtest-equity-graph", "figure"),
+            Output("backtest-graph-container", "style"),
+            Output("backtest-windows-table", "children"),
+        ],
+        Input("backtest-run-btn", "n_clicks"),
+        [
+            State("backtest-symbol-input", "value"),
+            State("backtest-start-date", "value"),
+            State("backtest-end-date", "value"),
+            State("backtest-window-bars", "value"),
+            State("backtest-allow-shorts", "value"),
+        ],
+        prevent_initial_call=True,
+    )
+    def run_backtest_callback(n_clicks, symbol, start_date, end_date, window_bars, allow_shorts):
+        hidden = {"display": "none"}
+        empty = go.Figure()
+
+        symbol = (symbol or "").strip().upper()
+        if not symbol:
+            alert = dbc.Alert("Enter a symbol to backtest.", color="warning", className="mb-0")
+            return alert, None, empty, hidden, None
+
+        try:
+            from tradingagents.backtest import run_recorded_walk_forward
+
+            result = run_recorded_walk_forward(
+                symbol,
+                start_date=start_date or None,
+                end_date=end_date or None,
+                window_bars=int(window_bars or 63),
+                allow_shorts=bool(allow_shorts),
+            )
+        except ValueError as e:
+            alert = dbc.Alert(str(e), color="warning", className="mb-0")
+            return alert, None, empty, hidden, None
+        except Exception as e:
+            alert = dbc.Alert(f"Backtest failed: {e}", color="danger", className="mb-0")
+            return alert, None, empty, hidden, None
+
+        full = result.full_period
+        status_bits = [
+            f"{full.start_date} → {full.end_date}",
+            f"{full.signals_used} recorded signal(s)",
+            "execution: next-bar open",
+        ]
+        if full.rejected_orders:
+            status_bits.append(f"{len(full.rejected_orders)} order(s) rejected on gaps")
+        status = html.Div(" · ".join(status_bits), className="text-muted small")
+
+        metrics_cards = _build_metric_cards(full.metrics, full.signals_used)
+        figure = _build_equity_figure(full.equity_curve, symbol)
+        windows_table = _build_windows_table(result.windows)
+        return status, metrics_cards, figure, {"display": "block"}, windows_table

--- a/webui/callbacks/backtest_callbacks.py
+++ b/webui/callbacks/backtest_callbacks.py
@@ -222,3 +222,61 @@ def register_backtest_callbacks(app):
         figure = _build_equity_figure(full.equity_curve, symbol)
         windows_table = _build_windows_table(result.windows)
         return status, metrics_cards, figure, {"display": "block"}, windows_table
+
+    @app.callback(
+        Output("backtest-teach-status", "children"),
+        Input("backtest-teach-btn", "n_clicks"),
+        [
+            State("backtest-symbol-input", "value"),
+            State("backtest-start-date", "value"),
+            State("backtest-end-date", "value"),
+        ],
+        prevent_initial_call=True,
+    )
+    def teach_memory_callback(n_clicks, symbol, start_date, end_date):
+        symbol = (symbol or "").strip().upper()
+        if not symbol:
+            return dbc.Alert(
+                "Enter a symbol to teach from.", color="warning", className="mb-0"
+            )
+
+        try:
+            from tradingagents.backtest import (
+                default_agent_memories,
+                teach_memories_from_history,
+            )
+
+            summary = teach_memories_from_history(
+                symbol,
+                default_agent_memories(),
+                start_date=start_date or None,
+                end_date=end_date or None,
+            )
+        except ValueError as e:
+            return dbc.Alert(str(e), color="warning", className="mb-0")
+        except Exception as e:
+            return dbc.Alert(f"Teaching failed: {e}", color="danger", className="mb-0")
+
+        taught = summary["decisions_taught"]
+        if not taught and summary["decisions_skipped_duplicate"]:
+            text = (
+                f"Nothing new to teach for {symbol}: "
+                f"{summary['decisions_skipped_duplicate']} decision(s) already in memory."
+            )
+            return dbc.Alert(text, color="info", className="mb-0")
+        if not taught:
+            text = (
+                f"No teachable decisions for {symbol} "
+                f"({summary['outcomes_computed']} outcome(s) computed, "
+                f"{summary['decisions_skipped_no_state']} without a recorded final state; "
+                "teaching also requires OpenAI embeddings)."
+            )
+            return dbc.Alert(text, color="warning", className="mb-0")
+
+        text = (
+            f"Taught {taught} decision(s) for {symbol} — "
+            f"{summary['lessons_written']} lesson(s) written to the agent memories "
+            f"({summary['decisions_skipped_duplicate']} duplicate(s) skipped, "
+            f"{summary['decisions_skipped_no_state']} without final state)."
+        )
+        return dbc.Alert(text, color="success", className="mb-0")

--- a/webui/callbacks/backtest_callbacks.py
+++ b/webui/callbacks/backtest_callbacks.py
@@ -170,10 +170,11 @@ def register_backtest_callbacks(app):
             State("backtest-end-date", "value"),
             State("backtest-window-bars", "value"),
             State("backtest-allow-shorts", "value"),
+            State("backtest-slippage-model", "value"),
         ],
         prevent_initial_call=True,
     )
-    def run_backtest_callback(n_clicks, symbol, start_date, end_date, window_bars, allow_shorts):
+    def run_backtest_callback(n_clicks, symbol, start_date, end_date, window_bars, allow_shorts, slippage_model):
         hidden = {"display": "none"}
         empty = go.Figure()
 
@@ -191,6 +192,7 @@ def register_backtest_callbacks(app):
                 end_date=end_date or None,
                 window_bars=int(window_bars or 63),
                 allow_shorts=bool(allow_shorts),
+                slippage_model=slippage_model or "fixed",
             )
         except ValueError as e:
             alert = dbc.Alert(str(e), color="warning", className="mb-0")
@@ -200,10 +202,17 @@ def register_backtest_callbacks(app):
             return alert, None, empty, hidden, None
 
         full = result.full_period
+        slippage = full.slippage or {}
+        slippage_text = {
+            "fixed": f"slippage: {slippage.get('bps', 0):g} bps",
+            "volatility": "slippage: volatility-scaled",
+            "none": "slippage: none",
+        }.get(slippage.get("model"), "slippage: n/a")
         status_bits = [
             f"{full.start_date} → {full.end_date}",
             f"{full.signals_used} recorded signal(s)",
             "execution: next-bar open",
+            slippage_text,
         ]
         if full.rejected_orders:
             status_bits.append(f"{len(full.rejected_orders)} order(s) rejected on gaps")

--- a/webui/callbacks/cost_callbacks.py
+++ b/webui/callbacks/cost_callbacks.py
@@ -1,0 +1,230 @@
+"""
+Cost callbacks for TradingAgents WebUI
+Scans the persisted run logs, aggregates LLM spend per day/symbol/model,
+joins each symbol's realized returns, and shows the daily token budget
+state from the safety layer.
+"""
+
+import dash_bootstrap_components as dbc
+import plotly.graph_objects as go
+from dash import Input, Output, html
+
+from webui.config.constants import COLORS
+
+
+def _fmt_usd(value):
+    return "—" if value is None else f"${value:,.2f}"
+
+
+def _fmt_tokens(value):
+    return f"{int(value or 0):,}"
+
+
+def _summary_card(label, text, color=None):
+    return dbc.Col(
+        dbc.Card(
+            dbc.CardBody(
+                [
+                    html.Div(label, className="text-muted small"),
+                    html.Div(
+                        text,
+                        style={
+                            "color": color or COLORS["text"],
+                            "fontSize": "1.3rem",
+                            "fontWeight": 600,
+                        },
+                    ),
+                ],
+                className="p-2 text-center",
+            ),
+            style={"backgroundColor": COLORS["card"], "border": f"1px solid {COLORS['border']}"},
+        ),
+        md=2,
+        xs=6,
+        className="mb-2",
+    )
+
+
+def _budget_text():
+    """Daily token usage vs the safety layer's budget, if configured."""
+    try:
+        from tradingagents.safety import get_safety_guard
+
+        guard = get_safety_guard()
+        used = guard.llm_tokens_used()
+        budget = float(guard.config.get("daily_llm_token_budget", 0) or 0)
+        if budget > 0:
+            return f"{used:,} / {budget:,.0f}", (
+                COLORS["error"] if used >= budget else COLORS["completed"]
+            )
+        return f"{used:,} / ∞", COLORS["text"]
+    except Exception:
+        return "—", COLORS["pending"]
+
+
+def _build_daily_figure(per_day):
+    days = sorted(per_day)
+    figure = go.Figure(
+        go.Bar(
+            x=days,
+            y=[per_day[d]["cost_usd"] for d in days],
+            marker_color=COLORS["primary"],
+        )
+    )
+    figure.update_layout(
+        title="Estimated LLM cost per day",
+        template="plotly_dark",
+        paper_bgcolor=COLORS["card"],
+        plot_bgcolor=COLORS["card"],
+        margin={"l": 40, "r": 20, "t": 40, "b": 30},
+        yaxis={"title": "USD", "tickformat": ",.2f"},
+        showlegend=False,
+    )
+    return figure
+
+
+def _build_symbol_table(per_symbol, returns_by_symbol):
+    if not per_symbol:
+        return None
+    header = html.Thead(
+        html.Tr(
+            [
+                html.Th("Symbol"),
+                html.Th("Runs"),
+                html.Th("Tokens"),
+                html.Th("Est. cost"),
+                html.Th("Resolved decisions"),
+                html.Th("Avg realized return"),
+            ]
+        )
+    )
+    rows = []
+    for symbol in sorted(per_symbol, key=lambda s: -per_symbol[s]["cost_usd"]):
+        stats = per_symbol[symbol]
+        outcome = returns_by_symbol.get(symbol) or {}
+        avg = outcome.get("avg_return")
+        avg_text = "—" if avg is None else f"{avg:+.2%}"
+        avg_color = (
+            COLORS["pending"]
+            if avg is None
+            else (COLORS["completed"] if avg > 0 else COLORS["error"])
+        )
+        rows.append(
+            html.Tr(
+                [
+                    html.Td(symbol),
+                    html.Td(stats["runs"]),
+                    html.Td(_fmt_tokens(stats["total_tokens"])),
+                    html.Td(_fmt_usd(stats["cost_usd"])),
+                    html.Td(outcome.get("resolved", 0)),
+                    html.Td(avg_text, style={"color": avg_color}),
+                ]
+            )
+        )
+    return html.Div(
+        [
+            html.H6("Per symbol — cost vs realized outcome", className="mt-2"),
+            dbc.Table([header, html.Tbody(rows)], bordered=False, hover=True, size="sm", striped=True),
+        ]
+    )
+
+
+def _build_model_table(per_model):
+    if not per_model:
+        return None
+    header = html.Thead(
+        html.Tr(
+            [
+                html.Th("Model"),
+                html.Th("Input tokens"),
+                html.Th("Output tokens"),
+                html.Th("Est. cost"),
+            ]
+        )
+    )
+    rows = []
+    for model in sorted(per_model, key=lambda m: -per_model[m]["cost_usd"]):
+        stats = per_model[model]
+        cost_text = _fmt_usd(stats["cost_usd"]) + (" (partly unpriced)" if stats.get("unpriced") else "")
+        rows.append(
+            html.Tr(
+                [
+                    html.Td(model),
+                    html.Td(_fmt_tokens(stats["input_tokens"])),
+                    html.Td(_fmt_tokens(stats["output_tokens"])),
+                    html.Td(cost_text),
+                ]
+            )
+        )
+    return html.Div(
+        [
+            html.H6("Per model", className="mt-2"),
+            dbc.Table([header, html.Tbody(rows)], bordered=False, hover=True, size="sm", striped=True),
+        ]
+    )
+
+
+def register_cost_callbacks(app):
+    """Register cost-panel callbacks with the Dash app"""
+
+    @app.callback(
+        [
+            Output("cost-summary-cards", "children"),
+            Output("cost-daily-graph", "figure"),
+            Output("cost-graph-container", "style"),
+            Output("cost-symbol-table", "children"),
+            Output("cost-model-table", "children"),
+        ],
+        Input("cost-refresh-btn", "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def refresh_cost_panel(n_clicks):
+        hidden = {"display": "none"}
+        empty = go.Figure()
+        try:
+            from tradingagents.dataflows.config import get_config
+            from tradingagents.llm_cost import (
+                aggregate_costs,
+                realized_returns_by_symbol,
+                scan_run_costs,
+            )
+
+            config = {}
+            try:
+                config = dict(get_config() or {})
+            except Exception:
+                config = {}
+            records = scan_run_costs(
+                eval_results_dir=config.get("results_dir", "eval_results"),
+                overrides=config.get("llm_pricing_per_million"),
+            )
+            aggregates = aggregate_costs(records)
+            returns_by_symbol = realized_returns_by_symbol(config)
+        except Exception as e:
+            alert = dbc.Alert(f"Cost scan failed: {e}", color="danger", className="mb-0")
+            return alert, empty, hidden, None, None
+
+        totals = aggregates["totals"]
+        if not totals["runs"]:
+            alert = dbc.Alert(
+                "No recorded runs found under eval_results/ yet.",
+                color="info",
+                className="mb-0",
+            )
+            return alert, empty, hidden, None, None
+
+        budget_text, budget_color = _budget_text()
+        cards = dbc.Row(
+            [
+                _summary_card("Analyses", f"{totals['runs']:,}"),
+                _summary_card("Total tokens", _fmt_tokens(totals["total_tokens"])),
+                _summary_card("Est. cost", _fmt_usd(totals["cost_usd"]), COLORS["primary"]),
+                _summary_card("Unpriced tokens", _fmt_tokens(totals["unpriced_tokens"])),
+                _summary_card("Today's tokens / budget", budget_text, budget_color),
+            ],
+            className="g-2",
+        )
+        figure = _build_daily_figure(aggregates["per_day"])
+        symbol_table = _build_symbol_table(aggregates["per_symbol"], returns_by_symbol)
+        model_table = _build_model_table(aggregates["per_model"])
+        return cards, figure, {"display": "block"}, symbol_table, model_table

--- a/webui/callbacks/safety_callbacks.py
+++ b/webui/callbacks/safety_callbacks.py
@@ -1,0 +1,155 @@
+"""
+Safety-layer callbacks for TradingAgents WebUI
+Renders live guardrail status and drives the kill switch.
+"""
+
+import dash_bootstrap_components as dbc
+from dash import Input, Output, ctx, html
+
+from webui.config.constants import COLORS
+
+_GUARD_LABELS = {
+    "kill_switch": "Kill Switch",
+    "trade_notional": "Trade Size Cap",
+    "concentration": "Concentration",
+    "daily_loss": "Daily Loss Breaker",
+    "drawdown": "Drawdown Breaker",
+    "rejection_streak": "Rejection Streak",
+    "llm_budget": "LLM Budget",
+}
+
+
+def _guard_detail_text(name, guard):
+    detail = guard.get("detail") or {}
+    if guard.get("status") == "skipped":
+        return str(detail.get("detail", "no account data"))
+    if name == "daily_loss" and "change_pct" in detail:
+        return f"{detail['change_pct']:+.2f}% today"
+    if name == "drawdown" and "drawdown_pct" in detail:
+        return f"-{detail['drawdown_pct']:.2f}% from peak"
+    if name == "rejection_streak":
+        return f"{detail.get('streak', 0)} in a row"
+    if name == "llm_budget":
+        budget = detail.get("budget") or 0
+        if not budget:
+            return "unlimited"
+        return f"{detail.get('used', 0):,.0f} / {budget:,.0f} tokens"
+    if name == "trade_notional":
+        cap = detail.get("cap") or 0
+        return f"cap ${cap:,.0f}" if cap else "uncapped"
+    if name == "concentration":
+        limit = detail.get("limit")
+        return f"limit ${limit:,.0f}" if limit else str(detail.get("detail", ""))
+    return ""
+
+
+def _status_cards(status):
+    cards = []
+    for name, label in _GUARD_LABELS.items():
+        guard = status["guards"].get(name)
+        if guard is None:
+            continue
+        if guard.get("status") == "skipped":
+            color = COLORS.get("pending", "#9ca3af")
+            icon = "fas fa-question-circle"
+        elif guard["ok"]:
+            color = COLORS.get("completed", "#22c55e")
+            icon = "fas fa-check-circle"
+        else:
+            color = COLORS.get("error", "#ef4444")
+            icon = "fas fa-exclamation-triangle"
+        cards.append(
+            dbc.Col(
+                dbc.Card(
+                    dbc.CardBody(
+                        [
+                            html.Div(
+                                [html.I(className=f"{icon} me-2", style={"color": color}), label],
+                                className="small fw-bold",
+                            ),
+                            html.Div(
+                                _guard_detail_text(name, guard),
+                                className="text-muted small",
+                            ),
+                        ],
+                        className="p-2",
+                    ),
+                    style={
+                        "backgroundColor": COLORS.get("card", "#1f2937"),
+                        "border": f"1px solid {color}",
+                    },
+                ),
+                md=3,
+                xs=6,
+                className="mb-2",
+            )
+        )
+    rows = [dbc.Row(cards, className="g-2")]
+    if status.get("reasons"):
+        rows.append(
+            dbc.Alert(
+                [html.Div(reason) for reason in status["reasons"]],
+                color="danger",
+                className="mt-2 mb-0 py-2 small",
+            )
+        )
+    if not status.get("enabled", True):
+        rows.append(
+            dbc.Alert(
+                "Safety layer is DISABLED via configuration (safety_enabled=False).",
+                color="warning",
+                className="mt-2 mb-0 py-2 small",
+            )
+        )
+    return html.Div(rows)
+
+
+def _account_snapshot():
+    try:
+        from tradingagents.dataflows.alpaca_utils import AlpacaUtils
+
+        account, _ = AlpacaUtils._safety_context("_status_")
+        return account
+    except Exception:
+        return None
+
+
+def register_safety_callbacks(app):
+    """Register safety-layer callbacks with the Dash app"""
+
+    @app.callback(
+        [
+            Output("safety-status-container", "children"),
+            Output("safety-action-status", "children"),
+        ],
+        [
+            Input("safety-refresh-interval", "n_intervals"),
+            Input("safety-kill-switch-btn", "n_clicks"),
+            Input("safety-release-btn", "n_clicks"),
+        ],
+        prevent_initial_call=False,
+    )
+    def refresh_safety_panel(_n, _engage_clicks, _release_clicks):
+        from tradingagents.safety import get_safety_guard
+
+        guard = get_safety_guard()
+        action_message = None
+
+        trigger = ctx.triggered_id if ctx.triggered_id else None
+        if trigger == "safety-kill-switch-btn":
+            guard.engage_kill_switch("engaged from WebUI")
+            action_message = dbc.Alert(
+                "Kill switch ENGAGED — all order flow is halted.",
+                color="danger",
+                className="mb-0 py-2 small",
+            )
+        elif trigger == "safety-release-btn":
+            guard.release_kill_switch()
+            action_message = dbc.Alert(
+                "Kill switch released — order flow may resume.",
+                color="success",
+                className="mb-0 py-2 small",
+            )
+
+        status = guard.status(account=_account_snapshot())
+        return _status_cards(status), action_message

--- a/webui/components/analysis.py
+++ b/webui/components/analysis.py
@@ -74,12 +74,18 @@ def execute_trade_after_analysis(ticker, allow_shorts, trade_amount):
         # Execute the typed intent when present; fall back to legacy signal execution
         # for older runs or providers that could not produce structured output.
         if trade_intent:
+            risk_params = (
+                dict(DEFAULT_CONFIG.get("risk_sizing_params") or {})
+                if DEFAULT_CONFIG.get("risk_sizing_enabled")
+                else None
+            )
             result = AlpacaUtils.execute_trade_intent(
                 symbol=ticker,
                 current_position=current_position,
                 trade_intent=trade_intent,
                 dollar_amount=trade_amount,
                 allow_shorts=allow_shorts,
+                risk_params=risk_params,
             )
         else:
             result = AlpacaUtils.execute_trading_action(

--- a/webui/components/analysis.py
+++ b/webui/components/analysis.py
@@ -67,6 +67,33 @@ def execute_trade_after_analysis(ticker, allow_shorts, trade_amount):
 
         print(f"[TRADE] Executing trade for {ticker}: {recommended_action} with ${trade_amount}")
 
+        # Portfolio-level sizing: deterministic layer above the per-symbol
+        # decision (correlation penalty, inverse-vol sizing, gross exposure
+        # cap). Failure-isolated: any problem keeps the requested amount.
+        try:
+            from tradingagents.dataflows.config import get_config
+            from tradingagents.portfolio import (
+                PortfolioLimitsConfig,
+                adjust_new_position_notional,
+                gather_portfolio_state_via_alpaca,
+            )
+
+            trade_amount = adjust_new_position_notional(
+                symbol=ticker,
+                action=recommended_action,
+                requested_notional=trade_amount,
+                gather_state=lambda: gather_portfolio_state_via_alpaca(ticker),
+                config=PortfolioLimitsConfig.from_config(get_config() or {}),
+            )
+            if trade_amount <= 0:
+                print(
+                    f"[TRADE] Portfolio layer zeroed the {ticker} order "
+                    "(no gross-exposure headroom); skipping execution."
+                )
+                return
+        except Exception as exc:
+            print(f"[TRADE] Portfolio sizing unavailable for {ticker}: {exc}")
+
         # Get current position
         current_position = AlpacaUtils.get_current_position_state(ticker)
         print(f"[TRADE] Current position for {ticker}: {current_position}")

--- a/webui/components/analysis.py
+++ b/webui/components/analysis.py
@@ -389,6 +389,19 @@ def start_analysis(
 ):
     """Start real-time analysis function for the UI"""
 
+    # Deterministic LLM budget gate (production safety layer): refuse to burn
+    # tokens on a new analysis once the daily budget is exhausted.
+    try:
+        from tradingagents.safety import get_safety_guard
+
+        budget_verdict = get_safety_guard().check_llm_budget()
+    except Exception:
+        budget_verdict = None
+    if budget_verdict is not None and not budget_verdict.allowed:
+        message = " ".join(budget_verdict.reasons)
+        print(f"[SAFETY] {message}")
+        return message
+
     # Parse selected analysts
     selected_analysts = []
     if analysts_market:

--- a/webui/components/analysis.py
+++ b/webui/components/analysis.py
@@ -67,6 +67,26 @@ def execute_trade_after_analysis(ticker, allow_shorts, trade_amount):
 
         print(f"[TRADE] Executing trade for {ticker}: {recommended_action} with ${trade_amount}")
 
+        # Regime-aware sizing: hostile regimes shrink NEW exposure, never
+        # flip the decision. Failure-isolated - any problem keeps the
+        # requested amount untouched.
+        if str(recommended_action).upper() in ("BUY", "LONG"):
+            try:
+                from tradingagents.dataflows.config import get_config
+                from tradingagents.regime import RegimeConfig, regime_risk_multiplier
+
+                multiplier = regime_risk_multiplier(
+                    ticker, config=RegimeConfig.from_config(get_config() or {})
+                )
+                if multiplier < 1.0:
+                    trade_amount = trade_amount * multiplier
+                    print(
+                        f"[TRADE] Regime filter scaled {ticker} amount to "
+                        f"${trade_amount:,.0f} (x{multiplier:.2f})"
+                    )
+            except Exception as exc:
+                print(f"[TRADE] Regime sizing unavailable for {ticker}: {exc}")
+
         # Get current position
         current_position = AlpacaUtils.get_current_position_state(ticker)
         print(f"[TRADE] Current position for {ticker}: {current_position}")

--- a/webui/components/backtest_panel.py
+++ b/webui/components/backtest_panel.py
@@ -25,7 +25,7 @@ def create_backtest_panel():
                         debounce=True,
                     ),
                 ],
-                md=3,
+                md=2,
             ),
             dbc.Col(
                 [
@@ -50,6 +50,21 @@ def create_backtest_panel():
                         value=63,
                         min=2,
                         step=1,
+                    ),
+                ],
+                md=1,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label("Slippage", html_for="backtest-slippage-model", className="small"),
+                    dbc.Select(
+                        id="backtest-slippage-model",
+                        options=[
+                            {"label": "Fixed (5 bps)", "value": "fixed"},
+                            {"label": "Volatility-scaled", "value": "volatility"},
+                            {"label": "None (frictionless)", "value": "none"},
+                        ],
+                        value="fixed",
                     ),
                 ],
                 md=2,

--- a/webui/components/backtest_panel.py
+++ b/webui/components/backtest_panel.py
@@ -1,0 +1,117 @@
+"""
+webui/components/backtest_panel.py - Walk-forward backtest dashboard panel
+
+Replays the decisions already recorded under eval_results/ against
+historical prices (zero LLM cost) and reports the TradingAgents-paper
+metric set: cumulative/annualized return, Sharpe ratio, max drawdown,
+plus win rate, per walk-forward window and for the full period.
+"""
+
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+
+def create_backtest_panel():
+    """Create the backtest panel card for the web UI."""
+    controls = dbc.Row(
+        [
+            dbc.Col(
+                [
+                    dbc.Label("Symbol", html_for="backtest-symbol-input", className="small"),
+                    dbc.Input(
+                        id="backtest-symbol-input",
+                        type="text",
+                        placeholder="e.g. AAPL or BTC/USD",
+                        debounce=True,
+                    ),
+                ],
+                md=3,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label("Start date (optional)", html_for="backtest-start-date", className="small"),
+                    dbc.Input(id="backtest-start-date", type="date"),
+                ],
+                md=2,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label("End date (optional)", html_for="backtest-end-date", className="small"),
+                    dbc.Input(id="backtest-end-date", type="date"),
+                ],
+                md=2,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label("Window (bars)", html_for="backtest-window-bars", className="small"),
+                    dbc.Input(
+                        id="backtest-window-bars",
+                        type="number",
+                        value=63,
+                        min=2,
+                        step=1,
+                    ),
+                ],
+                md=2,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label(" ", className="small d-block"),
+                    dbc.Switch(
+                        id="backtest-allow-shorts",
+                        label="Allow shorts",
+                        value=False,
+                    ),
+                ],
+                md=1,
+            ),
+            dbc.Col(
+                [
+                    dbc.Label(" ", className="small d-block"),
+                    dbc.Button(
+                        [html.I(className="fas fa-flask me-2"), "Run Backtest"],
+                        id="backtest-run-btn",
+                        color="primary",
+                        className="w-100",
+                    ),
+                ],
+                md=2,
+            ),
+        ],
+        className="g-2 align-items-end mb-3",
+    )
+
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.H4("Walk-Forward Backtest", className="mb-1"),
+                html.Div(
+                    "Replays this deployment's recorded agent decisions on historical "
+                    "prices — signals execute at the next bar's open (no lookahead).",
+                    className="text-muted small mb-3",
+                ),
+                controls,
+                dcc.Loading(
+                    id="backtest-loading",
+                    type="default",
+                    children=html.Div(
+                        [
+                            html.Div(id="backtest-status", className="mb-2"),
+                            html.Div(id="backtest-metrics", className="mb-3"),
+                            html.Div(
+                                dcc.Graph(
+                                    id="backtest-equity-graph",
+                                    config={"displayModeBar": False, "responsive": True},
+                                    style={"height": "320px", "width": "100%"},
+                                ),
+                                id="backtest-graph-container",
+                                style={"display": "none"},
+                            ),
+                            html.Div(id="backtest-windows-table"),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+        className="mb-4",
+    )

--- a/webui/components/backtest_panel.py
+++ b/webui/components/backtest_panel.py
@@ -96,6 +96,30 @@ def create_backtest_panel():
         className="g-2 align-items-end mb-3",
     )
 
+    teach_row = dbc.Row(
+        [
+            dbc.Col(
+                dbc.Button(
+                    [html.I(className="fas fa-graduation-cap me-2"), "Teach Memory"],
+                    id="backtest-teach-btn",
+                    color="secondary",
+                    outline=True,
+                    size="sm",
+                ),
+                width="auto",
+            ),
+            dbc.Col(
+                html.Div(
+                    "Injects one dated lesson per recorded decision (with its "
+                    "realized next-open return) into the persistent agent "
+                    "memories — idempotent, zero LLM cost.",
+                    className="text-muted small",
+                ),
+            ),
+        ],
+        className="g-2 align-items-center mb-2",
+    )
+
     return dbc.Card(
         dbc.CardBody(
             [
@@ -106,6 +130,12 @@ def create_backtest_panel():
                     className="text-muted small mb-3",
                 ),
                 controls,
+                teach_row,
+                dcc.Loading(
+                    id="backtest-teach-loading",
+                    type="default",
+                    children=html.Div(id="backtest-teach-status", className="mb-2"),
+                ),
                 dcc.Loading(
                     id="backtest-loading",
                     type="default",

--- a/webui/components/cost_panel.py
+++ b/webui/components/cost_panel.py
@@ -1,0 +1,65 @@
+"""
+webui/components/cost_panel.py - LLM cost monitoring panel
+
+Attributes LLM spend from the persisted run logs to analyses, days,
+symbols, and models, next to each symbol's realized returns — so cost
+without benefit is visible at a glance. Estimates are an upper bound
+(cache-read discounts are not recorded) and unknown models are surfaced
+as unpriced tokens rather than guessed.
+"""
+
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+
+def create_cost_panel():
+    """Create the LLM cost panel card for the web UI."""
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.H4("LLM Cost Monitor", className="mb-1"),
+                html.Div(
+                    "Estimated spend from recorded token usage — attributed per "
+                    "day, symbol, and model, against realized returns. Prices are "
+                    "estimates (override via llm_pricing_per_million); cache "
+                    "discounts are not tracked, so this is an upper bound.",
+                    className="text-muted small mb-3",
+                ),
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            dbc.Button(
+                                [html.I(className="fas fa-sync me-2"), "Refresh"],
+                                id="cost-refresh-btn",
+                                color="primary",
+                                size="sm",
+                            ),
+                            width="auto",
+                        ),
+                    ],
+                    className="g-2 mb-3",
+                ),
+                dcc.Loading(
+                    id="cost-loading",
+                    type="default",
+                    children=html.Div(
+                        [
+                            html.Div(id="cost-summary-cards", className="mb-3"),
+                            html.Div(
+                                dcc.Graph(
+                                    id="cost-daily-graph",
+                                    config={"displayModeBar": False, "responsive": True},
+                                    style={"height": "260px", "width": "100%"},
+                                ),
+                                id="cost-graph-container",
+                                style={"display": "none"},
+                            ),
+                            html.Div(id="cost-symbol-table", className="mb-2"),
+                            html.Div(id="cost-model-table"),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+        className="mb-4",
+    )

--- a/webui/components/safety_panel.py
+++ b/webui/components/safety_panel.py
@@ -1,0 +1,71 @@
+"""
+webui/components/safety_panel.py - Production safety layer status panel
+
+Shows a green/red badge for every deterministic guard (kill switch,
+pre-trade checks, circuit breakers, LLM budget) plus a kill-switch toggle
+that halts all order flow immediately, regardless of agent decisions.
+"""
+
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+
+def create_safety_panel():
+    """Create the safety guardrails card for the web UI."""
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.H4("Safety Guardrails", className="mb-1"),
+                                html.Div(
+                                    "Deterministic pre-trade checks, circuit breakers, and a "
+                                    "kill switch — enforced before any order reaches the broker, "
+                                    "independent of agent decisions.",
+                                    className="text-muted small",
+                                ),
+                            ],
+                            md=8,
+                        ),
+                        dbc.Col(
+                            [
+                                dbc.ButtonGroup(
+                                    [
+                                        dbc.Button(
+                                            [
+                                                html.I(className="fas fa-hand-paper me-2"),
+                                                "Engage Kill Switch",
+                                            ],
+                                            id="safety-kill-switch-btn",
+                                            color="danger",
+                                            size="sm",
+                                        ),
+                                        dbc.Button(
+                                            "Release",
+                                            id="safety-release-btn",
+                                            color="secondary",
+                                            outline=True,
+                                            size="sm",
+                                        ),
+                                    ],
+                                    className="float-end",
+                                ),
+                            ],
+                            md=4,
+                        ),
+                    ],
+                    className="mb-3 align-items-start",
+                ),
+                html.Div(id="safety-action-status", className="mb-2"),
+                html.Div(id="safety-status-container"),
+                dcc.Interval(
+                    id="safety-refresh-interval",
+                    interval=30_000,  # 30s
+                    n_intervals=0,
+                ),
+            ]
+        ),
+        className="mb-4",
+    )

--- a/webui/layout.py
+++ b/webui/layout.py
@@ -12,6 +12,7 @@ from webui.components.status_panel import create_status_panel
 from webui.components.chart_panel import create_chart_panel
 from webui.components.decision_panel import create_decision_panel
 from webui.components.reports_panel import create_reports_panel
+from webui.components.backtest_panel import create_backtest_panel
 from webui.components.alpaca_account import render_alpaca_account_section
 from webui.components.api_config_modal import create_api_config_modal
 from webui.config.constants import COLORS, REFRESH_INTERVALS
@@ -176,6 +177,7 @@ def create_main_layout():
                 ], md=6)
             ]),
             reports_card,
+            create_backtest_panel(),
             html.Div(className="mt-4"),
             create_footer(),
         ],

--- a/webui/layout.py
+++ b/webui/layout.py
@@ -14,6 +14,7 @@ from webui.components.decision_panel import create_decision_panel
 from webui.components.reports_panel import create_reports_panel
 from webui.components.alpaca_account import render_alpaca_account_section
 from webui.components.safety_panel import create_safety_panel
+from webui.components.cost_panel import create_cost_panel
 from webui.components.api_config_modal import create_api_config_modal
 from webui.config.constants import COLORS, REFRESH_INTERVALS
 
@@ -178,6 +179,7 @@ def create_main_layout():
                 ], md=6)
             ]),
             reports_card,
+            create_cost_panel(),
             html.Div(className="mt-4"),
             create_footer(),
         ],

--- a/webui/layout.py
+++ b/webui/layout.py
@@ -13,6 +13,7 @@ from webui.components.chart_panel import create_chart_panel
 from webui.components.decision_panel import create_decision_panel
 from webui.components.reports_panel import create_reports_panel
 from webui.components.alpaca_account import render_alpaca_account_section
+from webui.components.safety_panel import create_safety_panel
 from webui.components.api_config_modal import create_api_config_modal
 from webui.config.constants import COLORS, REFRESH_INTERVALS
 
@@ -164,6 +165,7 @@ def create_main_layout():
             
             # Main content
             header,
+            create_safety_panel(),
             alpaca_account_card,
             dbc.Row([
                 dbc.Col(config_card, md=6),


### PR DESCRIPTION
Integrates the full contribution set from #25, #26, #27, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, and #41 while preserving the original authors and stacked commit history.

The PRs pass independently, but several overlap in `alpaca_utils.py`, runtime configuration, safety handling, and WebUI registration. This integration resolves those conflicts as one tested system rather than merging branches independently and leaving main broken between stacks.

Additional hardening found during integration:
- safety breakers no longer trap existing positions; risk-reducing exits remain available while the explicit kill switch still blocks all order flow
- position flips close old exposure before independently gating replacement exposure
- whole-share orders never exceed the approved notional when one share is unaffordable
- risk sizing skips already-held target positions and forwards its deterministic ATR stop into bracket/OTO execution
- bracket tests do not write to the operator's real safety state
- provider and alert credentials are redacted from run logs and delivery errors
- CI has read-only permissions and manual dispatch support
- architecture docs reflect MiniMax and the integrated runtime surfaces

Validation:
- 294 tests passed, plus 158 subtests
- compileall passed
- pip check reported no broken requirements
- git diff --check passed
- integrated Dash app returned HTTP 200
- every original PR head is retained as an ancestor of this branch