### PR TITLE
fix: fail closed on position lookup errors during execution

### DIFF
--- a/tests/test_chaos_resilience.py
+++ b/tests/test_chaos_resilience.py
@@ -247,6 +247,47 @@ class MalformedBrokerPayloadTests(unittest.TestCase):
             state = AlpacaUtils.get_current_position_state("AAPL")
         self.assertEqual(state, "NEUTRAL")
 
+    def test_strict_raises_on_malformed_target_position_qty(self):
+        # A corrupted qty on the *matched* position is as unsafe as an outage:
+        # a strict execution caller must not read it as NEUTRAL (which would
+        # re-buy the real holding or skip a real exit). Non-strict prompt
+        # callers keep the forgiving NEUTRAL behavior.
+        bad_position = Mock()
+        bad_position.symbol = "AAPL"
+        bad_position.qty = "<html>502 Bad Gateway</html>"
+        client = Mock()
+        client.get_all_positions.return_value = [bad_position]
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
+            return_value=client,
+        ):
+            with self.assertRaises((ValueError, AttributeError)):
+                AlpacaUtils.get_current_position_state("AAPL", strict=True)
+            self.assertEqual(
+                AlpacaUtils.get_current_position_state("AAPL"), "NEUTRAL"
+            )
+
+    def test_strict_raises_on_non_finite_target_position_qty(self):
+        # "nan"/"inf" parse through float() without raising but are not a real
+        # position size; both LONG/SHORT comparisons are false so they would
+        # fall through to NEUTRAL. A strict execution caller must reject them;
+        # non-strict prompt callers keep NEUTRAL.
+        for bad_qty in ("nan", "inf", "-inf"):
+            bad_position = Mock()
+            bad_position.symbol = "AAPL"
+            bad_position.qty = bad_qty
+            client = Mock()
+            client.get_all_positions.return_value = [bad_position]
+            with patch(
+                "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
+                return_value=client,
+            ):
+                with self.assertRaises(ValueError):
+                    AlpacaUtils.get_current_position_state("AAPL", strict=True)
+                self.assertEqual(
+                    AlpacaUtils.get_current_position_state("AAPL"), "NEUTRAL"
+                )
+
     def test_account_fetch_outage_returns_zeroed_info_not_exception(self):
         client = Mock()
         client.get_account.side_effect = ConnectionError("nginx: 502")
@@ -257,6 +298,71 @@ class MalformedBrokerPayloadTests(unittest.TestCase):
             info = AlpacaUtils.get_account_info()
         self.assertEqual(info["buying_power"], 0)
         self.assertEqual(info["cash"], 0)
+
+
+class PositionFetchOutageTests(unittest.TestCase):
+    """A broker outage during the pre-trade position check must abort the
+    trade, not read as NEUTRAL.
+
+    get_current_position_state defaults to NEUTRAL on any error so agent
+    prompts keep working, but the trade executor uses the same value as
+    ground truth. If the account is actually LONG and the position fetch
+    fails, a BUY signal then re-buys the existing holding (pyramiding every
+    loop iteration the outage persists), and a SELL signal reads as "no
+    position to sell" and silently skips a risk exit.
+    """
+
+    def test_strict_position_check_raises_instead_of_guessing_neutral(self):
+        client = Mock()
+        client.get_all_positions.side_effect = ConnectionError("nginx: 502")
+        with patch(
+            "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
+            return_value=client,
+        ):
+            with self.assertRaises(ConnectionError):
+                AlpacaUtils.get_current_position_state("AAPL", strict=True)
+            # Non-strict callers (agent prompt context) keep the old behavior.
+            self.assertEqual(AlpacaUtils.get_current_position_state("AAPL"), "NEUTRAL")
+
+    def test_trade_execution_skips_order_when_position_fetch_fails(self):
+        from webui.components.analysis import execute_trade_after_analysis
+        from webui.utils.state import app_state
+
+        # Account is long AAPL, but the positions endpoint is down.
+        client = Mock()
+        client.get_all_positions.side_effect = ConnectionError("nginx: 502")
+        client.get_account.side_effect = ConnectionError("nginx: 502")
+
+        app_state.init_symbol_state("AAPL")
+        state = app_state.get_state("AAPL")
+        state["analysis_complete"] = True
+        state["recommended_action"] = "BUY"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = _guard(tmp)
+            with patch(
+                "tradingagents.dataflows.alpaca_utils.get_alpaca_trading_client",
+                return_value=client,
+            ), patch.object(
+                AlpacaUtils,
+                "get_latest_quote",
+                return_value={"bid_price": 100.0, "ask_price": 100.1},
+            ), patch.object(
+                AlpacaUtils,
+                "place_market_order",
+                return_value={"success": True},
+            ) as place_order, patch(
+                "tradingagents.safety.get_safety_guard", return_value=guard
+            ), patch(
+                "tradingagents.portfolio.adjust_new_position_notional",
+                side_effect=lambda **kwargs: kwargs["requested_notional"],
+            ), patch(
+                "tradingagents.regime.regime_risk_multiplier", return_value=1.0
+            ):
+                execute_trade_after_analysis("AAPL", allow_shorts=False, trade_amount=1000)
+
+            place_order.assert_not_called()
+            self.assertIn("error", state.get("trading_results") or {})
 
 
 if __name__ == "__main__":

--- a/tradingagents/dataflows/alpaca_utils.py
+++ b/tradingagents/dataflows/alpaca_utils.py
@@ -1,5 +1,6 @@
 # alpaca_utils.py
 
+import math
 import os
 import pandas as pd
 import time
@@ -691,7 +692,7 @@ class AlpacaUtils:
             } 
 
     @staticmethod
-    def get_current_position_state(symbol: str) -> str:
+    def get_current_position_state(symbol: str, strict: bool = False) -> str:
         """Return current position state for a symbol in the Alpaca account.
 
         Args:
@@ -699,10 +700,15 @@ class AlpacaUtils:
                     be treated the same way as equities – a positive quantity is
                     considered a *LONG* position while a negative quantity (should
                     Alpaca ever allow it) is considered *SHORT*.
+            strict: When True, re-raise broker/API errors instead of defaulting
+                    to "NEUTRAL".  The NEUTRAL fallback exists so agent prompts
+                    keep working through an outage; order execution paths must
+                    pass strict=True, because acting on a guessed NEUTRAL can
+                    re-buy an existing position or silently skip an exit.
 
         Returns:
-            One of "LONG", "SHORT", or "NEUTRAL" if no open position exists or we
-            encounter an error.
+            One of "LONG", "SHORT", or "NEUTRAL" if no open position exists (or,
+            when strict is False, when we encounter an error).
         """
         try:
             # Skip if credentials are missing – the helper will raise inside but we
@@ -723,7 +729,23 @@ class AlpacaUtils:
                     try:
                         qty = float(pos.qty)
                     except (ValueError, AttributeError):
+                        if strict:
+                            # A corrupted qty on the *target* position is as
+                            # unsafe as an outage for an execution caller:
+                            # guessing NEUTRAL here re-buys a real holding or
+                            # skips a real exit. Let it propagate.
+                            raise
                         qty = 0.0
+
+                    if not math.isfinite(qty):
+                        # e.g. qty "nan"/"inf" parses without raising but is
+                        # not a real position size. Same fail-open risk as a
+                        # malformed string for an execution caller.
+                        if strict:
+                            raise ValueError(
+                                f"non-finite position qty for {symbol}: {pos.qty!r}"
+                            )
+                        return "NEUTRAL"
 
                     if qty > 0:
                         return "LONG"
@@ -736,6 +758,11 @@ class AlpacaUtils:
             # If we fall through the loop there is no open position for symbol.
             return "NEUTRAL"
         except Exception as e:
+            if strict:
+                # Execution callers must not mistake an outage for "no
+                # position": a wrong NEUTRAL turns a BUY into pyramiding an
+                # existing holding and a SELL into a skipped exit.
+                raise
             # Log and default to neutral so agent prompts still work.
             print(f"Error determining current position for {symbol}: {e}")
             return "NEUTRAL"

--- a/webui/components/analysis.py
+++ b/webui/components/analysis.py
@@ -114,8 +114,24 @@ def execute_trade_after_analysis(ticker, allow_shorts, trade_amount):
             except Exception as exc:
                 print(f"[TRADE] Regime sizing unavailable for {ticker}: {exc}")
 
-        # Get current position
-        current_position = AlpacaUtils.get_current_position_state(ticker)
+        # Get current position. strict=True: a broker outage here must abort
+        # the trade instead of reading as NEUTRAL — acting on a guessed
+        # NEUTRAL re-buys an existing holding on BUY (pyramiding every loop
+        # iteration the outage persists) and skips the exit on SELL.
+        try:
+            current_position = AlpacaUtils.get_current_position_state(ticker, strict=True)
+        except Exception as e:
+            print(
+                f"[TRADE] Could not verify current position for {ticker} ({e}); "
+                "skipping trade execution rather than guessing NEUTRAL"
+            )
+            state["trading_results"] = {
+                "error": (
+                    f"Position check failed for {ticker}; trade skipped to avoid "
+                    f"acting on an unverified position: {e}"
+                )
+            }
+            return
         print(f"[TRADE] Current position for {ticker}: {current_position}")
 
         # Execute the typed intent when present; fall back to legacy signal execution


### PR DESCRIPTION
`get_current_position_state` swallowed position-API failures and returned `NEUTRAL`. That fallback is fine for prompt/read-only callers, but `execute_trade_after_analysis` used the same value as execution ground truth right before submitting orders — so during a transient positions-endpoint outage (rate limit, 502, network blip) a BUY signal bypasses the "already have a position → hold" guard and pyramids duplicate buys every loop iteration, and a SELL reads as "no position" and silently skips the exit.

This keeps the forgiving `NEUTRAL` default for prompt callers, but adds a `strict=True` mode that re-raises on broker/API errors; the executor uses it and aborts the trade (recording the error) rather than acting on a guessed position. It mirrors the existing convention where `get_account_risk_snapshot` raises instead of returning zeros.

Tests: two chaos cases added to `tests/test_chaos_resilience.py` (BUY-during-outage and SELL-during-outage), both failing before the change and passing after; full suite green.
